### PR TITLE
Patch grammar

### DIFF
--- a/bril-txt/briltxt.py
+++ b/bril-txt/briltxt.py
@@ -28,7 +28,7 @@ vop.3: IDENT ":" type "=" CNAME IDENT* ";"
 eop.2: CNAME IDENT* ";"
 label.1: IDENT ":"
 
-lit: NUMBER  -> int
+lit: SIGNED_INT  -> int
   | BOOL     -> bool
 
 type: CNAME
@@ -36,7 +36,7 @@ BOOL: "true" | "false"
 IDENT: ("_"|"%"|LETTER) ("_"|"%"|"."|LETTER|DIGIT)*
 COMMENT: /#.*/
 
-%import common.NUMBER
+%import common.SIGNED_INT
 %import common.WS
 %import common.CNAME
 %import common.LETTER


### PR DESCRIPTION
Looks like Lark's [NUMBER][lark] allows floating point numbers and doesn't allow signed values?

[lark]: https://github.com/lark-parser/lark/blob/535aebab3c770d5b3acbe6fa21394c901a1f2345/lark/grammars/common.lark#L17