### PR TITLE
Update LVN to bail on division by zero (fixes #40)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,9 +3,19 @@ TESTS := test/parse/*.bril \
 	test/interp/*.bril \
 	test/ts/*.ts
 
+EXAMPLE_TESTS :=  examples/*_test/*.bril 
+
 .PHONY: test
 test:
 	turnt $(TESTS)
+
+.PHONY: test_examples
+test_examples:
+	turnt $(EXAMPLE_TESTS)
+
+.PHONY: test_examples_save
+test_examples_save:
+	turnt --save $(EXAMPLE_TESTS)
 
 .PHONY: save
 save:
@@ -15,6 +25,12 @@ save:
 book:
 	rm -rf book
 	mdbook build
+
+.PHONY: ts
+ts:
+	cd bril-ts ; \
+	yarn ; \
+	yarn build ; \
 
 .PHONY: deploy
 RSYNCARGS := --compress --recursive --checksum --itemize-changes \

--- a/examples/dom_test/loopcond.out
+++ b/examples/dom_test/loopcond.out
@@ -1,0 +1,1 @@
+{'entry': {'entry'}, 'loop': {'loop', 'entry'}, 'exit': {'loop', 'exit', 'entry'}, 'body': {'loop', 'entry', 'body'}, 'then': {'then', 'loop', 'entry', 'body'}, 'endif': {'loop', 'endif', 'entry', 'body'}}

--- a/examples/dom_test/turnt.toml
+++ b/examples/dom_test/turnt.toml
@@ -1,0 +1,1 @@
+command = "bril2json < {filename} | python3 ../dom.py"

--- a/examples/lvn.py
+++ b/examples/lvn.py
@@ -204,9 +204,11 @@ def _fold(num2const, value):
     if value.op in FOLDABLE_OPS:
         try:
             const_args = [num2const[n] for n in value.args]
+            return FOLDABLE_OPS[value.op](*const_args)
         except KeyError:  # At least one argument is not a constant.
             return None
-        return FOLDABLE_OPS[value.op](*const_args)
+        except ZeroDivisionError: # If we hit a dynamic error, bail!
+            return None
     else:
         return None
 

--- a/examples/lvn_test/divide-by-zero.bril
+++ b/examples/lvn_test/divide-by-zero.bril
@@ -1,0 +1,7 @@
+main {
+entry:
+  zero : int = const 0;
+  one : int = const 1;
+  baddiv : int = div one zero;
+  print baddiv;
+}

--- a/examples/lvn_test/divide-by-zero.out
+++ b/examples/lvn_test/divide-by-zero.out
@@ -1,0 +1,7 @@
+main {
+entry:
+  zero: int = const 0;
+  one: int = const 1;
+  baddiv: int = div one zero;
+  print baddiv;
+}

--- a/examples/lvn_test/turnt.toml
+++ b/examples/lvn_test/turnt.toml
@@ -1,1 +1,1 @@
-command = "bril2json < {filename} | python3 ../lvn.py {args} | bril2txt"
+command = "bril2json < {filename} | python3 ../lvn.py -p -c -f {args} | bril2txt"


### PR DESCRIPTION
Also add example testing to Makefile.

The current implementation of constant folding via local value numbering in lvn.py crashes when the program divides by zero. Instead of crashing, the compiler should bail on folding constants when there are dynamic errors.