### PR TITLE
Update bril.ml

### DIFF
--- a/bril-ocaml/lib/bril.ml
+++ b/bril-ocaml/lib/bril.ml
@@ -250,15 +250,27 @@ let to_string { funcs } =
     | Nop -> `Assoc [ ("op", `String "nop") ]
   in
   let of_func { name; args; ret_type; instrs; _ } =
-    `Assoc
-      [
-        ("name", `String name);
-        ( "args",
-          `List
-            (List.map args ~f:(fun (name, bril_type) ->
-                 `Assoc [ ("name", `String name); ("type", of_type bril_type) ])) );
-        ("type", Option.value_map ret_type ~default:`Null ~f:of_type);
-        ("instrs", `List (List.map instrs ~f:of_instr));
-      ]
+    if Option.is_some ret_type then
+      `Assoc
+        [
+          ("name", `String name);
+          ( "args",
+            `List
+              (List.map args ~f:(fun (name, bril_type) ->
+                   `Assoc [ ("name", `String name); ("type", of_type bril_type) ])) );
+          ("type", Option.value_map ret_type ~default:`Null ~f:of_type);
+          ("instrs", `List (List.map instrs ~f:of_instr));
+        ]
+    else
+      `Assoc
+        [
+          ("name", `String name);
+          ( "args",
+            `List
+              (List.map args ~f:(fun (name, bril_type) ->
+                   `Assoc [ ("name", `String name); ("type", of_type bril_type) ])) );
+          ("instrs", `List (List.map instrs ~f:of_instr));
+        ]
+      
   in
   `Assoc [ ("functions", `List (List.map funcs ~f:of_func)) ] |> Yojson.pretty_to_string

--- a/bril-ocaml/lib/bril.ml
+++ b/bril-ocaml/lib/bril.ml
@@ -248,27 +248,13 @@ let to_string { funcs } =
     | Nop -> `Assoc [ ("op", `String "nop") ]
   in
   let of_func { name; args; ret_type; instrs; _ } =
-    if Option.is_some ret_type then
-      `Assoc
-        [
-          ("name", `String name);
-          ( "args",
-            `List
-              (List.map args ~f:(fun (name, bril_type) ->
-                   `Assoc [ ("name", `String name); ("type", of_type bril_type) ])) );
-          ("type", Option.value_map ret_type ~default:`Null ~f:of_type);
-          ("instrs", `List (List.map instrs ~f:of_instr));
-        ]
-    else
-      `Assoc
-        [
-          ("name", `String name);
+      `Assoc (
+        [ ("name", `String name);
           ( "args",
             `List
               (List.map args ~f:(fun (name, bril_type) ->
                    `Assoc [ ("name", `String name); ("type", of_type bril_type) ])) );
           ("instrs", `List (List.map instrs ~f:of_instr));
-        ]
-      
+        ] @ (Option.value_map ret_type ~default:[] ~f:(fun t -> [of_ret_type t])))
   in
   `Assoc [ ("functions", `List (List.map funcs ~f:of_func)) ] |> Yojson.pretty_to_string

--- a/bril-ocaml/lib/bril.ml
+++ b/bril-ocaml/lib/bril.ml
@@ -28,7 +28,6 @@ type binop =
   | Gt
   | Le
   | Ge
-  | Not
   | And
   | Or
 [@@deriving sexp_of, equal]
@@ -44,7 +43,6 @@ let binops_by_name =
     ("gt", Gt);
     ("le", Le);
     ("ge", Ge);
-    ("not", Not);
     ("and", And);
     ("or", Or);
   ]

--- a/bril-ocaml/lib/bril.mli
+++ b/bril-ocaml/lib/bril.mli
@@ -28,7 +28,6 @@ type binop =
   | Gt
   | Le
   | Ge
-  | Not
   | And
   | Or
 [@@deriving sexp_of]


### PR DESCRIPTION
There is a bug in the deparser that causes the types of void functions to be printed as `: None`. This should fix it.