### PR TITLE
ocaml library: include labels when converting to json

### DIFF
--- a/bril-ocaml/lib/func.mli
+++ b/bril-ocaml/lib/func.mli
@@ -8,6 +8,7 @@ type t = {
   blocks : Instr.t list String.Map.t;
   order : string list;
   cfg : string list String.Map.t;
+  extra_labels : string list;
 }
 [@@deriving compare, sexp_of]
 


### PR DESCRIPTION
The implementation of `to_json` for the OCaml library is not including any labels, so it's basically broken. This fix adds the labels before each basic block. It also keeps track of "extra" labels which are not bound to any basic block, which happens when there is a label as the very last instruction.

Not thoroughly tested, but I am using this for my lesson 3 implementation so I thought I would make a PR.

On a related note, I think there can be multiple labels that point to a single basic block, which happens when there are two (or more) labels in a row. I think the current implementation will end up printing the same basic block twice in this case, which is wasteful but not necessarily wrong, but I haven't tested yet.