### PR TITLE
Fix label processing, again

### DIFF
--- a/bril-ocaml/lib/func.ml
+++ b/bril-ocaml/lib/func.ml
@@ -14,7 +14,7 @@ type t = {
 let instrs { blocks; order; _ } = List.concat_map order ~f:(Map.find_exn blocks)
 
 let process_instrs instrs =
-  let block_name i = sprintf "block%d" i in
+  let block_name i = sprintf "block_%d" i in
   let (name, block, blocks) =
     List.fold
       instrs
@@ -22,8 +22,8 @@ let process_instrs instrs =
       ~f:(fun (name, block, blocks) (instr : Instr.t) ->
         match instr with
         | Label label ->
-          if List.is_empty block then (label, [], blocks)
-          else (label, [], (name, List.rev block) :: blocks)
+          if List.is_empty block then ("label_" ^ label, [ instr ], blocks)
+          else ("label_" ^ label, [ instr ], (name, List.rev block) :: blocks)
         | Jmp _
         | Br _
         | Ret _ ->

--- a/bril-ocaml/lib/func.ml
+++ b/bril-ocaml/lib/func.ml
@@ -52,6 +52,10 @@ let process_instrs instrs =
   in
   (String.Map.of_alist_exn blocks, order, String.Map.of_alist_exn cfg)
 
+let set_instrs t instrs =
+  let (blocks, order, cfg) = process_instrs instrs in
+  { t with blocks; order; cfg }
+
 let of_json json =
   let open Yojson.Basic.Util in
   let arg_of_json json =

--- a/bril-ocaml/lib/func.mli
+++ b/bril-ocaml/lib/func.mli
@@ -12,5 +12,6 @@ type t = {
 [@@deriving compare, sexp_of]
 
 val instrs : t -> Instr.t list
+val set_instrs : t -> Instr.t list -> t
 val of_json : Yojson.Basic.t -> t
 val to_json : t -> Yojson.Basic.t


### PR DESCRIPTION
Labels didn't make it to output JSON -- adding them as actual instructions in basic blocks should fix it. Also, double labels and trailing labels should now become "empty" (i.e. instructionless) basic blocks -- I believe this is the correct behavior? 

Also, it was previously possible to create a naming conflict in the CFG if there was a label `block0` and an unlabeled basic block. Prepending `label_` to the names of labeled basic blocks should fix that.