### PR TITLE
Make sure state ref gets mutated in `evalFunc`

### DIFF
--- a/bril-ts/brili.ts
+++ b/bril-ts/brili.ts
@@ -297,7 +297,7 @@ let NEXT: Action = {"action": "next"};
  * The interpreter state that's threaded through recursive calls.
  */
 type State = {
-  readonly env: Env,
+  env: Env,
   readonly heap: Heap<Value>,
   readonly funcs: readonly bril.Function[],
 
@@ -713,7 +713,8 @@ function evalInstr(instr: bril.Instruction, state: State): Action {
   throw error(`unhandled opcode ${(instr as any).op}`);
 }
 
-function evalFunc(func: bril.Function, state: State): Value | null {
+function evalFunc(func: bril.Function, state_ref: State): Value | null {
+  let state = state_ref;
   for (let i = 0; i < func.instrs.length; ++i) {
     let line = func.instrs[i];
     if ('op' in line) {
@@ -781,6 +782,12 @@ function evalFunc(func: bril.Function, state: State): Value | null {
       state.curlabel = line.label;
     }
   }
+
+  state_ref.env = state.env;
+  state_ref.icount = state.icount;
+  state_ref.lastlabel = state.lastlabel;
+  state_ref.curlabel = state.curlabel;
+  state_ref.specparent = state.specparent;
 
   // Reached the end of the function without hitting `ret`.
   if (state.specparent) {


### PR DESCRIPTION
In the `speculate` case in `evalFunc`, the `state` name is reassigned to a new object, so the original `state` object doesn't get mutated as it should from that point on. For example, updates to the `icount` and `env` don't make it to the original object whose reference is passed as the actual for `state`. This PR stores the original object, and makes sure that it gets mutated properly.