### PR TITLE
Bril rust extension

### DIFF
--- a/bril-rs/Cargo.toml
+++ b/bril-rs/Cargo.toml
@@ -9,3 +9,9 @@ edition = "2018"
 [dependencies]
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
+
+[features]
+float = []
+memory = []
+ssa = []
+speculate = []

--- a/bril-rs/src/lib.rs
+++ b/bril-rs/src/lib.rs
@@ -1,5 +1,5 @@
 use serde::{Deserialize, Serialize};
-use std::io::{self, Read};
+use std::io::{self, Read, Write};
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Program {
@@ -81,15 +81,15 @@ pub enum EffectOps {
     Return,
     Print,
     Nop,
-    #[cfg(feature="memory")]
+    #[cfg(feature = "memory")]
     Store,
-    #[cfg(feature="memory")]
+    #[cfg(feature = "memory")]
     Free,
-    #[cfg(feature="speculate")]
+    #[cfg(feature = "speculate")]
     Speculate,
-    #[cfg(feature="speculate")]
+    #[cfg(feature = "speculate")]
     Commit,
-    #[cfg(feature="speculate")]
+    #[cfg(feature = "speculate")]
     Guard,
 }
 
@@ -110,31 +110,31 @@ pub enum ValueOps {
     Or,
     Call,
     Id,
-    #[cfg(feature="ssa")]
+    #[cfg(feature = "ssa")]
     Phi,
-    #[cfg(feature="float")]
+    #[cfg(feature = "float")]
     Fadd,
-    #[cfg(feature="float")]
+    #[cfg(feature = "float")]
     Fsub,
-    #[cfg(feature="float")]
+    #[cfg(feature = "float")]
     Fmul,
-    #[cfg(feature="float")]
+    #[cfg(feature = "float")]
     Fdiv,
-    #[cfg(feature="float")]
+    #[cfg(feature = "float")]
     Feq,
-    #[cfg(feature="float")]
+    #[cfg(feature = "float")]
     Flt,
-    #[cfg(feature="float")]
+    #[cfg(feature = "float")]
     Fgt,
-    #[cfg(feature="float")]
+    #[cfg(feature = "float")]
     Fle,
-    #[cfg(feature="float")]
+    #[cfg(feature = "float")]
     Fge,
-    #[cfg(feature="memory")]
+    #[cfg(feature = "memory")]
     Alloc,
-    #[cfg(feature="memory")]
+    #[cfg(feature = "memory")]
     Load,
-    #[cfg(feature="memory")]
+    #[cfg(feature = "memory")]
     PtrAdd,
 }
 
@@ -144,7 +144,7 @@ pub enum Type {
     Int,
     Bool,
     Float,
-    #[cfg(feature="memory")]
+    #[cfg(feature = "memory")]
     #[serde(rename = "ptr")]
     Pointer(Box<Type>),
 }
@@ -161,4 +161,10 @@ pub fn load_program() -> Program {
     let mut buffer = String::new();
     io::stdin().read_to_string(&mut buffer).unwrap();
     serde_json::from_str(&buffer).unwrap()
+}
+
+pub fn output_program(p: &Program) {
+    io::stdout()
+        .write_all(serde_json::to_string(p).unwrap().as_bytes())
+        .unwrap();
 }

--- a/bril-rs/src/lib.rs
+++ b/bril-rs/src/lib.rs
@@ -81,10 +81,15 @@ pub enum EffectOps {
     Return,
     Print,
     Nop,
+    #[cfg(feature="memory")]
     Store,
+    #[cfg(feature="memory")]
     Free,
+    #[cfg(feature="speculate")]
     Speculate,
+    #[cfg(feature="speculate")]
     Commit,
+    #[cfg(feature="speculate")]
     Guard,
 }
 
@@ -105,18 +110,31 @@ pub enum ValueOps {
     Or,
     Call,
     Id,
+    #[cfg(feature="ssa")]
     Phi,
+    #[cfg(feature="float")]
     Fadd,
+    #[cfg(feature="float")]
     Fsub,
+    #[cfg(feature="float")]
     Fmul,
+    #[cfg(feature="float")]
     Fdiv,
+    #[cfg(feature="float")]
     Feq,
+    #[cfg(feature="float")]
     Flt,
+    #[cfg(feature="float")]
     Fgt,
+    #[cfg(feature="float")]
     Fle,
+    #[cfg(feature="float")]
     Fge,
+    #[cfg(feature="memory")]
     Alloc,
+    #[cfg(feature="memory")]
     Load,
+    #[cfg(feature="memory")]
     PtrAdd,
 }
 
@@ -126,6 +144,7 @@ pub enum Type {
     Int,
     Bool,
     Float,
+    #[cfg(feature="memory")]
     #[serde(rename = "ptr")]
     Pointer(Box<Type>),
 }

--- a/bril-rs/src/lib.rs
+++ b/bril-rs/src/lib.rs
@@ -83,6 +83,9 @@ pub enum EffectOps {
     Nop,
     Store,
     Free,
+    Speculate,
+    Commit,
+    Guard,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]

--- a/docs/tools/rust.md
+++ b/docs/tools/rust.md
@@ -1,7 +1,7 @@
 Rust Library
 ============
 
-This is a no-frills interface between Bril's JSON and your [Rust][] code. It supports the [Bril core][core] along with the [SSA][], [memory][], and [floating point][float] extensions.
+This is a no-frills interface between Bril's JSON and your [Rust][] code. It supports the [Bril core][core] along with the [SSA][], [memory][], [floating point][float], and [speculative execution][spec] extensions.
 
 Use
 ---
@@ -12,7 +12,10 @@ Include this by adding the following to your `Cargo.toml`:
 [dependencies.bril-rs]
 version = "0.1.0"
 path = "../bril-rs"
+features = ["ssa", "memory", "float", "speculate"]
 ```
+
+Each of the extensions to [Bril core][core] is feature gated. To ignore an extension, remove its corresponding string from the `features` list.
 
 There is one helper function, `load_program`, which will read a valid Bril program from stdin and return it as a Rust struct. Otherwise, this library can be treated like any other [serde][] JSON representation.
 
@@ -32,3 +35,4 @@ cargo clippy
 [ssa]: ../lang/ssa.md
 [memory]: ../lang/memory.md
 [float]: ../lang/float.md
+[spec]: ../lang/spec.md

--- a/docs/tools/rust.md
+++ b/docs/tools/rust.md
@@ -17,7 +17,7 @@ features = ["ssa", "memory", "float", "speculate"]
 
 Each of the extensions to [Bril core][core] is feature gated. To ignore an extension, remove its corresponding string from the `features` list.
 
-There is one helper function, `load_program`, which will read a valid Bril program from stdin and return it as a Rust struct. Otherwise, this library can be treated like any other [serde][] JSON representation.
+There are two helper functions, `load_program`, which will read a valid Bril program from stdin and and `output_program` which writes your Bril program to stdout. Otherwise, this library can be treated like any other [serde][] JSON representation.
 
 Development
 -----------


### PR DESCRIPTION
Adding the speculation extension. Introduces feature gating on each of the extensions so you only get what you need. Adding a serializing to stdout function seems like the bare minimum to include.