### PR TITLE
Add ne, eq, fix fold bug.

### DIFF
--- a/examples/lvn.py
+++ b/examples/lvn.py
@@ -209,7 +209,8 @@ def _fold(num2const, value):
             return FOLDABLE_OPS[value.op](*const_args)
         except KeyError:  # At least one argument is not a constant.
             # Two values are equal if their arguments are equivalent.
-            if value.op == 'eq': return FOLDABLE_OPS[value.op](*value.args)
+            if value.op == 'eq' and value.args[0] == value.args[1]:
+                return True
             return None
         except ZeroDivisionError:  # If we hit a dynamic error, bail!
             return None

--- a/examples/lvn.py
+++ b/examples/lvn.py
@@ -15,6 +15,7 @@ class Numbering(dict):
     """A dict mapping anything to numbers that can generate new numbers
     for you when adding new values.
     """
+
     def __init__(self, init={}):
         super(Numbering, self).__init__(init)
         self._next_fresh = 0
@@ -207,6 +208,8 @@ def _fold(num2const, value):
             const_args = [num2const[n] for n in value.args]
             return FOLDABLE_OPS[value.op](*const_args)
         except KeyError:  # At least one argument is not a constant.
+            # Two values are equal if their arguments are equivalent.
+            if value.op == 'eq': return FOLDABLE_OPS[value.op](*value.args)
             return None
         except ZeroDivisionError:  # If we hit a dynamic error, bail!
             return None

--- a/examples/lvn.py
+++ b/examples/lvn.py
@@ -208,10 +208,10 @@ def _fold(num2const, value):
             const_args = [num2const[n] for n in value.args]
             return FOLDABLE_OPS[value.op](*const_args)
         except KeyError:  # At least one argument is not a constant.
-            if value.op in {'eq', 'ne'} and value.args[0] == value.args[1]:
+            if value.op in {'eq', 'ne', 'le', 'ge'} and value.args[0] == value.args[1]:
                 # Equivalent arguments may be evaluated for equality.
-                # E.g. `eq x x`, where `x` is not a constant.
-                return value.op == 'eq'
+                # E.g. `eq x x`, where `x` is not a constant evaluates to `true`.
+                return value.op != 'ne'
             return None
         except ZeroDivisionError:  # If we hit a dynamic error, bail!
             return None

--- a/examples/lvn.py
+++ b/examples/lvn.py
@@ -160,7 +160,7 @@ def lvn_block(block, lookup, canonicalize, fold):
             if val:
                 # Is this value foldable to a constant?
                 const = fold(num2const, val)
-                if const:
+                if const != None:
                     num2const[newnum] = const
                     instr.update({
                         'op': 'const',

--- a/examples/lvn.py
+++ b/examples/lvn.py
@@ -196,6 +196,8 @@ FOLDABLE_OPS = {
     'lt': lambda a, b: a < b,
     'ge': lambda a, b: a >= b,
     'le': lambda a, b: a <= b,
+    'ne': lambda a, b: a != b,
+    'eq': lambda a, b: a == b,
 }
 
 

--- a/examples/lvn.py
+++ b/examples/lvn.py
@@ -210,7 +210,7 @@ def _fold(num2const, value):
         except KeyError:  # At least one argument is not a constant.
             if value.op in {'eq', 'ne'} and value.args[0] == value.args[1]:
                 # Equivalent arguments may be evaluated for equality.
-                return True if value.op == 'eq' else False
+                return value.op == 'eq'
             return None
         except ZeroDivisionError:  # If we hit a dynamic error, bail!
             return None

--- a/examples/lvn.py
+++ b/examples/lvn.py
@@ -208,9 +208,9 @@ def _fold(num2const, value):
             const_args = [num2const[n] for n in value.args]
             return FOLDABLE_OPS[value.op](*const_args)
         except KeyError:  # At least one argument is not a constant.
-            if value.op == 'eq' and value.args[0] == value.args[1]:
-                # Arguments are equivalent.
-                return True
+            if value.op in {'eq', 'ne'} and value.args[0] == value.args[1]:
+                # Equivalent arguments may be evaluated.
+                return True if value.op == 'eq' else False
             return None
         except ZeroDivisionError:  # If we hit a dynamic error, bail!
             return None

--- a/examples/lvn.py
+++ b/examples/lvn.py
@@ -161,7 +161,7 @@ def lvn_block(block, lookup, canonicalize, fold):
             if val:
                 # Is this value foldable to a constant?
                 const = fold(num2const, val)
-                if const != None:
+                if const is not None:
                     num2const[newnum] = const
                     instr.update({
                         'op': 'const',

--- a/examples/lvn.py
+++ b/examples/lvn.py
@@ -210,6 +210,7 @@ def _fold(num2const, value):
         except KeyError:  # At least one argument is not a constant.
             if value.op in {'eq', 'ne'} and value.args[0] == value.args[1]:
                 # Equivalent arguments may be evaluated for equality.
+                # E.g. `eq x x`, where `x` is not a constant.
                 return value.op == 'eq'
             return None
         except ZeroDivisionError:  # If we hit a dynamic error, bail!

--- a/examples/lvn.py
+++ b/examples/lvn.py
@@ -208,8 +208,8 @@ def _fold(num2const, value):
             const_args = [num2const[n] for n in value.args]
             return FOLDABLE_OPS[value.op](*const_args)
         except KeyError:  # At least one argument is not a constant.
-            # Two values are equal if their arguments are equivalent.
             if value.op == 'eq' and value.args[0] == value.args[1]:
+                # Arguments are equivalent.
                 return True
             return None
         except ZeroDivisionError:  # If we hit a dynamic error, bail!

--- a/examples/lvn.py
+++ b/examples/lvn.py
@@ -209,7 +209,7 @@ def _fold(num2const, value):
             return FOLDABLE_OPS[value.op](*const_args)
         except KeyError:  # At least one argument is not a constant.
             if value.op in {'eq', 'ne'} and value.args[0] == value.args[1]:
-                # Equivalent arguments may be evaluated.
+                # Equivalent arguments may be evaluated for equality.
                 return True if value.op == 'eq' else False
             return None
         except ZeroDivisionError:  # If we hit a dynamic error, bail!

--- a/examples/test/lvn/fold-comparisons.bril
+++ b/examples/test/lvn/fold-comparisons.bril
@@ -3,9 +3,12 @@
 @main(arg1: int, arg2: int) {
   a: int = const 4;
   b: int = const 3;
-  constant_fold1: bool = eq a b;
-  constant_fold2: bool = le a b;
-  constant_fold3: bool = gt b a;
+  constant_fold1: bool = ne b a;
+  constant_fold2: bool = eq a b;
+  constant_fold3: bool = le a b;
+  constant_fold4: bool = lt b a;
+  constant_fold5: bool = gt b a;
+  constant_fold6: bool = ge b a;
 
   should_fold1: bool = eq arg1 arg1;
   should_fold2: bool = ne arg1 arg1;

--- a/examples/test/lvn/fold-comparisons.bril
+++ b/examples/test/lvn/fold-comparisons.bril
@@ -1,0 +1,22 @@
+# ARGS: -f
+
+@main(arg1: int, arg2: int) {
+  a: int = const 4;
+  b: int = const 3;
+  constant_fold1: bool = eq a b;
+  constant_fold2: bool = le a b;
+  constant_fold3: bool = gt b a;
+
+  should_fold1: bool = eq arg1 arg1;
+  should_fold2: bool = ne arg1 arg1;
+  should_fold3: bool = le arg1 arg1;
+  should_fold4: bool = ge arg1 arg1;
+
+  no_fold1: bool = eq arg1 arg2;
+  no_fold2: bool = ne arg1 arg2;
+  no_fold3: bool = le arg1 arg2;
+  no_fold4: bool = ge arg1 arg2;
+
+  no_fold5: bool = lt arg1 arg1;
+  no_fold6: bool = gt arg2 arg2;
+}

--- a/examples/test/lvn/fold-comparisons.out
+++ b/examples/test/lvn/fold-comparisons.out
@@ -1,0 +1,17 @@
+@main(arg1: int, arg2: int) {
+  a: int = const 4;
+  b: int = const 3;
+  constant_fold1: bool = const false;
+  constant_fold2: bool = const false;
+  constant_fold3: bool = const false;
+  should_fold1: bool = const true;
+  should_fold2: bool = const false;
+  should_fold3: bool = const true;
+  should_fold4: bool = const true;
+  no_fold1: bool = eq arg1 arg2;
+  no_fold2: bool = ne arg1 arg2;
+  no_fold3: bool = le arg1 arg2;
+  no_fold4: bool = ge arg1 arg2;
+  no_fold5: bool = lt arg1 arg1;
+  no_fold6: bool = gt arg2 arg2;
+}

--- a/examples/test/lvn/fold-comparisons.out
+++ b/examples/test/lvn/fold-comparisons.out
@@ -1,9 +1,12 @@
 @main(arg1: int, arg2: int) {
   a: int = const 4;
   b: int = const 3;
-  constant_fold1: bool = const false;
+  constant_fold1: bool = const true;
   constant_fold2: bool = const false;
   constant_fold3: bool = const false;
+  constant_fold4: bool = const true;
+  constant_fold5: bool = const false;
+  constant_fold6: bool = const false;
   should_fold1: bool = const true;
   should_fold2: bool = const false;
   should_fold3: bool = const true;


### PR DESCRIPTION
`bril2json < comparisons.bril | python3 examples/lvn.py -p -c -f | bril2txt`

```
@main {
  a: int = const 4;
  b: int = const 3;
  c: bool = eq a b;
  print c;
}
```

=>

```
@main {
  a: int = const 4;
  b: int = const 3;
  c: bool = const false;
  print c;
}
```

Initially this was not folding since `const == False`.