### PR TITLE
Fix domination frontier bug.

### DIFF
--- a/examples/dom.py
+++ b/examples/dom.py
@@ -85,7 +85,7 @@ def dom_fronts(dom, succ):
         # You're in the frontier if you're not strictly dominated by the
         # current block.
         frontiers[block] = [b for b in dominated_succs
-                            if b not in dom_inv[block] or b == block]
+                            if b not in dom_inv[block] and b != block]
 
     return frontiers
 

--- a/examples/dom.py
+++ b/examples/dom.py
@@ -72,6 +72,10 @@ def get_dom(succ, entry):
 
 def dom_fronts(dom, succ):
     """Compute the dominance frontier, given the dominance relation.
+
+    A's domination frontier contains B if:
+      1. A does not strictly dominate B
+      2. A dominates a predecessor of B.
     """
     dom_inv = map_inv(dom)
 
@@ -84,8 +88,7 @@ def dom_fronts(dom, succ):
 
         # You're in the frontier if you're not strictly dominated by the
         # current block.
-        frontiers[block] = [b for b in dominated_succs
-                            if b != block and b not in dom_inv[block]]
+        frontiers[block] = [b for b in dominated_succs if b not in dom_inv[block]]
 
     return frontiers
 

--- a/examples/dom.py
+++ b/examples/dom.py
@@ -85,7 +85,7 @@ def dom_fronts(dom, succ):
         # You're in the frontier if you're not strictly dominated by the
         # current block.
         frontiers[block] = [b for b in dominated_succs
-                            if b not in dom_inv[block] and b != block]
+                            if b != block and b not in dom_inv[block]]
 
     return frontiers
 

--- a/examples/test/dom/loopcond-front.out
+++ b/examples/test/dom/loopcond-front.out
@@ -7,9 +7,7 @@
   ],
   "entry": [],
   "exit": [],
-  "loop": [
-    "loop"
-  ],
+  "loop": [],
   "then": [
     "endif"
   ]


### PR DESCRIPTION
Discussed in #109.

`frontiers[block] = [b for b in dominated_succs if b not in dom_inv[block]]`

To my understanding, `dom_inv[b]` should contain `b` itself since `A dominates A` for all `b`. This avoids adding itself to the frontiers of `b`.

I took a different approach to this problem, so I may not be following your algorithm correctly.