### PR TITLE
[SSA] Fix bug in to_ssa.py

### DIFF
--- a/examples/test/to_ssa/if-const.bril
+++ b/examples/test/to_ssa/if-const.bril
@@ -1,0 +1,14 @@
+@main() {
+    cond: bool = const true;
+    br cond .true .false;
+.true:
+    a: int = const 0;
+    jmp .zexit;
+.false:
+    b: int = const 1;
+    jmp .zexit;
+# zexit to trigger a bug in to_ssa.py that depends on
+# the order that basic blocks get renamed.
+.zexit:
+    print a;
+}

--- a/examples/test/to_ssa/if-const.out
+++ b/examples/test/to_ssa/if-const.out
@@ -1,0 +1,16 @@
+@main {
+.b1:
+  cond.0: bool = const true;
+  br cond.0 .true .false;
+.true:
+  a.0: int = const 0;
+  jmp .zexit;
+.false:
+  b.0: int = const 1;
+  jmp .zexit;
+.zexit:
+  b.1: int = phi b.0 b.0 .false .true;
+  a.1: int = phi __undefined a.0 .false .true;
+  print a.1;
+  ret;
+}

--- a/examples/test/to_ssa/if-ssa.bril
+++ b/examples/test/to_ssa/if-ssa.bril
@@ -1,0 +1,16 @@
+@main(cond: bool) {
+.entry:
+    a.1: int = const 47;
+    br cond .left .right;
+.left:
+    a.2: int = add a.1 a.1;
+    jmp .zexit;
+.right:
+    a.3: int = mul a.1 a.1;
+    jmp .zexit;
+# zexit to trigger a bug in to_ssa.py that depends on
+# the order that basic blocks get renamed.
+.zexit:
+    a.4: int = phi .left a.2 .right a.3;
+    print a.4;
+}

--- a/examples/test/to_ssa/if-ssa.out
+++ b/examples/test/to_ssa/if-ssa.out
@@ -1,0 +1,17 @@
+@main(cond: bool) {
+.entry:
+  a.1.0: int = const 47;
+  br cond .left .right;
+.left:
+  a.2.0: int = add a.1.0 a.1.0;
+  jmp .zexit;
+.right:
+  a.3.0: int = mul a.1.0 a.1.0;
+  jmp .zexit;
+.zexit:
+  a.3.1: int = phi __undefined a.3.0 .left .right;
+  a.2.1: int = phi a.2.0 a.2.0 .left .right;
+  a.4.0: int = phi a.2.1 a.3.1 .left .right;
+  print a.4.0;
+  ret;
+}

--- a/examples/test/to_ssa/loop.out
+++ b/examples/test/to_ssa/loop.out
@@ -3,7 +3,9 @@
   i.0: int = const 1;
   jmp .loop;
 .loop:
+  max.0: int = phi __undefined max.1 .entry .body;
   i.1: int = phi i.0 i.2 .entry .body;
+  cond.0: bool = phi __undefined cond.1 .entry .body;
   max.1: int = const 10;
   cond.1: bool = lt i.1 max.1;
   br cond.1 .body .exit;

--- a/examples/test/to_ssa/selfloop.out
+++ b/examples/test/to_ssa/selfloop.out
@@ -6,6 +6,7 @@
   jmp .loop;
 .loop:
   x.1: int = phi x.0 x.2 .entry .br;
+  done.0: bool = phi __undefined done.1 .entry .br;
   x.2: int = sub x.1 one.0;
   done.1: bool = eq x.2 zero.0;
   jmp .br;

--- a/examples/test/to_ssa/while.out
+++ b/examples/test/to_ssa/while.out
@@ -2,6 +2,9 @@
 .entry1:
   jmp .while.cond;
 .while.cond:
+  zero.0: int = phi __undefined zero.1 .entry1 .while.body;
+  one.0: int = phi __undefined one.1 .entry1 .while.body;
+  is_term.0: bool = phi __undefined is_term.1 .entry1 .while.body;
   a.0: int = phi a a.1 .entry1 .while.body;
   zero.1: int = const 0;
   is_term.1: bool = eq a.0 zero.1;


### PR DESCRIPTION
Fixes Issue #108.

The optimization in prune_phis() is not sound. phi nodes that are
"partially undefined" cannot be removed. It is only illegal to read
from the result if the second to last executed label corresponds to
an undefined argument. `to_ssa.py` generated incorrect code for the
two tests added, before the fix.

In most cases, these phi nodes aren't read from, and will be removed
by DCE. However, in the case where the phi nodes are read, a correct
optimization would be:
1. Detect partially undefined phi nodes whose value is always used.
   Let `undefined_labels` be the set of labels whose argument is
   undefined.
2. Leverage the undefined behavior to say that `undefined_labels`
   are in fact not predecessors to the basic block.
   `preds = preds - undefined_labels`.

Though, I'm not sure how useful that optimization would be in
practice.