### PR TITLE
Attempt at fixing copy propagation in LVN pass.

### DIFF
--- a/examples/test/lvn/nonlocal-variable-reuse-2.bril
+++ b/examples/test/lvn/nonlocal-variable-reuse-2.bril
@@ -1,0 +1,10 @@
+# CMD: bril2json < {filename} | python3 ../../lvn.py -p | bril2txt
+@main {
+  a: int = const 42;
+.lbl:
+  # While `a` is outside the local scope, we essentially
+  # have a no-op here, so nonlocal re-naming isn't necessary.
+  a: int = id a;
+  a: int = const 5;
+  print a;
+}

--- a/examples/test/lvn/nonlocal-variable-reuse-2.out
+++ b/examples/test/lvn/nonlocal-variable-reuse-2.out
@@ -1,0 +1,7 @@
+@main {
+  a: int = const 42;
+.lbl:
+  a: int = id a;
+  a: int = const 5;
+  print a;
+}

--- a/examples/test/lvn/nonlocal-variable-reuse-3.bril
+++ b/examples/test/lvn/nonlocal-variable-reuse-3.bril
@@ -1,0 +1,13 @@
+# CMD: bril2json < {filename} | python3 ../../lvn.py -p | bril2txt
+@main {
+  # This should re-name within local scope only with `lvn`.
+  a: int = const 3;
+  b: int = id a;
+  a: int = id b;
+  print b;
+  print a;
+  a: int = const 4;
+  print a;
+  a: int = const 5;
+  print a;
+}

--- a/examples/test/lvn/nonlocal-variable-reuse-3.out
+++ b/examples/test/lvn/nonlocal-variable-reuse-3.out
@@ -1,0 +1,11 @@
+@main {
+  lvn.0: int = const 3;
+  b: int = const 3;
+  a: int = const 3;
+  print lvn.0;
+  print lvn.0;
+  lvn.1: int = const 4;
+  print lvn.1;
+  a: int = const 5;
+  print a;
+}

--- a/examples/test/lvn/nonlocal-variable-reuse.bril
+++ b/examples/test/lvn/nonlocal-variable-reuse.bril
@@ -1,0 +1,9 @@
+# CMD: bril2json < {filename} | python3 ../../lvn.py -p | bril2txt
+@main {
+  a: int = const 42;
+.lbl:
+  b: int = id a;
+  # This should be re-named since `a` is defined outside of the local scope.
+  a: int = const 5;
+  print b;
+}

--- a/examples/test/lvn/nonlocal-variable-reuse.out
+++ b/examples/test/lvn/nonlocal-variable-reuse.out
@@ -1,0 +1,7 @@
+@main {
+  a: int = const 42;
+.lbl:
+  b: int = id a;
+  _a: int = const 5;
+  print a;
+}


### PR DESCRIPTION
This is a first attempt at #77. It is far from elegant.
This gist of the function is to:

1. Look for an instruction with `id` op. If `arg` has not been defined yet, assume it is defined outside of the local scope.
2. For every other instruction, if the `dest` name is equivalent to some variable defined outside the local scope, rename it.
3. Rename every use until its next assign as well.