### PR TITLE
Speeding up Brilirs

### DIFF
--- a/benchmarks/turnt_brilirs.toml
+++ b/benchmarks/turnt_brilirs.toml
@@ -1,3 +1,3 @@
-command = "bril2json < {filename} | cargo run --manifest-path ../brilirs/Cargo.toml --quiet -- -p {args}"
+command = "bril2json < {filename} | cargo +nightly run --manifest-path ../brilirs/Cargo.toml --quiet -- -p {args}"
 output.out = "-"
 output.prof = "2"

--- a/brilirs/Cargo.toml
+++ b/brilirs/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-clap         = "~2.31"
+clap         = "~2.33"
 fxhash       = "0.2"
 mimalloc     = "0.1"
 

--- a/brilirs/Cargo.toml
+++ b/brilirs/Cargo.toml
@@ -8,7 +8,8 @@ edition = "2018"
 
 [dependencies]
 clap         = "~2.31"
-fxhash       = "0.2.1"
+fxhash       = "0.2"
+mimalloc     = "0.1"
 
 [dependencies.bril-rs]
 version = "0.1.0"

--- a/brilirs/Cargo.toml
+++ b/brilirs/Cargo.toml
@@ -8,8 +8,15 @@ edition = "2018"
 
 [dependencies]
 clap         = "~2.31"
+fxhash       = "0.2.1"
 
 [dependencies.bril-rs]
 version = "0.1.0"
 path = "../bril-rs"
 features = ["ssa", "memory", "float", "speculate"]
+
+[profile.release]
+# this can shave off a few ms but doubles the build time so it's not really worth it
+# codegen-units = 1
+lto = true
+panic = "abort"

--- a/brilirs/Makefile
+++ b/brilirs/Makefile
@@ -26,4 +26,4 @@ compare: release
 # This is primarily used for running examples and debuging a bril program
 .PHONY: example
 example:
-	bril2json < ../benchmarks/pythagorean_triple.bril | cargo run -- -p 125
+	bril2json < ../benchmarks/sqrt.bril | cargo +nightly run

--- a/brilirs/Makefile
+++ b/brilirs/Makefile
@@ -12,7 +12,18 @@ test:
 benchmark:
 	turnt -c turnt_brilirs.toml $(BENCHMARKS)
 
+.PHONY: release
+release:
+	RUSTFLAGS="-C target-cpu=native" cargo +nightly build --release
+
+.PHONY: compare
+compare: release
+	./benchmark.sh
+	#hyperfine --export-markdown results.md --warmup 5 \
+	-L interp brili,./target/release/brilirs \
+	"bril2json < ../benchmarks/check-primes.bril | {interp} -p 50"
+
 # This is primarily used for running examples and debuging a bril program
 .PHONY: example
 example:
-	bril2json < ../benchmarks/mat-mul.bril | cargo run -- -p 50 109658
+	bril2json < ../benchmarks/pythagorean_triple.bril | cargo run -- -p 125

--- a/brilirs/benchmark.sh
+++ b/brilirs/benchmark.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+files=( "../benchmarks/ackermann.bril" "../benchmarks/binary-fmt.bril" "../benchmarks/check-primes.bril" \
+        "../benchmarks/collatz.bril" "../benchmarks/digital-root.bril" "../benchmarks/eight-queens.bril" \
+        "../benchmarks/euclid.bril" "../benchmarks/fib.bril" "../benchmarks/fizz-buzz.bril" \
+        "../benchmarks/gcd.bril" "../benchmarks/loopfact.bril" "../benchmarks/mat-mul.bril" \
+        "../benchmarks/orders.bril" "../benchmarks/perfect.bril" "../benchmarks/pythagorean_triple.bril" \
+        "../benchmarks/quadratic.bril" "../benchmarks/ray-sphere-intersection.bril" \
+        "../benchmarks/recfact.bril" "../benchmarks/sieve.bril" "../benchmarks/sqrt.bril" \
+        "../benchmarks/sum-bits.bril" "../benchmarks/sum-sq-diff.bril"
+        )
+jsons=( "../benchmarks/ackermann.json" "../benchmarks/binary-fmt.json" "../benchmarks/check-primes.json" \
+        "../benchmarks/collatz.json" "../benchmarks/digital-root.json" "../benchmarks/eight-queens.json" \
+        "../benchmarks/euclid.json" "../benchmarks/fib.json" "../benchmarks/fizz-buzz.json" \
+        "../benchmarks/gcd.json" "../benchmarks/loopfact.json" "../benchmarks/mat-mul.json" \
+        "../benchmarks/orders.json" "../benchmarks/perfect.json" "../benchmarks/pythagorean_triple.json" \
+        "../benchmarks/quadratic.json" "../benchmarks/ray-sphere-intersection.json" \
+        "../benchmarks/recfact.json" "../benchmarks/sieve.json" "../benchmarks/sqrt.json" \
+        "../benchmarks/sum-bits.json" "../benchmarks/sum-sq-diff.json"
+        )
+args=( "3 6" "128" "50" "7" "645634654" "8" "" "10" "101" "4 20" "8" "50 109658" "96 false" "496" "125" \
+        "-5 8 21" "" "8" "100" "" "42" "100")
+
+for i in "${!files[@]}"; do
+    bril2json < ${files[i]} > ${jsons[i]}
+
+    export json=${jsons[i]}
+    export arg=${args[i]}
+    echo "file is ${files[i]}"
+    echo "arg is $arg"
+    hyperfine --warmup 5 -L interp brili,./target/release/brilirs '{interp} -p $arg < $json'
+
+    rm ${jsons[i]}
+done

--- a/brilirs/long_benchmark.sh
+++ b/brilirs/long_benchmark.sh
@@ -3,7 +3,6 @@
 # Some ideas for faster code
 # Async code?
 # Feature gate type checking?
-# CoW?
 
 files=( "../benchmarks/ackermann.bril" "../benchmarks/eight-queens.bril" \
         "../benchmarks/mat-mul.bril"\

--- a/brilirs/long_benchmark.sh
+++ b/brilirs/long_benchmark.sh
@@ -1,20 +1,17 @@
 #!/bin/bash
 
 # Some ideas for faster code
-# Async code?
 # Feature gate type checking?
 
 files=( "../benchmarks/ackermann.bril" "../benchmarks/eight-queens.bril" \
-        "../benchmarks/mat-mul.bril"\
-        "../benchmarks/quadratic.bril"
+        "../benchmarks/mat-mul.bril"
 
         )
 jsons=( "../benchmarks/ackermann.json" "../benchmarks/eight-queens.json" \
-        "../benchmarks/mat-mul.json"\
-        "../benchmarks/quadratic.json"
+        "../benchmarks/mat-mul.json"
 
         )
-args=( "3 6" "8" "50 109658" "-5 8 21")
+args=( "3 6" "8" "50 109658")
 
 for i in "${!files[@]}"; do
     bril2json < ${files[i]} > ${jsons[i]}

--- a/brilirs/long_benchmark.sh
+++ b/brilirs/long_benchmark.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# Some ideas for faster code
+# Async code?
+# Feature gate type checking?
+# CoW?
+
+files=( "../benchmarks/ackermann.bril" "../benchmarks/eight-queens.bril" \
+        "../benchmarks/mat-mul.bril"\
+        "../benchmarks/quadratic.bril"
+
+        )
+jsons=( "../benchmarks/ackermann.json" "../benchmarks/eight-queens.json" \
+        "../benchmarks/mat-mul.json"\
+        "../benchmarks/quadratic.json"
+
+        )
+args=( "3 6" "8" "50 109658" "-5 8 21")
+
+for i in "${!files[@]}"; do
+    bril2json < ${files[i]} > ${jsons[i]}
+
+    export json=${jsons[i]}
+    export arg=${args[i]}
+    echo "file is ${files[i]}"
+    echo "arg is $arg"
+    hyperfine --warmup 5 -L interp brili,./target/release/brilirs '{interp} -p $arg < $json'
+
+    rm ${jsons[i]}
+done

--- a/brilirs/src/basic_block.rs
+++ b/brilirs/src/basic_block.rs
@@ -106,12 +106,15 @@ impl BBFunction {
       blocks.push(curr_block);
     }
 
-    (BBFunction {
-      name: func.name,
-      args: func.args,
-      return_type: func.return_type,
-      blocks,
-    }, label_map)
+    (
+      BBFunction {
+        name: func.name,
+        args: func.args,
+        return_type: func.return_type,
+        blocks,
+      },
+      label_map,
+    )
   }
 
   fn build_cfg(&mut self, label_map: FxHashMap<String, usize>) {

--- a/brilirs/src/basic_block.rs
+++ b/brilirs/src/basic_block.rs
@@ -1,5 +1,8 @@
 use bril_rs::{Function, Instruction, Program};
 use fxhash::FxHashMap;
+use error::InterpError;
+
+use crate::error;
 
 // A program represented as basic blocks.
 #[derive(Debug)]
@@ -8,13 +11,19 @@ pub struct BBProgram {
 }
 
 impl BBProgram {
-  pub fn new(prog: Program) -> BBProgram {
-    BBProgram {
+  pub fn new(prog: Program) -> Result<BBProgram, InterpError> {
+    let num_funcs = prog.functions.len();
+    let bb = BBProgram {
       func_index: prog
         .functions
         .into_iter()
         .map(|func| (func.name.clone(), BBFunction::new(func)))
         .collect(),
+    };
+    if bb.func_index.len() != num_funcs {
+      Err(InterpError::DuplicateFunction)
+    } else {
+      Ok(bb)
     }
   }
 

--- a/brilirs/src/check.rs
+++ b/brilirs/src/check.rs
@@ -9,473 +9,476 @@ use fxhash::FxHashMap;
 
 #[inline(always)]
 fn check_num_args(expected: usize, args: &[String]) -> Result<(), InterpError> {
-    if expected != args.len() {
-        Err(InterpError::BadNumArgs(expected, args.len()))
-    } else {
-        Ok(())
-    }
+  if expected != args.len() {
+    Err(InterpError::BadNumArgs(expected, args.len()))
+  } else {
+    Ok(())
+  }
 }
 
 #[inline(always)]
 fn check_num_funcs(expected: usize, funcs: &[String]) -> Result<(), InterpError> {
-    if expected != funcs.len() {
-        Err(InterpError::BadNumFuncs(expected, funcs.len()))
-    } else {
-        Ok(())
-    }
+  if expected != funcs.len() {
+    Err(InterpError::BadNumFuncs(expected, funcs.len()))
+  } else {
+    Ok(())
+  }
 }
 
 #[inline(always)]
 fn check_num_labels(expected: usize, labels: &[String]) -> Result<(), InterpError> {
-    if expected != labels.len() {
-        Err(InterpError::BadNumLabels(expected, labels.len()))
-    } else {
-        Ok(())
-    }
+  if expected != labels.len() {
+    Err(InterpError::BadNumLabels(expected, labels.len()))
+  } else {
+    Ok(())
+  }
 }
 
 #[inline(always)]
 fn check_asmt_type(expected: &bril_rs::Type, actual: &bril_rs::Type) -> Result<(), InterpError> {
-    if expected == actual {
-        Ok(())
-    } else {
-        Err(InterpError::BadAsmtType(expected.clone(), actual.clone()))
-    }
+  if expected == actual {
+    Ok(())
+  } else {
+    Err(InterpError::BadAsmtType(expected.clone(), actual.clone()))
+  }
 }
 
 #[inline(always)]
 fn update_env<'a>(
-    env: &mut FxHashMap<&'a String, &'a Type>,
-    dest: &'a String,
-    typ: &'a Type,
+  env: &mut FxHashMap<&'a String, &'a Type>,
+  dest: &'a String,
+  typ: &'a Type,
 ) -> Result<(), InterpError> {
-    match env.get(dest) {
-        Some(current_typ) => check_asmt_type(current_typ, &typ),
-        None => {
-            env.insert(dest, typ);
-            Ok(())
-        }
+  match env.get(dest) {
+    Some(current_typ) => check_asmt_type(current_typ, &typ),
+    None => {
+      env.insert(dest, typ);
+      Ok(())
     }
+  }
 }
 
 #[inline(always)]
 fn get_type<'a>(
-    env: &'a FxHashMap<&'a String, &'a Type>,
-    index: usize,
-    args: &[String],
+  env: &'a FxHashMap<&'a String, &'a Type>,
+  index: usize,
+  args: &[String],
 ) -> Result<&'a &'a Type, InterpError> {
-    if index >= args.len() {
-        return Err(InterpError::BadNumArgs(index, args.len()));
-    }
+  if index >= args.len() {
+    return Err(InterpError::BadNumArgs(index, args.len()));
+  }
 
-    env.get(&args[index])
-        .ok_or_else(|| InterpError::VarNotFound(args[index].to_string()))
+  env
+    .get(&args[index])
+    .ok_or_else(|| InterpError::VarNotFound(args[index].to_string()))
 }
 
 #[inline(always)]
 fn get_ptr_type(typ: &bril_rs::Type) -> Result<&bril_rs::Type, InterpError> {
-    match typ {
-        bril_rs::Type::Pointer(ptr_type) => Ok(&ptr_type),
-        _ => Err(InterpError::ExpectedPointerType(typ.clone())),
-    }
+  match typ {
+    bril_rs::Type::Pointer(ptr_type) => Ok(&ptr_type),
+    _ => Err(InterpError::ExpectedPointerType(typ.clone())),
+  }
 }
 
 fn type_check_instruction<'a>(
-    instr: &'a Instruction,
-    func: &BBFunction,
-    prog: &BBProgram,
-    env: &mut FxHashMap<&'a String, &'a Type>,
+  instr: &'a Instruction,
+  func: &BBFunction,
+  prog: &BBProgram,
+  env: &mut FxHashMap<&'a String, &'a Type>,
 ) -> Result<(), InterpError> {
-    match instr {
-        Instruction::Constant {
-            op: ConstOps::Const,
-            dest,
-            const_type,
-            value,
-        } => {
-            if const_type == &Type::Float && value.get_type() == Type::Int {
-                ()
-            } else {
-                check_asmt_type(const_type, &value.get_type())?;
-            }
-            update_env(env, dest, const_type)
-        }
-        Instruction::Value {
-            op: ValueOps::Add | ValueOps::Sub | ValueOps::Mul | ValueOps::Div,
-            dest,
-            op_type,
-            args,
-            funcs,
-            labels,
-        } => {
-            check_num_args(2, args)?;
-            check_num_funcs(0, funcs)?;
-            check_num_labels(0, labels)?;
-            check_asmt_type(&Type::Int, get_type(env, 0, args)?)?;
-            check_asmt_type(&Type::Int, get_type(env, 1, args)?)?;
-            check_asmt_type(&Type::Int, op_type)?;
-            update_env(env, dest, op_type)
-        }
-        Instruction::Value {
-            op: ValueOps::Eq | ValueOps::Lt | ValueOps::Gt | ValueOps::Le | ValueOps::Ge,
-            dest,
-            op_type,
-            args,
-            funcs,
-            labels,
-        } => {
-            check_num_args(2, args)?;
-            check_num_funcs(0, funcs)?;
-            check_num_labels(0, labels)?;
-            check_asmt_type(&Type::Int, get_type(env, 0, args)?)?;
-            check_asmt_type(&Type::Int, get_type(env, 1, args)?)?;
-            check_asmt_type(&Type::Bool, op_type)?;
-            update_env(env, dest, op_type)
-        }
-        Instruction::Value {
-            op: ValueOps::Not,
-            dest,
-            op_type,
-            args,
-            funcs,
-            labels,
-        } => {
-            check_num_args(1, args)?;
-            check_num_funcs(0, funcs)?;
-            check_num_labels(0, labels)?;
-            check_asmt_type(&Type::Bool, get_type(env, 0, args)?)?;
-            check_asmt_type(&Type::Bool, op_type)?;
-            update_env(env, dest, op_type)
-        }
-        Instruction::Value {
-            op: ValueOps::And | ValueOps::Or,
-            dest,
-            op_type,
-            args,
-            funcs,
-            labels,
-        } => {
-            check_num_args(2, args)?;
-            check_num_funcs(0, funcs)?;
-            check_num_labels(0, labels)?;
-            check_asmt_type(&Type::Bool, get_type(env, 0, args)?)?;
-            check_asmt_type(&Type::Bool, get_type(env, 1, args)?)?;
-            check_asmt_type(&Type::Bool, op_type)?;
-            update_env(env, dest, op_type)
-        }
-        Instruction::Value {
-            op: ValueOps::Id,
-            dest,
-            op_type,
-            args,
-            funcs,
-            labels,
-        } => {
-            check_num_args(1, args)?;
-            check_num_funcs(0, funcs)?;
-            check_num_labels(0, labels)?;
-            check_asmt_type(op_type, get_type(env, 0, args)?)?;
-            update_env(env, dest, op_type)
-        }
-        Instruction::Value {
-            op: ValueOps::Fadd | ValueOps::Fsub | ValueOps::Fmul | ValueOps::Fdiv,
-            dest,
-            op_type,
-            args,
-            funcs,
-            labels,
-        } => {
-            check_num_args(2, args)?;
-            check_num_funcs(0, funcs)?;
-            check_num_labels(0, labels)?;
-            check_asmt_type(&Type::Float, get_type(env, 0, args)?)?;
-            check_asmt_type(&Type::Float, get_type(env, 1, args)?)?;
-            check_asmt_type(&Type::Float, op_type)?;
-            update_env(env, dest, op_type)
-        }
-        Instruction::Value {
-            op: ValueOps::Feq | ValueOps::Flt | ValueOps::Fgt | ValueOps::Fle | ValueOps::Fge,
-            dest,
-            op_type,
-            args,
-            funcs,
-            labels,
-        } => {
-            check_num_args(2, args)?;
-            check_num_funcs(0, funcs)?;
-            check_num_labels(0, labels)?;
-            check_asmt_type(&Type::Float, get_type(env, 0, args)?)?;
-            check_asmt_type(&Type::Float, get_type(env, 1, args)?)?;
-            check_asmt_type(&Type::Bool, op_type)?;
-            update_env(env, dest, op_type)
-        }
-        Instruction::Value {
-            op: ValueOps::Call,
-            dest,
-            op_type,
-            args,
-            funcs,
-            labels,
-        } => {
-            check_num_funcs(1, funcs)?;
-            check_num_labels(0, labels)?;
-            let callee_func = prog
-                .func_index
-                .get(&funcs[0])
-                .ok_or_else(|| InterpError::FuncNotFound(funcs[0].clone()))?;
-            if args.len() != callee_func.args.len() {
-                return Err(InterpError::BadNumArgs(callee_func.args.len(), args.len()));
-            }
-
-            args.iter()
-                .zip(callee_func.args.iter())
-                .try_for_each(|(arg_name, expected_arg)| {
-                    let ty = env
-                        .get(&arg_name)
-                        .ok_or_else(|| InterpError::VarNotFound(arg_name.to_string()))?;
-
-                    check_asmt_type(&ty, &expected_arg.arg_type)
-                })?;
-
-            match &callee_func.return_type {
-                None => Err(InterpError::EmptyRetForfunc(callee_func.name.clone())),
-                Some(t) => check_asmt_type(op_type, &t),
-            }?;
-            update_env(env, dest, op_type)
-        }
-        Instruction::Value {
-            op: ValueOps::Phi,
-            dest,
-            op_type,
-            args,
-            funcs,
-            labels,
-        } => {
-            if args.len() != labels.len() {
-                return Err(InterpError::UnequalPhiNode);
-            }
-            check_num_funcs(0, funcs)?;
-            // Phi nodes are a little weird with their args and theirs been some discussion on an _undefined var name in #108
-            // Instead, we are going to assign the type we expect to all of the args and this will trigger an error if any of these args ends up being a different type.
-            args.iter().try_for_each(|a| update_env(env, a, op_type))?;
-
-            update_env(env, dest, op_type)
-        }
-        Instruction::Value {
-            op: ValueOps::Alloc,
-            dest,
-            op_type,
-            args,
-            funcs,
-            labels,
-        } => {
-            check_num_args(1, args)?;
-            check_num_funcs(0, funcs)?;
-            check_num_labels(0, labels)?;
-            check_asmt_type(&Type::Int, get_type(env, 0, args)?)?;
-            get_ptr_type(op_type)?;
-            update_env(env, dest, op_type)
-        }
-        Instruction::Value {
-            op: ValueOps::Load,
-            dest,
-            op_type,
-            args,
-            funcs,
-            labels,
-        } => {
-            check_num_args(1, args)?;
-            check_num_funcs(0, funcs)?;
-            check_num_labels(0, labels)?;
-            let ptr_type = get_ptr_type(get_type(env, 0, args)?)?;
-            check_asmt_type(ptr_type, op_type)?;
-            update_env(env, dest, op_type)
-        }
-        Instruction::Value {
-            op: ValueOps::PtrAdd,
-            dest,
-            op_type,
-            args,
-            funcs,
-            labels,
-        } => {
-            check_num_args(2, args)?;
-            check_num_funcs(0, funcs)?;
-            check_num_labels(0, labels)?;
-            let ty0 = get_type(env, 0, args)?;
-            get_ptr_type(ty0)?;
-            check_asmt_type(&Type::Int, get_type(env, 1, args)?)?;
-            check_asmt_type(ty0, op_type)?;
-            update_env(env, dest, op_type)
-        }
-        Instruction::Effect {
-            op: EffectOps::Jump,
-            args,
-            funcs,
-            labels,
-        } => {
-            check_num_args(0, args)?;
-            check_num_funcs(0, funcs)?;
-            check_num_labels(1, labels)?;
-            Ok(())
-        }
-        Instruction::Effect {
-            op: EffectOps::Branch,
-            args,
-            funcs,
-            labels,
-        } => {
-            check_num_args(1, args)?;
-            check_asmt_type(&Type::Bool, get_type(env, 0, args)?)?;
-            check_num_funcs(0, funcs)?;
-            check_num_labels(2, labels)?;
-            Ok(())
-        }
-        Instruction::Effect {
-            op: EffectOps::Return,
-            args,
-            funcs,
-            labels,
-        } => {
-            check_num_funcs(0, funcs)?;
-            check_num_labels(0, labels)?;
-            match &func.return_type {
-                Some(t) => {
-                    check_num_args(1, args)?;
-                    let ty0 = get_type(env, 0, args)?;
-                    check_asmt_type(t, ty0)?;
-                    return Ok(());
-                }
-                None => {
-                    if args.is_empty() {
-                        return Ok(());
-                    } else {
-                        return Err(InterpError::NonEmptyRetForfunc(func.name.clone()));
-                    }
-                }
-            }
-        }
-        Instruction::Effect {
-            op: EffectOps::Print,
-            args,
-            funcs,
-            labels,
-        } => {
-            check_num_funcs(0, funcs)?;
-            check_num_labels(0, labels)?;
-            args.iter().enumerate().try_for_each(|(i, _)| {
-                get_type(env, i, args)?;
-                Ok(())
-            })
-        }
-        Instruction::Effect {
-            op: EffectOps::Nop,
-            args,
-            funcs,
-            labels,
-        } => {
-            check_num_args(0, args)?;
-            check_num_funcs(0, funcs)?;
-            check_num_labels(0, labels)?;
-            Ok(())
-        }
-        Instruction::Effect {
-            op: EffectOps::Call,
-            args,
-            funcs,
-            labels,
-        } => {
-            check_num_funcs(1, funcs)?;
-            check_num_labels(0, labels)?;
-            let callee_func = prog
-                .func_index
-                .get(&funcs[0])
-                .ok_or_else(|| InterpError::FuncNotFound(funcs[0].clone()))?;
-            if args.len() != callee_func.args.len() {
-                return Err(InterpError::BadNumArgs(callee_func.args.len(), args.len()));
-            }
-
-            args.iter()
-                .zip(callee_func.args.iter())
-                .try_for_each(|(arg_name, expected_arg)| {
-                    let ty = env
-                        .get(&arg_name)
-                        .ok_or_else(|| InterpError::VarNotFound(arg_name.to_string()))?;
-
-                    check_asmt_type(ty, &expected_arg.arg_type)
-                })?;
-
-            if callee_func.return_type.is_some() {
-                Err(InterpError::NonEmptyRetForfunc(callee_func.name.clone()))
-            } else {
-                Ok(())
-            }
-        }
-        Instruction::Effect {
-            op: EffectOps::Store,
-            args,
-            funcs,
-            labels,
-        } => {
-            check_num_args(2, args)?;
-            check_num_funcs(0, funcs)?;
-            check_num_labels(0, labels)?;
-            let ty0 = get_type(env, 0, args)?;
-            let ty1 = get_type(env, 1, args)?;
-            check_asmt_type(get_ptr_type(ty0)?, ty1)
-        }
-        Instruction::Effect {
-            op: EffectOps::Free,
-            args,
-            funcs,
-            labels,
-        } => {
-            check_num_args(1, args)?;
-            check_num_funcs(0, funcs)?;
-            check_num_labels(0, labels)?;
-            get_ptr_type(get_type(env, 0, args)?)?;
-            Ok(())
-        }
-        Instruction::Effect {
-            op: EffectOps::Speculate | EffectOps::Guard | EffectOps::Commit,
-            args: _,
-            funcs: _,
-            labels: _,
-        } => {
-            unimplemented!()
-        }
+  match instr {
+    Instruction::Constant {
+      op: ConstOps::Const,
+      dest,
+      const_type,
+      value,
+    } => {
+      if const_type == &Type::Float && value.get_type() == Type::Int {
+        ()
+      } else {
+        check_asmt_type(const_type, &value.get_type())?;
+      }
+      update_env(env, dest, const_type)
     }
+    Instruction::Value {
+      op: ValueOps::Add | ValueOps::Sub | ValueOps::Mul | ValueOps::Div,
+      dest,
+      op_type,
+      args,
+      funcs,
+      labels,
+    } => {
+      check_num_args(2, args)?;
+      check_num_funcs(0, funcs)?;
+      check_num_labels(0, labels)?;
+      check_asmt_type(&Type::Int, get_type(env, 0, args)?)?;
+      check_asmt_type(&Type::Int, get_type(env, 1, args)?)?;
+      check_asmt_type(&Type::Int, op_type)?;
+      update_env(env, dest, op_type)
+    }
+    Instruction::Value {
+      op: ValueOps::Eq | ValueOps::Lt | ValueOps::Gt | ValueOps::Le | ValueOps::Ge,
+      dest,
+      op_type,
+      args,
+      funcs,
+      labels,
+    } => {
+      check_num_args(2, args)?;
+      check_num_funcs(0, funcs)?;
+      check_num_labels(0, labels)?;
+      check_asmt_type(&Type::Int, get_type(env, 0, args)?)?;
+      check_asmt_type(&Type::Int, get_type(env, 1, args)?)?;
+      check_asmt_type(&Type::Bool, op_type)?;
+      update_env(env, dest, op_type)
+    }
+    Instruction::Value {
+      op: ValueOps::Not,
+      dest,
+      op_type,
+      args,
+      funcs,
+      labels,
+    } => {
+      check_num_args(1, args)?;
+      check_num_funcs(0, funcs)?;
+      check_num_labels(0, labels)?;
+      check_asmt_type(&Type::Bool, get_type(env, 0, args)?)?;
+      check_asmt_type(&Type::Bool, op_type)?;
+      update_env(env, dest, op_type)
+    }
+    Instruction::Value {
+      op: ValueOps::And | ValueOps::Or,
+      dest,
+      op_type,
+      args,
+      funcs,
+      labels,
+    } => {
+      check_num_args(2, args)?;
+      check_num_funcs(0, funcs)?;
+      check_num_labels(0, labels)?;
+      check_asmt_type(&Type::Bool, get_type(env, 0, args)?)?;
+      check_asmt_type(&Type::Bool, get_type(env, 1, args)?)?;
+      check_asmt_type(&Type::Bool, op_type)?;
+      update_env(env, dest, op_type)
+    }
+    Instruction::Value {
+      op: ValueOps::Id,
+      dest,
+      op_type,
+      args,
+      funcs,
+      labels,
+    } => {
+      check_num_args(1, args)?;
+      check_num_funcs(0, funcs)?;
+      check_num_labels(0, labels)?;
+      check_asmt_type(op_type, get_type(env, 0, args)?)?;
+      update_env(env, dest, op_type)
+    }
+    Instruction::Value {
+      op: ValueOps::Fadd | ValueOps::Fsub | ValueOps::Fmul | ValueOps::Fdiv,
+      dest,
+      op_type,
+      args,
+      funcs,
+      labels,
+    } => {
+      check_num_args(2, args)?;
+      check_num_funcs(0, funcs)?;
+      check_num_labels(0, labels)?;
+      check_asmt_type(&Type::Float, get_type(env, 0, args)?)?;
+      check_asmt_type(&Type::Float, get_type(env, 1, args)?)?;
+      check_asmt_type(&Type::Float, op_type)?;
+      update_env(env, dest, op_type)
+    }
+    Instruction::Value {
+      op: ValueOps::Feq | ValueOps::Flt | ValueOps::Fgt | ValueOps::Fle | ValueOps::Fge,
+      dest,
+      op_type,
+      args,
+      funcs,
+      labels,
+    } => {
+      check_num_args(2, args)?;
+      check_num_funcs(0, funcs)?;
+      check_num_labels(0, labels)?;
+      check_asmt_type(&Type::Float, get_type(env, 0, args)?)?;
+      check_asmt_type(&Type::Float, get_type(env, 1, args)?)?;
+      check_asmt_type(&Type::Bool, op_type)?;
+      update_env(env, dest, op_type)
+    }
+    Instruction::Value {
+      op: ValueOps::Call,
+      dest,
+      op_type,
+      args,
+      funcs,
+      labels,
+    } => {
+      check_num_funcs(1, funcs)?;
+      check_num_labels(0, labels)?;
+      let callee_func = prog
+        .func_index
+        .get(&funcs[0])
+        .ok_or_else(|| InterpError::FuncNotFound(funcs[0].clone()))?;
+      if args.len() != callee_func.args.len() {
+        return Err(InterpError::BadNumArgs(callee_func.args.len(), args.len()));
+      }
+
+      args
+        .iter()
+        .zip(callee_func.args.iter())
+        .try_for_each(|(arg_name, expected_arg)| {
+          let ty = env
+            .get(&arg_name)
+            .ok_or_else(|| InterpError::VarNotFound(arg_name.to_string()))?;
+
+          check_asmt_type(&ty, &expected_arg.arg_type)
+        })?;
+
+      match &callee_func.return_type {
+        None => Err(InterpError::EmptyRetForfunc(callee_func.name.clone())),
+        Some(t) => check_asmt_type(op_type, &t),
+      }?;
+      update_env(env, dest, op_type)
+    }
+    Instruction::Value {
+      op: ValueOps::Phi,
+      dest,
+      op_type,
+      args,
+      funcs,
+      labels,
+    } => {
+      if args.len() != labels.len() {
+        return Err(InterpError::UnequalPhiNode);
+      }
+      check_num_funcs(0, funcs)?;
+      // Phi nodes are a little weird with their args and theirs been some discussion on an _undefined var name in #108
+      // Instead, we are going to assign the type we expect to all of the args and this will trigger an error if any of these args ends up being a different type.
+      args.iter().try_for_each(|a| update_env(env, a, op_type))?;
+
+      update_env(env, dest, op_type)
+    }
+    Instruction::Value {
+      op: ValueOps::Alloc,
+      dest,
+      op_type,
+      args,
+      funcs,
+      labels,
+    } => {
+      check_num_args(1, args)?;
+      check_num_funcs(0, funcs)?;
+      check_num_labels(0, labels)?;
+      check_asmt_type(&Type::Int, get_type(env, 0, args)?)?;
+      get_ptr_type(op_type)?;
+      update_env(env, dest, op_type)
+    }
+    Instruction::Value {
+      op: ValueOps::Load,
+      dest,
+      op_type,
+      args,
+      funcs,
+      labels,
+    } => {
+      check_num_args(1, args)?;
+      check_num_funcs(0, funcs)?;
+      check_num_labels(0, labels)?;
+      let ptr_type = get_ptr_type(get_type(env, 0, args)?)?;
+      check_asmt_type(ptr_type, op_type)?;
+      update_env(env, dest, op_type)
+    }
+    Instruction::Value {
+      op: ValueOps::PtrAdd,
+      dest,
+      op_type,
+      args,
+      funcs,
+      labels,
+    } => {
+      check_num_args(2, args)?;
+      check_num_funcs(0, funcs)?;
+      check_num_labels(0, labels)?;
+      let ty0 = get_type(env, 0, args)?;
+      get_ptr_type(ty0)?;
+      check_asmt_type(&Type::Int, get_type(env, 1, args)?)?;
+      check_asmt_type(ty0, op_type)?;
+      update_env(env, dest, op_type)
+    }
+    Instruction::Effect {
+      op: EffectOps::Jump,
+      args,
+      funcs,
+      labels,
+    } => {
+      check_num_args(0, args)?;
+      check_num_funcs(0, funcs)?;
+      check_num_labels(1, labels)?;
+      Ok(())
+    }
+    Instruction::Effect {
+      op: EffectOps::Branch,
+      args,
+      funcs,
+      labels,
+    } => {
+      check_num_args(1, args)?;
+      check_asmt_type(&Type::Bool, get_type(env, 0, args)?)?;
+      check_num_funcs(0, funcs)?;
+      check_num_labels(2, labels)?;
+      Ok(())
+    }
+    Instruction::Effect {
+      op: EffectOps::Return,
+      args,
+      funcs,
+      labels,
+    } => {
+      check_num_funcs(0, funcs)?;
+      check_num_labels(0, labels)?;
+      match &func.return_type {
+        Some(t) => {
+          check_num_args(1, args)?;
+          let ty0 = get_type(env, 0, args)?;
+          check_asmt_type(t, ty0)?;
+          return Ok(());
+        }
+        None => {
+          if args.is_empty() {
+            return Ok(());
+          } else {
+            return Err(InterpError::NonEmptyRetForfunc(func.name.clone()));
+          }
+        }
+      }
+    }
+    Instruction::Effect {
+      op: EffectOps::Print,
+      args,
+      funcs,
+      labels,
+    } => {
+      check_num_funcs(0, funcs)?;
+      check_num_labels(0, labels)?;
+      args.iter().enumerate().try_for_each(|(i, _)| {
+        get_type(env, i, args)?;
+        Ok(())
+      })
+    }
+    Instruction::Effect {
+      op: EffectOps::Nop,
+      args,
+      funcs,
+      labels,
+    } => {
+      check_num_args(0, args)?;
+      check_num_funcs(0, funcs)?;
+      check_num_labels(0, labels)?;
+      Ok(())
+    }
+    Instruction::Effect {
+      op: EffectOps::Call,
+      args,
+      funcs,
+      labels,
+    } => {
+      check_num_funcs(1, funcs)?;
+      check_num_labels(0, labels)?;
+      let callee_func = prog
+        .func_index
+        .get(&funcs[0])
+        .ok_or_else(|| InterpError::FuncNotFound(funcs[0].clone()))?;
+      if args.len() != callee_func.args.len() {
+        return Err(InterpError::BadNumArgs(callee_func.args.len(), args.len()));
+      }
+
+      args
+        .iter()
+        .zip(callee_func.args.iter())
+        .try_for_each(|(arg_name, expected_arg)| {
+          let ty = env
+            .get(&arg_name)
+            .ok_or_else(|| InterpError::VarNotFound(arg_name.to_string()))?;
+
+          check_asmt_type(ty, &expected_arg.arg_type)
+        })?;
+
+      if callee_func.return_type.is_some() {
+        Err(InterpError::NonEmptyRetForfunc(callee_func.name.clone()))
+      } else {
+        Ok(())
+      }
+    }
+    Instruction::Effect {
+      op: EffectOps::Store,
+      args,
+      funcs,
+      labels,
+    } => {
+      check_num_args(2, args)?;
+      check_num_funcs(0, funcs)?;
+      check_num_labels(0, labels)?;
+      let ty0 = get_type(env, 0, args)?;
+      let ty1 = get_type(env, 1, args)?;
+      check_asmt_type(get_ptr_type(ty0)?, ty1)
+    }
+    Instruction::Effect {
+      op: EffectOps::Free,
+      args,
+      funcs,
+      labels,
+    } => {
+      check_num_args(1, args)?;
+      check_num_funcs(0, funcs)?;
+      check_num_labels(0, labels)?;
+      get_ptr_type(get_type(env, 0, args)?)?;
+      Ok(())
+    }
+    Instruction::Effect {
+      op: EffectOps::Speculate | EffectOps::Guard | EffectOps::Commit,
+      args: _,
+      funcs: _,
+      labels: _,
+    } => {
+      unimplemented!()
+    }
+  }
 }
 
 fn type_check_func(bbfunc: &BBFunction, bbprog: &BBProgram) -> Result<(), InterpError> {
-    let mut env = FxHashMap::with_capacity_and_hasher(20, fxhash::FxBuildHasher::default());
-    bbfunc.args.iter().for_each(|a| {
-        env.insert(&a.name, &a.arg_type);
-    });
+  let mut env = FxHashMap::with_capacity_and_hasher(20, fxhash::FxBuildHasher::default());
+  bbfunc.args.iter().for_each(|a| {
+    env.insert(&a.name, &a.arg_type);
+  });
 
-    let mut work_list = vec![0];
-    let mut done_list = Vec::new();
+  let mut work_list = vec![0];
+  let mut done_list = Vec::new();
 
-    while let Some(b) = work_list.pop() {
-        let block = bbfunc.blocks.get(b).unwrap();
-        block
-            .instrs
-            .iter()
-            .try_for_each(|i| type_check_instruction(i, bbfunc, bbprog, &mut env))?;
-        done_list.push(b);
-        block.exit.iter().for_each(|e| {
-            if !done_list.contains(e) && !work_list.contains(e) {
-                work_list.push(*e)
-            }
-        })
-    }
+  while let Some(b) = work_list.pop() {
+    let block = bbfunc.blocks.get(b).unwrap();
+    block
+      .instrs
+      .iter()
+      .try_for_each(|i| type_check_instruction(i, bbfunc, bbprog, &mut env))?;
+    done_list.push(b);
+    block.exit.iter().for_each(|e| {
+      if !done_list.contains(e) && !work_list.contains(e) {
+        work_list.push(*e)
+      }
+    })
+  }
 
-    Ok(())
+  Ok(())
 }
 
 pub fn type_check(bbprog: &BBProgram) -> Result<(), InterpError> {
-    bbprog
-        .func_index
-        .iter()
-        .try_for_each(|(_, bbfunc)| type_check_func(bbfunc, bbprog))
+  bbprog
+    .func_index
+    .iter()
+    .try_for_each(|(_, bbfunc)| type_check_func(bbfunc, bbprog))
 }

--- a/brilirs/src/check.rs
+++ b/brilirs/src/check.rs
@@ -1,0 +1,481 @@
+use std::unimplemented;
+
+use crate::basic_block::{BBFunction, BBProgram};
+use bril_rs::{ConstOps, EffectOps, Instruction, Type, ValueOps};
+
+use crate::error::InterpError;
+
+use fxhash::FxHashMap;
+
+#[inline(always)]
+fn check_num_args(expected: usize, args: &[String]) -> Result<(), InterpError> {
+    if expected != args.len() {
+        Err(InterpError::BadNumArgs(expected, args.len()))
+    } else {
+        Ok(())
+    }
+}
+
+#[inline(always)]
+fn check_num_funcs(expected: usize, funcs: &[String]) -> Result<(), InterpError> {
+    if expected != funcs.len() {
+        Err(InterpError::BadNumFuncs(expected, funcs.len()))
+    } else {
+        Ok(())
+    }
+}
+
+#[inline(always)]
+fn check_num_labels(expected: usize, labels: &[String]) -> Result<(), InterpError> {
+    if expected != labels.len() {
+        Err(InterpError::BadNumLabels(expected, labels.len()))
+    } else {
+        Ok(())
+    }
+}
+
+#[inline(always)]
+fn check_asmt_type(expected: &bril_rs::Type, actual: &bril_rs::Type) -> Result<(), InterpError> {
+    if expected == actual {
+        Ok(())
+    } else {
+        Err(InterpError::BadAsmtType(expected.clone(), actual.clone()))
+    }
+}
+
+#[inline(always)]
+fn update_env<'a>(
+    env: &mut FxHashMap<&'a String, &'a Type>,
+    dest: &'a String,
+    typ: &'a Type,
+) -> Result<(), InterpError> {
+    match env.get(dest) {
+        Some(current_typ) => check_asmt_type(current_typ, &typ),
+        None => {
+            env.insert(dest, typ);
+            Ok(())
+        }
+    }
+}
+
+#[inline(always)]
+fn get_type<'a>(
+    env: &'a FxHashMap<&'a String, &'a Type>,
+    index: usize,
+    args: &[String],
+) -> Result<&'a &'a Type, InterpError> {
+    if index >= args.len() {
+        return Err(InterpError::BadNumArgs(index, args.len()));
+    }
+
+    env.get(&args[index])
+        .ok_or_else(|| InterpError::VarNotFound(args[index].to_string()))
+}
+
+#[inline(always)]
+fn get_ptr_type(typ: &bril_rs::Type) -> Result<&bril_rs::Type, InterpError> {
+    match typ {
+        bril_rs::Type::Pointer(ptr_type) => Ok(&ptr_type),
+        _ => Err(InterpError::ExpectedPointerType(typ.clone())),
+    }
+}
+
+fn type_check_instruction<'a>(
+    instr: &'a Instruction,
+    func: &BBFunction,
+    prog: &BBProgram,
+    env: &mut FxHashMap<&'a String, &'a Type>,
+) -> Result<(), InterpError> {
+    match instr {
+        Instruction::Constant {
+            op: ConstOps::Const,
+            dest,
+            const_type,
+            value,
+        } => {
+            if const_type == &Type::Float && value.get_type() == Type::Int {
+                ()
+            } else {
+                check_asmt_type(const_type, &value.get_type())?;
+            }
+            update_env(env, dest, const_type)
+        }
+        Instruction::Value {
+            op: ValueOps::Add | ValueOps::Sub | ValueOps::Mul | ValueOps::Div,
+            dest,
+            op_type,
+            args,
+            funcs,
+            labels,
+        } => {
+            check_num_args(2, args)?;
+            check_num_funcs(0, funcs)?;
+            check_num_labels(0, labels)?;
+            check_asmt_type(&Type::Int, get_type(env, 0, args)?)?;
+            check_asmt_type(&Type::Int, get_type(env, 1, args)?)?;
+            check_asmt_type(&Type::Int, op_type)?;
+            update_env(env, dest, op_type)
+        }
+        Instruction::Value {
+            op: ValueOps::Eq | ValueOps::Lt | ValueOps::Gt | ValueOps::Le | ValueOps::Ge,
+            dest,
+            op_type,
+            args,
+            funcs,
+            labels,
+        } => {
+            check_num_args(2, args)?;
+            check_num_funcs(0, funcs)?;
+            check_num_labels(0, labels)?;
+            check_asmt_type(&Type::Int, get_type(env, 0, args)?)?;
+            check_asmt_type(&Type::Int, get_type(env, 1, args)?)?;
+            check_asmt_type(&Type::Bool, op_type)?;
+            update_env(env, dest, op_type)
+        }
+        Instruction::Value {
+            op: ValueOps::Not,
+            dest,
+            op_type,
+            args,
+            funcs,
+            labels,
+        } => {
+            check_num_args(1, args)?;
+            check_num_funcs(0, funcs)?;
+            check_num_labels(0, labels)?;
+            check_asmt_type(&Type::Bool, get_type(env, 0, args)?)?;
+            check_asmt_type(&Type::Bool, op_type)?;
+            update_env(env, dest, op_type)
+        }
+        Instruction::Value {
+            op: ValueOps::And | ValueOps::Or,
+            dest,
+            op_type,
+            args,
+            funcs,
+            labels,
+        } => {
+            check_num_args(2, args)?;
+            check_num_funcs(0, funcs)?;
+            check_num_labels(0, labels)?;
+            check_asmt_type(&Type::Bool, get_type(env, 0, args)?)?;
+            check_asmt_type(&Type::Bool, get_type(env, 1, args)?)?;
+            check_asmt_type(&Type::Bool, op_type)?;
+            update_env(env, dest, op_type)
+        }
+        Instruction::Value {
+            op: ValueOps::Id,
+            dest,
+            op_type,
+            args,
+            funcs,
+            labels,
+        } => {
+            check_num_args(1, args)?;
+            check_num_funcs(0, funcs)?;
+            check_num_labels(0, labels)?;
+            check_asmt_type(op_type, get_type(env, 0, args)?)?;
+            update_env(env, dest, op_type)
+        }
+        Instruction::Value {
+            op: ValueOps::Fadd | ValueOps::Fsub | ValueOps::Fmul | ValueOps::Fdiv,
+            dest,
+            op_type,
+            args,
+            funcs,
+            labels,
+        } => {
+            check_num_args(2, args)?;
+            check_num_funcs(0, funcs)?;
+            check_num_labels(0, labels)?;
+            check_asmt_type(&Type::Float, get_type(env, 0, args)?)?;
+            check_asmt_type(&Type::Float, get_type(env, 1, args)?)?;
+            check_asmt_type(&Type::Float, op_type)?;
+            update_env(env, dest, op_type)
+        }
+        Instruction::Value {
+            op: ValueOps::Feq | ValueOps::Flt | ValueOps::Fgt | ValueOps::Fle | ValueOps::Fge,
+            dest,
+            op_type,
+            args,
+            funcs,
+            labels,
+        } => {
+            check_num_args(2, args)?;
+            check_num_funcs(0, funcs)?;
+            check_num_labels(0, labels)?;
+            check_asmt_type(&Type::Float, get_type(env, 0, args)?)?;
+            check_asmt_type(&Type::Float, get_type(env, 1, args)?)?;
+            check_asmt_type(&Type::Bool, op_type)?;
+            update_env(env, dest, op_type)
+        }
+        Instruction::Value {
+            op: ValueOps::Call,
+            dest,
+            op_type,
+            args,
+            funcs,
+            labels,
+        } => {
+            check_num_funcs(1, funcs)?;
+            check_num_labels(0, labels)?;
+            let callee_func = prog
+                .func_index
+                .get(&funcs[0])
+                .ok_or_else(|| InterpError::FuncNotFound(funcs[0].clone()))?;
+            if args.len() != callee_func.args.len() {
+                return Err(InterpError::BadNumArgs(callee_func.args.len(), args.len()));
+            }
+
+            args.iter()
+                .zip(callee_func.args.iter())
+                .try_for_each(|(arg_name, expected_arg)| {
+                    let ty = env
+                        .get(&arg_name)
+                        .ok_or_else(|| InterpError::VarNotFound(arg_name.to_string()))?;
+
+                    check_asmt_type(&ty, &expected_arg.arg_type)
+                })?;
+
+            match &callee_func.return_type {
+                None => Err(InterpError::EmptyRetForfunc(callee_func.name.clone())),
+                Some(t) => check_asmt_type(op_type, &t),
+            }?;
+            update_env(env, dest, op_type)
+        }
+        Instruction::Value {
+            op: ValueOps::Phi,
+            dest,
+            op_type,
+            args,
+            funcs,
+            labels,
+        } => {
+            if args.len() != labels.len() {
+                return Err(InterpError::UnequalPhiNode);
+            }
+            check_num_funcs(0, funcs)?;
+            // Phi nodes are a little weird with their args and theirs been some discussion on an _undefined var name in #108
+            // Instead, we are going to assign the type we expect to all of the args and this will trigger an error if any of these args ends up being a different type.
+            args.iter().try_for_each(|a| update_env(env, a, op_type))?;
+
+            update_env(env, dest, op_type)
+        }
+        Instruction::Value {
+            op: ValueOps::Alloc,
+            dest,
+            op_type,
+            args,
+            funcs,
+            labels,
+        } => {
+            check_num_args(1, args)?;
+            check_num_funcs(0, funcs)?;
+            check_num_labels(0, labels)?;
+            check_asmt_type(&Type::Int, get_type(env, 0, args)?)?;
+            get_ptr_type(op_type)?;
+            update_env(env, dest, op_type)
+        }
+        Instruction::Value {
+            op: ValueOps::Load,
+            dest,
+            op_type,
+            args,
+            funcs,
+            labels,
+        } => {
+            check_num_args(1, args)?;
+            check_num_funcs(0, funcs)?;
+            check_num_labels(0, labels)?;
+            let ptr_type = get_ptr_type(get_type(env, 0, args)?)?;
+            check_asmt_type(ptr_type, op_type)?;
+            update_env(env, dest, op_type)
+        }
+        Instruction::Value {
+            op: ValueOps::PtrAdd,
+            dest,
+            op_type,
+            args,
+            funcs,
+            labels,
+        } => {
+            check_num_args(2, args)?;
+            check_num_funcs(0, funcs)?;
+            check_num_labels(0, labels)?;
+            let ty0 = get_type(env, 0, args)?;
+            get_ptr_type(ty0)?;
+            check_asmt_type(&Type::Int, get_type(env, 1, args)?)?;
+            check_asmt_type(ty0, op_type)?;
+            update_env(env, dest, op_type)
+        }
+        Instruction::Effect {
+            op: EffectOps::Jump,
+            args,
+            funcs,
+            labels,
+        } => {
+            check_num_args(0, args)?;
+            check_num_funcs(0, funcs)?;
+            check_num_labels(1, labels)?;
+            Ok(())
+        }
+        Instruction::Effect {
+            op: EffectOps::Branch,
+            args,
+            funcs,
+            labels,
+        } => {
+            check_num_args(1, args)?;
+            check_asmt_type(&Type::Bool, get_type(env, 0, args)?)?;
+            check_num_funcs(0, funcs)?;
+            check_num_labels(2, labels)?;
+            Ok(())
+        }
+        Instruction::Effect {
+            op: EffectOps::Return,
+            args,
+            funcs,
+            labels,
+        } => {
+            check_num_funcs(0, funcs)?;
+            check_num_labels(0, labels)?;
+            match &func.return_type {
+                Some(t) => {
+                    check_num_args(1, args)?;
+                    let ty0 = get_type(env, 0, args)?;
+                    check_asmt_type(t, ty0)?;
+                    return Ok(());
+                }
+                None => {
+                    if args.is_empty() {
+                        return Ok(());
+                    } else {
+                        return Err(InterpError::NonEmptyRetForfunc(func.name.clone()));
+                    }
+                }
+            }
+        }
+        Instruction::Effect {
+            op: EffectOps::Print,
+            args,
+            funcs,
+            labels,
+        } => {
+            check_num_funcs(0, funcs)?;
+            check_num_labels(0, labels)?;
+            args.iter().enumerate().try_for_each(|(i, _)| {
+                get_type(env, i, args)?;
+                Ok(())
+            })
+        }
+        Instruction::Effect {
+            op: EffectOps::Nop,
+            args,
+            funcs,
+            labels,
+        } => {
+            check_num_args(0, args)?;
+            check_num_funcs(0, funcs)?;
+            check_num_labels(0, labels)?;
+            Ok(())
+        }
+        Instruction::Effect {
+            op: EffectOps::Call,
+            args,
+            funcs,
+            labels,
+        } => {
+            check_num_funcs(1, funcs)?;
+            check_num_labels(0, labels)?;
+            let callee_func = prog
+                .func_index
+                .get(&funcs[0])
+                .ok_or_else(|| InterpError::FuncNotFound(funcs[0].clone()))?;
+            if args.len() != callee_func.args.len() {
+                return Err(InterpError::BadNumArgs(callee_func.args.len(), args.len()));
+            }
+
+            args.iter()
+                .zip(callee_func.args.iter())
+                .try_for_each(|(arg_name, expected_arg)| {
+                    let ty = env
+                        .get(&arg_name)
+                        .ok_or_else(|| InterpError::VarNotFound(arg_name.to_string()))?;
+
+                    check_asmt_type(ty, &expected_arg.arg_type)
+                })?;
+
+            if callee_func.return_type.is_some() {
+                Err(InterpError::NonEmptyRetForfunc(callee_func.name.clone()))
+            } else {
+                Ok(())
+            }
+        }
+        Instruction::Effect {
+            op: EffectOps::Store,
+            args,
+            funcs,
+            labels,
+        } => {
+            check_num_args(2, args)?;
+            check_num_funcs(0, funcs)?;
+            check_num_labels(0, labels)?;
+            let ty0 = get_type(env, 0, args)?;
+            let ty1 = get_type(env, 1, args)?;
+            check_asmt_type(get_ptr_type(ty0)?, ty1)
+        }
+        Instruction::Effect {
+            op: EffectOps::Free,
+            args,
+            funcs,
+            labels,
+        } => {
+            check_num_args(1, args)?;
+            check_num_funcs(0, funcs)?;
+            check_num_labels(0, labels)?;
+            get_ptr_type(get_type(env, 0, args)?)?;
+            Ok(())
+        }
+        Instruction::Effect {
+            op: EffectOps::Speculate | EffectOps::Guard | EffectOps::Commit,
+            args: _,
+            funcs: _,
+            labels: _,
+        } => {
+            unimplemented!()
+        }
+    }
+}
+
+fn type_check_func(bbfunc: &BBFunction, bbprog: &BBProgram) -> Result<(), InterpError> {
+    let mut env = FxHashMap::with_capacity_and_hasher(20, fxhash::FxBuildHasher::default());
+    bbfunc.args.iter().for_each(|a| {
+        env.insert(&a.name, &a.arg_type);
+    });
+
+    let mut work_list = vec![0];
+    let mut done_list = Vec::new();
+
+    while let Some(b) = work_list.pop() {
+        let block = bbfunc.blocks.get(b).unwrap();
+        block
+            .instrs
+            .iter()
+            .try_for_each(|i| type_check_instruction(i, bbfunc, bbprog, &mut env))?;
+        done_list.push(b);
+        block.exit.iter().for_each(|e| {
+            if !done_list.contains(e) && !work_list.contains(e) {
+                work_list.push(*e)
+            }
+        })
+    }
+
+    Ok(())
+}
+
+pub fn type_check(bbprog: &BBProgram) -> Result<(), InterpError> {
+    bbprog
+        .func_index
+        .iter()
+        .try_for_each(|(_, bbfunc)| type_check_func(bbfunc, bbprog))
+}

--- a/brilirs/src/check.rs
+++ b/brilirs/src/check.rs
@@ -70,7 +70,7 @@ fn get_type<'a>(
 
   env
     .get(&args[index] as &str)
-    .ok_or_else(|| InterpError::VarNotFound(args[index].to_string()))
+    .ok_or_else(|| InterpError::VarUndefined(args[index].to_string()))
 }
 
 #[inline(always)]
@@ -232,13 +232,13 @@ fn type_check_instruction<'a>(
         .try_for_each(|(arg_name, expected_arg)| {
           let ty = env
             .get(&arg_name as &str)
-            .ok_or_else(|| InterpError::VarNotFound(arg_name.to_string()))?;
+            .ok_or_else(|| InterpError::VarUndefined(arg_name.to_string()))?;
 
           check_asmt_type(&ty, &expected_arg.arg_type)
         })?;
 
       match &callee_func.return_type {
-        None => Err(InterpError::EmptyRetForfunc(callee_func.name.clone())),
+        None => Err(InterpError::NonEmptyRetForfunc(callee_func.name.clone())),
         Some(t) => check_asmt_type(op_type, &t),
       }?;
       update_env(env, dest, op_type)
@@ -400,7 +400,7 @@ fn type_check_instruction<'a>(
         .try_for_each(|(arg_name, expected_arg)| {
           let ty = env
             .get(&arg_name as &str)
-            .ok_or_else(|| InterpError::VarNotFound(arg_name.to_string()))?;
+            .ok_or_else(|| InterpError::VarUndefined(arg_name.to_string()))?;
 
           check_asmt_type(ty, &expected_arg.arg_type)
         })?;

--- a/brilirs/src/error.rs
+++ b/brilirs/src/error.rs
@@ -1,0 +1,24 @@
+#[derive(Debug)]
+pub enum InterpError {
+  MemLeak,
+  UsingUninitializedMemory,
+  NoLastLabel,
+  NoMainFunction,
+  UnequalPhiNode, // Unequal number of args and labels
+  EmptyRetForfunc(String),
+  NonEmptyRetForfunc(String),
+  CannotAllocSize(i64),
+  IllegalFree(usize, i64),         // (base, offset)
+  InvalidMemoryAccess(usize, i64), // (base, offset)
+  BadNumFuncArgs(usize, usize),    // (expected, actual)
+  BadNumArgs(usize, usize),        // (expected, actual)
+  BadNumLabels(usize, usize),      // (expected, actual)
+  BadNumFuncs(usize, usize),       // (expected, actual)
+  FuncNotFound(String),
+  VarNotFound(String),
+  PhiMissingLabel(String),
+  ExpectedPointerType(bril_rs::Type),        // found type
+  BadFuncArgType(bril_rs::Type, String),     // (expected, actual)
+  BadAsmtType(bril_rs::Type, bril_rs::Type), // (expected, actual). For when the LHS type of an instruction is bad
+  IoError(Box<std::io::Error>),
+}

--- a/brilirs/src/error.rs
+++ b/brilirs/src/error.rs
@@ -1,3 +1,5 @@
+use std::fmt::{Display, Formatter};
+
 #[derive(Debug)]
 pub enum InterpError {
   MemLeak,
@@ -5,7 +7,7 @@ pub enum InterpError {
   NoLastLabel,
   NoMainFunction,
   UnequalPhiNode, // Unequal number of args and labels
-  EmptyRetForfunc(String),
+  DuplicateFunction,
   NonEmptyRetForfunc(String),
   CannotAllocSize(i64),
   IllegalFree(usize, i64),         // (base, offset)
@@ -15,10 +17,115 @@ pub enum InterpError {
   BadNumLabels(usize, usize),      // (expected, actual)
   BadNumFuncs(usize, usize),       // (expected, actual)
   FuncNotFound(String),
-  VarNotFound(String),
+  VarUndefined(String),
   PhiMissingLabel(String),
   ExpectedPointerType(bril_rs::Type),        // found type
   BadFuncArgType(bril_rs::Type, String),     // (expected, actual)
   BadAsmtType(bril_rs::Type, bril_rs::Type), // (expected, actual). For when the LHS type of an instruction is bad
   IoError(Box<std::io::Error>),
+}
+
+impl Display for InterpError {
+  fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    match self {
+      InterpError::MemLeak => {
+        write!(
+          f,
+          "error: Some memory locations have not been freed by the end of execution"
+        )
+      }
+      InterpError::UsingUninitializedMemory => {
+        write!(f, "error: Trying to load from uninitialized memory")
+      }
+      InterpError::NoLastLabel => {
+        write!(f, "error: phi node executed with no last label")
+      }
+      InterpError::NoMainFunction => {
+        write!(f, "error: no main function defined, doing nothing")
+      }
+      InterpError::UnequalPhiNode => {
+        write!(f, "error: pi node has unequal numbers of labels and args")
+      }
+      InterpError::DuplicateFunction => {
+        write!(f, "error: multiple functions of the same name found")
+      }
+      InterpError::NonEmptyRetForfunc(func) => {
+        write!(f, "error: Expected empty return for {}, found value", func)
+      }
+      InterpError::CannotAllocSize(amt) => {
+        write!(f, "error: cannot allocate {} entries", amt)
+      }
+      InterpError::IllegalFree(base, offset) => {
+        write!(
+          f,
+          "error: Tried to free illegal memory location base: {}, offset: {}. Offset must be 0.",
+          base, offset
+        )
+      }
+      InterpError::InvalidMemoryAccess(base, offset) => {
+        write!(
+          f,
+          "error: Uninitialized heap location {} and/or illegal offset {}",
+          base, offset
+        )
+      }
+      InterpError::BadNumFuncArgs(expected, actual) => {
+        write!(
+          f,
+          "error: Expected {} function arguments, found {}",
+          expected, actual
+        )
+      }
+      InterpError::BadNumArgs(expected, actual) => {
+        write!(
+          f,
+          "error: Expected {} instruction arguments, found {}",
+          expected, actual
+        )
+      }
+      InterpError::BadNumLabels(expected, actual) => {
+        write!(f, "error: Expected {} labels, found {}", expected, actual)
+      }
+      InterpError::BadNumFuncs(expected, actual) => {
+        write!(
+          f,
+          "error: Expected {} functions, found {}",
+          expected, actual
+        )
+      }
+      InterpError::FuncNotFound(func) => {
+        write!(f, "error: no function of name {} found", func)
+      }
+      InterpError::VarUndefined(v) => {
+        write!(f, "error: undefined variable {}", v)
+      }
+      InterpError::PhiMissingLabel(label) => {
+        write!(f, "error: Label {} for phi node not found", label)
+      }
+      InterpError::ExpectedPointerType(typ) => {
+        write!(f, "error: unspecified pointer type {:?}", typ)
+      }
+      InterpError::BadFuncArgType(expected, actual) => {
+        write!(
+          f,
+          "error: Expected type {:?} for function argument, found {:?}",
+          expected, actual
+        )
+      }
+      InterpError::BadAsmtType(expected, actual) => {
+        write!(
+          f,
+          "error: Expected type {:?} for assignment, found {:?}",
+          expected, actual
+        )
+      }
+      InterpError::IoError(err) => {
+        write!(
+          f,
+          "error: There has been an io error when trying to print: {:?}",
+          err
+        )
+      }
+    }
+  }
 }

--- a/brilirs/src/interp.rs
+++ b/brilirs/src/interp.rs
@@ -35,6 +35,7 @@ impl Environment {
   }
 }
 
+// todo: This is basically a copy of the heap implement in brili and we could probably do something smarter. This currently isn't that worth it to optimize because most benchmarks do not use the memory extension nor do they run for very long. You (the reader in the future) may be working with bril programs that you would like to speed up that extensively use the bril memory extension. In that case, it would be worth seeing how to implement Heap without a map based memory. Maybe try to re-implement malloc for a large Vec<Value>?
 struct Heap {
   memory: FxHashMap<usize, Vec<Value>>,
   base_num_counter: usize,
@@ -406,6 +407,7 @@ fn make_func_args<'a>(
   args: &[u32],
   vars: &Environment,
 ) -> Environment {
+  // todo: Having to allocate a new environment on each function call probably makes small function calls very heavy weight. This could be interesting to profile and see if old environments can be reused instead of being deallocated and reallocated. Maybe there is another way to sometimes avoid this allocation.
   let mut next_env = Environment::new(callee_func.num_of_vars);
 
   args

--- a/brilirs/src/interp.rs
+++ b/brilirs/src/interp.rs
@@ -25,6 +25,8 @@ impl Environment {
   }
   #[inline(always)]
   pub fn get(&self, ident: &u32) -> &Value {
+    // A bril program is well formed when, dynamically, every variable is defined before its use.
+    // If this is violated, this will return Value::Uninitialized and the whole interpreter will come crashing down.
     self.env.get(*ident as usize).unwrap()
   }
   #[inline(always)]

--- a/brilirs/src/lib.rs
+++ b/brilirs/src/lib.rs
@@ -1,29 +1,26 @@
 #![feature(or_patterns)]
 
+use error::InterpError;
+
 mod basic_block;
 mod check;
 mod error;
 mod interp;
 
 pub fn run_input<T: std::io::Write>(
-  input: Box<dyn std::io::Read>,
-  out: T,
-  input_args: Vec<&str>,
-  profiling: bool,
-  check: bool,
-) {
-  let prog = bril_rs::load_program_from_read(input);
-  let bbprog = basic_block::BBProgram::new(prog);
+    input: Box<dyn std::io::Read>,
+    out: T,
+    input_args: Vec<&str>,
+    profiling: bool,
+    check: bool,
+) -> Result<(), InterpError> {
+    let prog = bril_rs::load_program_from_read(input);
+    let bbprog = basic_block::BBProgram::new(prog)?;
+    check::type_check(&bbprog)?;
 
-  if let Err(e) = check::type_check(&bbprog) {
-    eprintln!("{:?}", e);
-    std::process::exit(2)
-  }
-
-  if !check {
-    if let Err(e) = interp::execute_main(bbprog, out, input_args, profiling) {
-      eprintln!("{:?}", e);
-      std::process::exit(2)
+    if !check {
+        interp::execute_main(bbprog, out, input_args, profiling)?;
     }
-  }
+
+    Ok(())
 }

--- a/brilirs/src/lib.rs
+++ b/brilirs/src/lib.rs
@@ -1,4 +1,8 @@
+#![feature(or_patterns)]
+
 mod basic_block;
+mod check;
+mod error;
 mod interp;
 
 pub fn run_input<T: std::io::Write>(
@@ -9,6 +13,11 @@ pub fn run_input<T: std::io::Write>(
 ) {
   let prog = bril_rs::load_program_from_read(input);
   let bbprog = basic_block::BBProgram::new(prog);
+
+  if let Err(e) = check::type_check(&bbprog) {
+    eprintln!("{:?}", e);
+    std::process::exit(2)
+  };
 
   if let Err(e) = interp::execute_main(bbprog, out, input_args, profiling) {
     eprintln!("{:?}", e);

--- a/brilirs/src/lib.rs
+++ b/brilirs/src/lib.rs
@@ -10,6 +10,7 @@ pub fn run_input<T: std::io::Write>(
   out: T,
   input_args: Vec<&str>,
   profiling: bool,
+  check: bool,
 ) {
   let prog = bril_rs::load_program_from_read(input);
   let bbprog = basic_block::BBProgram::new(prog);
@@ -17,10 +18,12 @@ pub fn run_input<T: std::io::Write>(
   if let Err(e) = check::type_check(&bbprog) {
     eprintln!("{:?}", e);
     std::process::exit(2)
-  };
+  }
 
-  if let Err(e) = interp::execute_main(bbprog, out, input_args, profiling) {
-    eprintln!("{:?}", e);
-    std::process::exit(2)
-  };
+  if !check {
+    if let Err(e) = interp::execute_main(bbprog, out, input_args, profiling) {
+      eprintln!("{:?}", e);
+      std::process::exit(2)
+    }
+  }
 }

--- a/brilirs/src/main.rs
+++ b/brilirs/src/main.rs
@@ -21,11 +21,14 @@ fn main() {
     Some(input_file) => Box::new(File::open(input_file).unwrap()),
   };
 
-  brilirs::run_input(
+  if let Err(e) = brilirs::run_input(
     input,
     std::io::stdout(),
     input_args,
     args.is_present("profiling"),
     args.is_present("check"),
-  )
+  ) {
+    eprintln!("{}", e);
+    std::process::exit(2)
+  }
 }

--- a/brilirs/src/main.rs
+++ b/brilirs/src/main.rs
@@ -8,7 +8,8 @@ fn main() {
     (about: "An interpreter for Bril")
     (@arg profiling: -p "Flag to output the total number of dynamic instructions")
     (@arg FILE: -f --file +takes_value "The Bril file to run. stdin is assumed if FILE is not provided")
-    (@arg args: ... "Arguments for the main function")
+    (@arg check: --check "Flag to only typeckeck/validate the bril program")
+    (@arg args: +allow_hyphen_values ... "Arguments for the main function")
   ).setting(AppSettings::AllowLeadingHyphen)
   .get_matches();
 
@@ -25,5 +26,6 @@ fn main() {
     std::io::stdout(),
     input_args,
     args.is_present("profiling"),
+    args.is_present("check"),
   )
 }

--- a/docs/tools/brilirs.md
+++ b/docs/tools/brilirs.md
@@ -19,6 +19,7 @@ Run a program by piping a JSON Bril program into it:
 
     bril2json < myprogram.bril | brilirs
 
+Similar to [type-infer](infer.md), `brilirs` can be used to typecheck and validate your Bril JSON program by passing the `--check` flag (similar to `cargo --check`).
 
 [rust]: https://www.rust-lang.org
 [ssa]: ../lang/ssa.md

--- a/docs/tools/brilirs.md
+++ b/docs/tools/brilirs.md
@@ -7,13 +7,18 @@ It implements [core Bril](../lang/core.md) and the [SSA][], [memory][], and [flo
 
 Read [more about the implementation][blog], which is originally by Wil Thomason and Daniel Glus.
 
-Like any other Rust project, building is easy:
+Install
+-------
+To use `brilirs` you will need to [install Rust](https://www.rust-lang.org/tools/install) and add the nightly channel with `rustup toolchain install nightly`. Use `echo $PATH` to check that `$HOME/.cargo/bin` is on your [path](https://unix.stackexchange.com/a/26059/61192).
 
-    cargo build
+In the `brilirs` directory, build the interpreter with:
+
+    cargo +nightly install --path .
 
 Run a program by piping a JSON Bril program into it:
 
-    bril2json < myprogram.bril | cargo run
+    bril2json < myprogram.bril | brilirs
+
 
 [rust]: https://www.rust-lang.org
 [ssa]: ../lang/ssa.md

--- a/test/fail/turnt_brilirs.toml
+++ b/test/fail/turnt_brilirs.toml
@@ -1,2 +1,2 @@
-command = "bril2json < {filename} | cargo run --manifest-path ../../brilirs/Cargo.toml -- {args}"
+command = "bril2json < {filename} | cargo +nightly run --manifest-path ../../brilirs/Cargo.toml -- {args}"
 return_code = 2

--- a/test/interp-error/turnt_brilirs.toml
+++ b/test/interp-error/turnt_brilirs.toml
@@ -1,3 +1,3 @@
-command = "bril2json < {filename} | cargo run --manifest-path ../../brilirs/Cargo.toml -- {args}"
+command = "bril2json < {filename} | cargo +nightly run --manifest-path ../../brilirs/Cargo.toml -- {args}"
 return_code = 2
 output.err = "2"

--- a/test/interp/turnt_brilirs.toml
+++ b/test/interp/turnt_brilirs.toml
@@ -1,1 +1,1 @@
-command = "bril2json < {filename} | cargo run --manifest-path ../../brilirs/Cargo.toml -- {args}"
+command = "bril2json < {filename} | cargo +nightly run --manifest-path ../../brilirs/Cargo.toml -- {args}"

--- a/test/mem/turnt_brilirs.toml
+++ b/test/mem/turnt_brilirs.toml
@@ -1,1 +1,1 @@
-command = "bril2json < {filename} | cargo run --manifest-path ../../brilirs/Cargo.toml -- {args}"
+command = "bril2json < {filename} | cargo +nightly run --manifest-path ../../brilirs/Cargo.toml -- {args}"


### PR DESCRIPTION
This pr does some of the low hanging fruit to bring `brilirs` to about 7.5x-11x faster than `brili`. Dependent on #117.

All but three benchmarks do not run for long enough to be accurately reported by `hyperfine` (`hyperfine` reports ~5ms for all of them with `brilirs`, about ~40-60ms when running with `brili`).

```sh
make release
./long_benchmark.sh 
```

| Benchmark | `brili` | `brilirs` | Speedup |
| ----------- | ------ | -------- | ---------|
| ackermann | 555ms ±44ms | 68.9ms ± 2.5ms | ~8 ± .7 |
| eight-queens | 511ms ±66ms | 46.5 ms ± 9.2ms | ~11 ± 2.5 |
| mat-mul | 876ms ± 84ms | 82.9ms ±11 ms | ~10.5 ± 2 |

This isn't attempting to be a rigorous benchmarking of `brili` vs `brilirs` but to more so show a significant improvement in the performance of `brilirs`(which started at ~1x-1.5x over `brili` on these benchmarks ).

Two of the most significant optimizations are a drastic reduction in the amount of `clone()`/`String::from()` calls and switching from `Hashmap` to `FxHashMap` with an initialized capacity. 

Other optimizations relate to the release profile in `cargo.toml`, switching to the MiMalloc allocator and annotating many of the functions with `#[inline(always)]`.

Typechecking has been pulled out and is now done first before executing `main` for a small, but noticeable performance increase. It should now also do a mostly complete validation of the bril code.

I made attempts to use async code, the smallvec crate, unsafe argument indexing, and program parallelism but there was no immediate improvement. 

`brilirs` now uses nightly rust for or patterns in match statements and a slight performance increase.