### PR TITLE
Brilirs stable

### DIFF
--- a/benchmarks/turnt_brilirs.toml
+++ b/benchmarks/turnt_brilirs.toml
@@ -1,3 +1,3 @@
-command = "bril2json < {filename} | cargo +nightly run --manifest-path ../brilirs/Cargo.toml --quiet -- -p {args}"
+command = "bril2json < {filename} | cargo run --manifest-path ../brilirs/Cargo.toml --quiet -- -p {args}"
 output.out = "-"
 output.prof = "2"

--- a/brilirs/Makefile
+++ b/brilirs/Makefile
@@ -14,7 +14,7 @@ benchmark:
 
 .PHONY: release
 release:
-	RUSTFLAGS="-C target-cpu=native" cargo +nightly build --release
+	RUSTFLAGS="-C target-cpu=native" cargo build --release
 
 .PHONY: compare
 compare: release
@@ -26,4 +26,4 @@ compare: release
 # This is primarily used for running examples and debuging a bril program
 .PHONY: example
 example:
-	bril2json < ../benchmarks/sqrt.bril | cargo +nightly run
+	bril2json < ../benchmarks/sqrt.bril | cargo run

--- a/brilirs/src/lib.rs
+++ b/brilirs/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(or_patterns)]
-
 use error::InterpError;
 
 mod basic_block;

--- a/docs/tools/brilirs.md
+++ b/docs/tools/brilirs.md
@@ -2,18 +2,18 @@ Fast Interpreter in Rust
 ========================
 
 The `brilirs` directory contains a fast Bril interpreter written in [Rust][].
-It is a drop-in replacement for the [reference interpreter](interp.md) that prioritizes speed over completeness and hacakability.
+It is a drop-in replacement for the [reference interpreter](interp.md) that prioritizes speed over completeness and hackability.
 It implements [core Bril](../lang/core.md) and the [SSA][], [memory][], and [floating point][float] extensions.
 
 Read [more about the implementation][blog], which is originally by Wil Thomason and Daniel Glus.
 
 Install
 -------
-To use `brilirs` you will need to [install Rust](https://www.rust-lang.org/tools/install) and add the nightly channel with `rustup toolchain install nightly`. Use `echo $PATH` to check that `$HOME/.cargo/bin` is on your [path](https://unix.stackexchange.com/a/26059/61192).
+To use `brilirs` you will need to [install Rust](https://www.rust-lang.org/tools/install). Use `echo $PATH` to check that `$HOME/.cargo/bin` is on your [path](https://unix.stackexchange.com/a/26059/61192).
 
 In the `brilirs` directory, build the interpreter with:
 
-    cargo +nightly install --path .
+    cargo install --path .
 
 Run a program by piping a JSON Bril program into it:
 

--- a/test/fail/turnt_brilirs.toml
+++ b/test/fail/turnt_brilirs.toml
@@ -1,2 +1,2 @@
-command = "bril2json < {filename} | cargo +nightly run --manifest-path ../../brilirs/Cargo.toml -- {args}"
+command = "bril2json < {filename} | cargo run --manifest-path ../../brilirs/Cargo.toml -- {args}"
 return_code = 2

--- a/test/interp-error/turnt_brilirs.toml
+++ b/test/interp-error/turnt_brilirs.toml
@@ -1,3 +1,3 @@
-command = "bril2json < {filename} | cargo +nightly run --manifest-path ../../brilirs/Cargo.toml -- {args}"
+command = "bril2json < {filename} | cargo run --manifest-path ../../brilirs/Cargo.toml -- {args}"
 return_code = 2
 output.err = "2"

--- a/test/interp/turnt_brilirs.toml
+++ b/test/interp/turnt_brilirs.toml
@@ -1,1 +1,1 @@
-command = "bril2json < {filename} | cargo +nightly run --manifest-path ../../brilirs/Cargo.toml -- {args}"
+command = "bril2json < {filename} | cargo run --manifest-path ../../brilirs/Cargo.toml -- {args}"

--- a/test/mem/turnt_brilirs.toml
+++ b/test/mem/turnt_brilirs.toml
@@ -1,1 +1,1 @@
-command = "bril2json < {filename} | cargo +nightly run --manifest-path ../../brilirs/Cargo.toml -- {args}"
+command = "bril2json < {filename} | cargo run --manifest-path ../../brilirs/Cargo.toml -- {args}"


### PR DESCRIPTION
With Rust 1.51, `#![feature(or_patterns)]` should be stablized. This pr moves `brilirs` back on to the stable channel. This pr is dependent of #122.

See https://forge.rust-lang.org/ for the rust release schedule. The current date is March 25th.