### PR TITLE
implement Display for rust types

### DIFF
--- a/bril-rs/.gitignore
+++ b/bril-rs/.gitignore
@@ -1,2 +1,3 @@
 **/target
 Cargo.lock
+.idea/**

--- a/bril-rs/Cargo.toml
+++ b/bril-rs/Cargo.toml
@@ -10,6 +10,10 @@ edition = "2018"
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 
+[dev-dependencies]
+# trick to enable all features in test
+bril-rs = { path = ".", features = ["memory", "float", "ssa", "speculate"] }
+
 [features]
 float = []
 memory = []


### PR DESCRIPTION
this adds a default `Display` implementation for the rust types formatting bril code in the text representation.

not sure if this is desired/helpful, but I find myself wanting to print something readable to the console again and again :)