### PR TITLE
bril2txt with Rust!

### DIFF
--- a/bril-rs/Cargo.toml
+++ b/bril-rs/Cargo.toml
@@ -10,12 +10,23 @@ edition = "2018"
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 
-[dev-dependencies]
-# trick to enable all features in test
-bril-rs = { path = ".", features = ["memory", "float", "ssa", "speculate"] }
-
 [features]
 float = []
 memory = []
 ssa = []
 speculate = []
+
+[[example]]
+name = "bril2txt"
+path = "examples/bril2txt.rs"
+# I would like these features to be included by default using `features = ["memory", "float", "ssa", "speculate"]`
+# However this currently does not work as expected and is being hashed out in https://github.com/rust-lang/rfcs/pull/3020 and https://github.com/rust-lang/rfcs/pull/2887
+# Until a solution is reached, I'm using `required-features` so that these features must be passed by flag. This is less ergonomic at the moment, however the user will get a nicer error that they need a feature flag instead of an Result::unwrap() error.
+# Note: See dev-dependencies for a hack to not need the user to pass that feature flag.
+required-features = ["memory", "float", "ssa", "speculate"]
+
+[dev-dependencies]
+# trick to enable all features in test
+# This is actually really hacky because it is used in all tests/examples/benchmarks but since we currently only have one example this works for enabling the following feature flags for our users.
+# If the above rfcs every get resolved, then dev-dependencies will no longer be needed.
+bril-rs = { path = ".", features = ["memory", "float", "ssa", "speculate"] }

--- a/bril-rs/Makefile
+++ b/bril-rs/Makefile
@@ -1,0 +1,5 @@
+TESTS :=  ../test/print/*.json
+
+.PHONY: test
+test:
+	turnt --diff -c turnt_brilrs.toml $(TESTS)

--- a/bril-rs/examples/bril2txt.rs
+++ b/bril-rs/examples/bril2txt.rs
@@ -1,0 +1,5 @@
+use bril_rs::load_program;
+
+fn main() {
+    print!("{}", load_program());
+}

--- a/docs/tools/rust.md
+++ b/docs/tools/rust.md
@@ -19,6 +19,11 @@ Each of the extensions to [Bril core][core] is feature gated. To ignore an exten
 
 There are two helper functions, `load_program`, which will read a valid Bril program from stdin, and `output_program` which writes your Bril program to stdout. Otherwise, this library can be treated like any other [serde][] JSON representation.
 
+Examples
+---
+
+There is currently a very trivial example that uses this interface to create a rust implementation of `bril2txt`. Run it with `cargo run --example bril2txt`.
+
 Development
 -----------
 

--- a/test/print/eight-queens.bril
+++ b/test/print/eight-queens.bril
@@ -1,0 +1,69 @@
+@main(input: int) {
+  n: int = id input;
+  zero: int = const 0;
+  icount: int = id zero;
+  site: ptr<int> = alloc n;
+  result: int = call @queen zero n icount site;
+  print result;
+  free site;
+}
+@queen(n: int, queens: int, icount: int, site: ptr<int>): int {
+  one: int = const 1;
+  ite: int = id one;
+  ret_cond: bool = eq n queens;
+  br ret_cond .next.ret .for.cond;
+.next.ret:
+  icount: int = add icount one;
+  ret icount;
+.for.cond:
+  for_cond_0: bool = le ite queens;
+  br for_cond_0 .for.body .next.ret.1;
+.for.body:
+  nptr: ptr<int> = ptradd site n;
+  store nptr ite;
+  is_valid: bool = call @valid n site;
+  br is_valid .rec.func .next.loop;
+.rec.func:
+  n_1: int = add n one;
+  icount: int = call @queen n_1 queens icount site;
+.next.loop:
+  ite: int = add ite one;
+  jmp .for.cond;
+.next.ret.1:
+  ret icount;
+}
+@valid(n: int, site: ptr<int>): bool {
+  zero: int = const 0;
+  one: int = const 1;
+  true: bool = eq one one;
+  false: bool = eq zero one;
+  ite: int = id zero;
+.for.cond:
+  for_cond: bool = lt ite n;
+  br for_cond .for.body .ret.end;
+.for.body:
+  iptr: ptr<int> = ptradd site ite;
+  nptr: ptr<int> = ptradd site n;
+  help_0: int = const 500;
+  vali: int = load iptr;
+  valn: int = load nptr;
+  eq_cond_0: bool = eq vali valn;
+  br eq_cond_0 .true.ret.0 .false.else;
+.true.ret.0:
+  ret false;
+.false.else:
+  sub_0: int = sub vali valn;
+  sub_1: int = sub valn vali;
+  sub_2: int = sub n ite;
+  eq_cond_1: bool = eq sub_0 sub_2;
+  eq_cond_2: bool = eq sub_1 sub_2;
+  eq_cond_12: bool = or eq_cond_1 eq_cond_2;
+  br eq_cond_12 .true.ret.1 .false.loop;
+.true.ret.1:
+  ret false;
+.false.loop:
+  ite: int = add ite one;
+  jmp .for.cond;
+.ret.end:
+  ret true;
+}

--- a/test/print/eight-queens.json
+++ b/test/print/eight-queens.json
@@ -1,0 +1,524 @@
+{
+  "functions": [
+    {
+      "args": [
+        {
+          "name": "input",
+          "type": "int"
+        }
+      ],
+      "instrs": [
+        {
+          "args": [
+            "input"
+          ],
+          "dest": "n",
+          "op": "id",
+          "type": "int"
+        },
+        {
+          "dest": "zero",
+          "op": "const",
+          "type": "int",
+          "value": 0
+        },
+        {
+          "args": [
+            "zero"
+          ],
+          "dest": "icount",
+          "op": "id",
+          "type": "int"
+        },
+        {
+          "args": [
+            "n"
+          ],
+          "dest": "site",
+          "op": "alloc",
+          "type": {
+            "ptr": "int"
+          }
+        },
+        {
+          "args": [
+            "zero",
+            "n",
+            "icount",
+            "site"
+          ],
+          "dest": "result",
+          "funcs": [
+            "queen"
+          ],
+          "op": "call",
+          "type": "int"
+        },
+        {
+          "args": [
+            "result"
+          ],
+          "op": "print"
+        },
+        {
+          "args": [
+            "site"
+          ],
+          "op": "free"
+        }
+      ],
+      "name": "main"
+    },
+    {
+      "args": [
+        {
+          "name": "n",
+          "type": "int"
+        },
+        {
+          "name": "queens",
+          "type": "int"
+        },
+        {
+          "name": "icount",
+          "type": "int"
+        },
+        {
+          "name": "site",
+          "type": {
+            "ptr": "int"
+          }
+        }
+      ],
+      "instrs": [
+        {
+          "dest": "one",
+          "op": "const",
+          "type": "int",
+          "value": 1
+        },
+        {
+          "args": [
+            "one"
+          ],
+          "dest": "ite",
+          "op": "id",
+          "type": "int"
+        },
+        {
+          "args": [
+            "n",
+            "queens"
+          ],
+          "dest": "ret_cond",
+          "op": "eq",
+          "type": "bool"
+        },
+        {
+          "args": [
+            "ret_cond"
+          ],
+          "labels": [
+            "next.ret",
+            "for.cond"
+          ],
+          "op": "br"
+        },
+        {
+          "label": "next.ret"
+        },
+        {
+          "args": [
+            "icount",
+            "one"
+          ],
+          "dest": "icount",
+          "op": "add",
+          "type": "int"
+        },
+        {
+          "args": [
+            "icount"
+          ],
+          "op": "ret"
+        },
+        {
+          "label": "for.cond"
+        },
+        {
+          "args": [
+            "ite",
+            "queens"
+          ],
+          "dest": "for_cond_0",
+          "op": "le",
+          "type": "bool"
+        },
+        {
+          "args": [
+            "for_cond_0"
+          ],
+          "labels": [
+            "for.body",
+            "next.ret.1"
+          ],
+          "op": "br"
+        },
+        {
+          "label": "for.body"
+        },
+        {
+          "args": [
+            "site",
+            "n"
+          ],
+          "dest": "nptr",
+          "op": "ptradd",
+          "type": {
+            "ptr": "int"
+          }
+        },
+        {
+          "args": [
+            "nptr",
+            "ite"
+          ],
+          "op": "store"
+        },
+        {
+          "args": [
+            "n",
+            "site"
+          ],
+          "dest": "is_valid",
+          "funcs": [
+            "valid"
+          ],
+          "op": "call",
+          "type": "bool"
+        },
+        {
+          "args": [
+            "is_valid"
+          ],
+          "labels": [
+            "rec.func",
+            "next.loop"
+          ],
+          "op": "br"
+        },
+        {
+          "label": "rec.func"
+        },
+        {
+          "args": [
+            "n",
+            "one"
+          ],
+          "dest": "n_1",
+          "op": "add",
+          "type": "int"
+        },
+        {
+          "args": [
+            "n_1",
+            "queens",
+            "icount",
+            "site"
+          ],
+          "dest": "icount",
+          "funcs": [
+            "queen"
+          ],
+          "op": "call",
+          "type": "int"
+        },
+        {
+          "label": "next.loop"
+        },
+        {
+          "args": [
+            "ite",
+            "one"
+          ],
+          "dest": "ite",
+          "op": "add",
+          "type": "int"
+        },
+        {
+          "labels": [
+            "for.cond"
+          ],
+          "op": "jmp"
+        },
+        {
+          "label": "next.ret.1"
+        },
+        {
+          "args": [
+            "icount"
+          ],
+          "op": "ret"
+        }
+      ],
+      "name": "queen",
+      "type": "int"
+    },
+    {
+      "args": [
+        {
+          "name": "n",
+          "type": "int"
+        },
+        {
+          "name": "site",
+          "type": {
+            "ptr": "int"
+          }
+        }
+      ],
+      "instrs": [
+        {
+          "dest": "zero",
+          "op": "const",
+          "type": "int",
+          "value": 0
+        },
+        {
+          "dest": "one",
+          "op": "const",
+          "type": "int",
+          "value": 1
+        },
+        {
+          "args": [
+            "one",
+            "one"
+          ],
+          "dest": "true",
+          "op": "eq",
+          "type": "bool"
+        },
+        {
+          "args": [
+            "zero",
+            "one"
+          ],
+          "dest": "false",
+          "op": "eq",
+          "type": "bool"
+        },
+        {
+          "args": [
+            "zero"
+          ],
+          "dest": "ite",
+          "op": "id",
+          "type": "int"
+        },
+        {
+          "label": "for.cond"
+        },
+        {
+          "args": [
+            "ite",
+            "n"
+          ],
+          "dest": "for_cond",
+          "op": "lt",
+          "type": "bool"
+        },
+        {
+          "args": [
+            "for_cond"
+          ],
+          "labels": [
+            "for.body",
+            "ret.end"
+          ],
+          "op": "br"
+        },
+        {
+          "label": "for.body"
+        },
+        {
+          "args": [
+            "site",
+            "ite"
+          ],
+          "dest": "iptr",
+          "op": "ptradd",
+          "type": {
+            "ptr": "int"
+          }
+        },
+        {
+          "args": [
+            "site",
+            "n"
+          ],
+          "dest": "nptr",
+          "op": "ptradd",
+          "type": {
+            "ptr": "int"
+          }
+        },
+        {
+          "dest": "help_0",
+          "op": "const",
+          "type": "int",
+          "value": 500
+        },
+        {
+          "args": [
+            "iptr"
+          ],
+          "dest": "vali",
+          "op": "load",
+          "type": "int"
+        },
+        {
+          "args": [
+            "nptr"
+          ],
+          "dest": "valn",
+          "op": "load",
+          "type": "int"
+        },
+        {
+          "args": [
+            "vali",
+            "valn"
+          ],
+          "dest": "eq_cond_0",
+          "op": "eq",
+          "type": "bool"
+        },
+        {
+          "args": [
+            "eq_cond_0"
+          ],
+          "labels": [
+            "true.ret.0",
+            "false.else"
+          ],
+          "op": "br"
+        },
+        {
+          "label": "true.ret.0"
+        },
+        {
+          "args": [
+            "false"
+          ],
+          "op": "ret"
+        },
+        {
+          "label": "false.else"
+        },
+        {
+          "args": [
+            "vali",
+            "valn"
+          ],
+          "dest": "sub_0",
+          "op": "sub",
+          "type": "int"
+        },
+        {
+          "args": [
+            "valn",
+            "vali"
+          ],
+          "dest": "sub_1",
+          "op": "sub",
+          "type": "int"
+        },
+        {
+          "args": [
+            "n",
+            "ite"
+          ],
+          "dest": "sub_2",
+          "op": "sub",
+          "type": "int"
+        },
+        {
+          "args": [
+            "sub_0",
+            "sub_2"
+          ],
+          "dest": "eq_cond_1",
+          "op": "eq",
+          "type": "bool"
+        },
+        {
+          "args": [
+            "sub_1",
+            "sub_2"
+          ],
+          "dest": "eq_cond_2",
+          "op": "eq",
+          "type": "bool"
+        },
+        {
+          "args": [
+            "eq_cond_1",
+            "eq_cond_2"
+          ],
+          "dest": "eq_cond_12",
+          "op": "or",
+          "type": "bool"
+        },
+        {
+          "args": [
+            "eq_cond_12"
+          ],
+          "labels": [
+            "true.ret.1",
+            "false.loop"
+          ],
+          "op": "br"
+        },
+        {
+          "label": "true.ret.1"
+        },
+        {
+          "args": [
+            "false"
+          ],
+          "op": "ret"
+        },
+        {
+          "label": "false.loop"
+        },
+        {
+          "args": [
+            "ite",
+            "one"
+          ],
+          "dest": "ite",
+          "op": "add",
+          "type": "int"
+        },
+        {
+          "labels": [
+            "for.cond"
+          ],
+          "op": "jmp"
+        },
+        {
+          "label": "ret.end"
+        },
+        {
+          "args": [
+            "true"
+          ],
+          "op": "ret"
+        }
+      ],
+      "name": "valid",
+      "type": "bool"
+    }
+  ]
+}

--- a/test/print/spec-abort.bril
+++ b/test/print/spec-abort.bril
@@ -1,0 +1,13 @@
+@main {
+  v: int = const 4;
+  speculate;
+  v: int = const 2;
+  b: bool = const false;
+  guard b .failed;
+  commit;
+  print v;
+  ret;
+.failed:
+  y: int = const 0;
+  print y;
+}

--- a/test/print/spec-abort.json
+++ b/test/print/spec-abort.json
@@ -1,0 +1,66 @@
+{
+  "functions": [
+    {
+      "instrs": [
+        {
+          "dest": "v",
+          "op": "const",
+          "type": "int",
+          "value": 4
+        },
+        {
+          "op": "speculate"
+        },
+        {
+          "dest": "v",
+          "op": "const",
+          "type": "int",
+          "value": 2
+        },
+        {
+          "dest": "b",
+          "op": "const",
+          "type": "bool",
+          "value": false
+        },
+        {
+          "args": [
+            "b"
+          ],
+          "labels": [
+            "failed"
+          ],
+          "op": "guard"
+        },
+        {
+          "op": "commit"
+        },
+        {
+          "args": [
+            "v"
+          ],
+          "op": "print"
+        },
+        {
+          "op": "ret"
+        },
+        {
+          "label": "failed"
+        },
+        {
+          "dest": "y",
+          "op": "const",
+          "type": "int",
+          "value": 0
+        },
+        {
+          "args": [
+            "y"
+          ],
+          "op": "print"
+        }
+      ],
+      "name": "main"
+    }
+  ]
+}

--- a/test/print/turnt_brilrs.toml
+++ b/test/print/turnt_brilrs.toml
@@ -1,0 +1,2 @@
+command = "cargo run --example bril2txt --manifest-path ../../bril-rs/Cargo.toml < {filename}"
+output.bril = "-"


### PR DESCRIPTION
This builds upon #127 to create an example for `bril-rs` that trivially implements `bril2txt`. This allows the `Display` trait to be compared against the text version of a Bril program using turnt. Through this, I found two inconsistencies between the `Display` trait and `bril2txt` which have been fixed.

I have removed the original testing in favor of turnt + `make test`. This seemed a lot easier than managing two testing systems, the idomatic rust testing framework and the turnt framework.

Two more tests have been added to cover more features of `bril2txt`.