### PR TITLE
[bril-ocaml] Update documentation RE ocamlformat & `-k path`

### DIFF
--- a/docs/tools/ocaml.md
+++ b/docs/tools/ocaml.md
@@ -9,22 +9,33 @@ Install
 To build the library, you first need to [install OCaml][inst].
 Then, install the dependencies with `opam install core yojson`.
 
+To install the bril-ocaml library:
+
+```bash
+git clone https://github.com/sampsyo/bril path/to/my/bril
+opam pin add -k path bril path/to/brill/bril-ocaml
+opam install bril
+```
+
+Thats it! Now, you can then include it in your [Dune][] files as `bril`, like any other ocaml library!
+
 Use
 ---
-
-You can include the library by running:
-
-    opam pin add bril https://github.com/sampsyo/bril/tree/master/bril-ocaml
-
-You can then include it in your [Dune][] files as `bril`, like any other library!
 
 The interface for the library can be found in `bril.mli`—good starting points are `from_string`, `from_file`, and `to_string`.
 A small code example for the library lives in the `count` subdirectory.
 
+If you wish to make changes to the bril OCaml library, simply hack on the git clone.
+
+When you are done, simply reinstall the package with `opam reinstall bril`. Restart the build of your
+local project to pick up changes made to bril-ocaml.
+
 For Development
 ---------------
 
-[ocamlformat][] is recommended for style consistency.
+[ocamlformat][ocamlformat] is recommended for style consistency. The
+[dune documentation on Automatic Formatting](https://dune.readthedocs.io/en/stable/formatting.html)
+has information about using ocamlformat with dune.
 
 [ocamlformat]: https://github.com/ocaml-ppx/ocamlformat
 [inst]: https://ocaml.org/docs/install.html


### PR DESCRIPTION
opam no longer supports installing from a subpath of a git repo.
Using pin add `-k path` is a suitable workaround

I tested the instlattion command on opam 2.0.7 on a M1 mac with ocaml 4.10.2