### PR TITLE
Bril-rs/Brilirs clippy warnings

### DIFF
--- a/benchmarks/turnt_brilirs.toml
+++ b/benchmarks/turnt_brilirs.toml
@@ -1,3 +1,3 @@
-command = "bril2json < {filename} | cargo +nightly run --manifest-path ../brilirs/Cargo.toml --quiet -- -p {args}"
+command = "bril2json < {filename} | cargo run --manifest-path ../brilirs/Cargo.toml --quiet -- -p {args}"
 output.out = "-"
 output.prof = "2"

--- a/bril-rs/src/lib.rs
+++ b/bril-rs/src/lib.rs
@@ -1,3 +1,10 @@
+#![warn(clippy::all, clippy::pedantic, clippy::nursery, clippy::cargo)]
+// todo these are allowed to appease clippy but should be addressed some day
+#![allow(clippy::missing_errors_doc)]
+#![allow(clippy::missing_panics_doc)]
+#![allow(clippy::must_use_candidate)]
+#![allow(clippy::cargo_common_metadata)]
+
 use std::fmt::{self, Display, Formatter};
 use std::io::{self, Write};
 
@@ -10,7 +17,7 @@ pub struct Program {
 
 impl Display for Program {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        for func in self.functions.iter() {
+        for func in &self.functions {
             writeln!(f, "{}", func)?;
         }
         Ok(())
@@ -46,7 +53,7 @@ impl Display for Function {
             write!(f, ": {}", tpe)?;
         }
         writeln!(f, " {{")?;
-        for instr in self.instrs.iter() {
+        for instr in &self.instrs {
             writeln!(f, "{}", instr)?;
         }
         write!(f, "}}")?;
@@ -331,7 +338,7 @@ pub enum Type {
     Float,
     #[cfg(feature = "memory")]
     #[serde(rename = "ptr")]
-    Pointer(Box<Type>),
+    Pointer(Box<Self>),
 }
 
 impl Display for Type {
@@ -368,7 +375,7 @@ impl Display for Literal {
 }
 
 impl Literal {
-    pub fn get_type(&self) -> Type {
+    pub const fn get_type(&self) -> Type {
         match self {
             Literal::Int(_) => Type::Int,
             Literal::Bool(_) => Type::Bool,

--- a/brilirs/Makefile
+++ b/brilirs/Makefile
@@ -14,7 +14,7 @@ benchmark:
 
 .PHONY: release
 release:
-	RUSTFLAGS="-C target-cpu=native" cargo +nightly build --release
+	RUSTFLAGS="-C target-cpu=native" cargo build --release
 
 .PHONY: compare
 compare: release
@@ -26,4 +26,4 @@ compare: release
 # This is primarily used for running examples and debuging a bril program
 .PHONY: example
 example:
-	bril2json < ../benchmarks/sqrt.bril | cargo +nightly run
+	bril2json < ../benchmarks/sqrt.bril | cargo run

--- a/brilirs/src/basic_block.rs
+++ b/brilirs/src/basic_block.rs
@@ -11,9 +11,9 @@ pub struct BBProgram {
 }
 
 impl BBProgram {
-  pub fn new(prog: Program) -> Result<BBProgram, InterpError> {
+  pub fn new(prog: Program) -> Result<Self, InterpError> {
     let num_funcs = prog.functions.len();
-    let bb = BBProgram {
+    let bb = Self {
       func_index: prog
         .functions
         .into_iter()
@@ -44,8 +44,8 @@ pub struct BasicBlock {
 }
 
 impl BasicBlock {
-  fn new() -> BasicBlock {
-    BasicBlock {
+  const fn new() -> Self {
+    Self {
       label: None,
       instrs: Vec::new(),
       numified_instrs: Vec::new(),
@@ -83,18 +83,18 @@ impl NumifiedInstruction {
     num_var_map: &mut FxHashMap<String, u32>,
   ) -> Self {
     match instr {
-      Instruction::Constant { dest, .. } => NumifiedInstruction {
+      Instruction::Constant { dest, .. } => Self {
         dest: Some(get_num_from_map(dest, num_of_vars, num_var_map)),
         args: Vec::new(),
       },
-      Instruction::Value { dest, args, .. } => NumifiedInstruction {
+      Instruction::Value { dest, args, .. } => Self {
         dest: Some(get_num_from_map(dest, num_of_vars, num_var_map)),
         args: args
           .iter()
           .map(|v| get_num_from_map(v, num_of_vars, num_var_map))
           .collect(),
       },
-      Instruction::Effect { args, .. } => NumifiedInstruction {
+      Instruction::Effect { args, .. } => Self {
         dest: None,
         args: args
           .iter()
@@ -119,13 +119,13 @@ pub struct BBFunction {
 }
 
 impl BBFunction {
-  pub fn new(f: Function) -> BBFunction {
-    let (mut func, label_map) = BBFunction::find_basic_blocks(f);
+  pub fn new(f: Function) -> Self {
+    let (mut func, label_map) = Self::find_basic_blocks(f);
     func.build_cfg(label_map);
     func
   }
 
-  fn find_basic_blocks(func: bril_rs::Function) -> (BBFunction, FxHashMap<String, usize>) {
+  fn find_basic_blocks(func: bril_rs::Function) -> (Self, FxHashMap<String, usize>) {
     let mut blocks = Vec::new();
     let mut label_map = FxHashMap::default();
 
@@ -197,7 +197,7 @@ impl BBFunction {
     }
 
     (
-      BBFunction {
+      Self {
         name: func.name,
         args: func.args,
         return_type: func.return_type,

--- a/brilirs/src/lib.rs
+++ b/brilirs/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(or_patterns)]
-
 use error::InterpError;
 
 mod basic_block;

--- a/brilirs/src/lib.rs
+++ b/brilirs/src/lib.rs
@@ -1,3 +1,10 @@
+// The group clippy::pedantic is not used as it ends up being more annoying than useful
+#![warn(clippy::all, clippy::nursery, clippy::cargo)]
+// todo these are allowed to appease clippy but should be addressed some day
+#![allow(clippy::missing_errors_doc)]
+#![allow(clippy::cargo_common_metadata)]
+#![allow(clippy::too_many_arguments)]
+
 use error::InterpError;
 
 mod basic_block;
@@ -6,19 +13,19 @@ mod error;
 mod interp;
 
 pub fn run_input<T: std::io::Write>(
-    input: Box<dyn std::io::Read>,
-    out: T,
-    input_args: Vec<&str>,
-    profiling: bool,
-    check: bool,
+  input: Box<dyn std::io::Read>,
+  out: T,
+  input_args: Vec<&str>,
+  profiling: bool,
+  check: bool,
 ) -> Result<(), InterpError> {
-    let prog = bril_rs::load_program_from_read(input);
-    let bbprog = basic_block::BBProgram::new(prog)?;
-    check::type_check(&bbprog)?;
+  let prog = bril_rs::load_program_from_read(input);
+  let bbprog = basic_block::BBProgram::new(prog)?;
+  check::type_check(&bbprog)?;
 
-    if !check {
-        interp::execute_main(bbprog, out, input_args, profiling)?;
-    }
+  if !check {
+    interp::execute_main(&bbprog, out, &input_args, profiling)?;
+  }
 
-    Ok(())
+  Ok(())
 }

--- a/docs/tools/brilirs.md
+++ b/docs/tools/brilirs.md
@@ -2,18 +2,18 @@ Fast Interpreter in Rust
 ========================
 
 The `brilirs` directory contains a fast Bril interpreter written in [Rust][].
-It is a drop-in replacement for the [reference interpreter](interp.md) that prioritizes speed over completeness and hacakability.
+It is a drop-in replacement for the [reference interpreter](interp.md) that prioritizes speed over completeness and hackability.
 It implements [core Bril](../lang/core.md) and the [SSA][], [memory][], and [floating point][float] extensions.
 
 Read [more about the implementation][blog], which is originally by Wil Thomason and Daniel Glus.
 
 Install
 -------
-To use `brilirs` you will need to [install Rust](https://www.rust-lang.org/tools/install) and add the nightly channel with `rustup toolchain install nightly`. Use `echo $PATH` to check that `$HOME/.cargo/bin` is on your [path](https://unix.stackexchange.com/a/26059/61192).
+To use `brilirs` you will need to [install Rust](https://www.rust-lang.org/tools/install). Use `echo $PATH` to check that `$HOME/.cargo/bin` is on your [path](https://unix.stackexchange.com/a/26059/61192).
 
 In the `brilirs` directory, build the interpreter with:
 
-    cargo +nightly install --path .
+    cargo install --path .
 
 Run a program by piping a JSON Bril program into it:
 

--- a/test/fail/turnt_brilirs.toml
+++ b/test/fail/turnt_brilirs.toml
@@ -1,2 +1,2 @@
-command = "bril2json < {filename} | cargo +nightly run --manifest-path ../../brilirs/Cargo.toml -- {args}"
+command = "bril2json < {filename} | cargo run --manifest-path ../../brilirs/Cargo.toml -- {args}"
 return_code = 2

--- a/test/interp-error/turnt_brilirs.toml
+++ b/test/interp-error/turnt_brilirs.toml
@@ -1,3 +1,3 @@
-command = "bril2json < {filename} | cargo +nightly run --manifest-path ../../brilirs/Cargo.toml -- {args}"
+command = "bril2json < {filename} | cargo run --manifest-path ../../brilirs/Cargo.toml -- {args}"
 return_code = 2
 output.err = "2"

--- a/test/interp/turnt_brilirs.toml
+++ b/test/interp/turnt_brilirs.toml
@@ -1,1 +1,1 @@
-command = "bril2json < {filename} | cargo +nightly run --manifest-path ../../brilirs/Cargo.toml -- {args}"
+command = "bril2json < {filename} | cargo run --manifest-path ../../brilirs/Cargo.toml -- {args}"

--- a/test/mem/turnt_brilirs.toml
+++ b/test/mem/turnt_brilirs.toml
@@ -1,1 +1,1 @@
-command = "bril2json < {filename} | cargo +nightly run --manifest-path ../../brilirs/Cargo.toml -- {args}"
+command = "bril2json < {filename} | cargo run --manifest-path ../../brilirs/Cargo.toml -- {args}"


### PR DESCRIPTION
Clippy is the builtin rust linter which is run with `cargo clippy`. This pr addresses Clippy warnings, most of which are about stylistic consistency and smoothing over a couple snippets using references.

Builds upon #125