### PR TITLE
Let the funcRegexp for vim match a function with an argument

### DIFF
--- a/bril-vim/syntax/bril.vim
+++ b/bril-vim/syntax/bril.vim
@@ -25,7 +25,7 @@ let identifierRegexp = '(\a|_)\w*'
 call s:DefSynGroup('brilVariable', identifierRegexp, 'contained')
 
 " Tokens
-let funcRegexp = s:ConcatRegexp('\@', identifierRegexp)
+let funcRegexp = s:ConcatRegexp('\@', identifierRegexp, '(\(.*\))?')
 call s:DefSynGroup('brilFuncName', funcRegexp, 'contained')
 
 " Types


### PR DESCRIPTION
This should probably continue into parsing the arguments and their
types, but this at least restores syntax highlighting for functions
with args.
