### PR TITLE
Bril struct extension

### DIFF
--- a/bril-txt/briltxt.py
+++ b/bril-txt/briltxt.py
@@ -17,7 +17,10 @@ __version__ = '0.0.1'
 # Text format parser.
 
 GRAMMAR = """
-start: func*
+start: (struct | func)*
+
+struct: STRUCT IDENT "=" "{" mbr* "}"
+mbr: IDENT ":" type ";"
 
 func: FUNC ["(" arg_list? ")"] [tyann] "{" instr* "}"
 arg_list: | arg ("," arg)*
@@ -36,15 +39,18 @@ op: IDENT (FUNC | LABEL | IDENT)*
 lit: SIGNED_INT  -> int
   | BOOL         -> bool
   | SIGNED_FLOAT -> float
+  | "nullptr"    -> nullptr
 
-type: IDENT "<" type ">" -> paramtype
-    | IDENT              -> primtype
+type: IDENT "<" type ">"  -> paramtype
+    | IDENT               -> primtype
 
 BOOL: "true" | "false"
+STRUCT: "struct"
 IDENT: ("_"|"%"|LETTER) ("_"|"%"|"."|LETTER|DIGIT)*
 FUNC: "@" IDENT
 LABEL: "." IDENT
 COMMENT: /#.*/
+
 
 %import common.SIGNED_INT
 %import common.SIGNED_FLOAT
@@ -58,7 +64,12 @@ COMMENT: /#.*/
 
 class JSONTransformer(lark.Transformer):
     def start(self, items):
-        return {'functions': items}
+        structs = [i for i in items if 'mbrs' in i]
+        funcs = [i for i in items if 'mbrs' not in i]
+        return {
+            'structs' : structs,
+            'functions': funcs,
+        }
 
     def func(self, items):
         name, args, typ = items[:3]
@@ -79,6 +90,22 @@ class JSONTransformer(lark.Transformer):
         return {
             'name': name,
             'type': typ,
+        }
+
+    def struct(self, items):
+        name = items[1]
+        mbrs = items[2:]
+        return {
+            'name': name,
+            'mbrs': mbrs,
+        }
+
+    def mbr(self, items):
+        name = items.pop(0)
+        typ = items.pop(0)
+        return {
+            'name' : name,
+            'type' : typ,
         }
 
     def arg_list(self, items):
@@ -153,6 +180,9 @@ class JSONTransformer(lark.Transformer):
 
     def float(self, items):
         return float(items[0])
+
+    def nullptr(self, items):
+        return 0
 
 
 def parse_bril(txt):

--- a/bril-txt/briltxt.py
+++ b/bril-txt/briltxt.py
@@ -66,10 +66,13 @@ class JSONTransformer(lark.Transformer):
     def start(self, items):
         structs = [i for i in items if 'mbrs' in i]
         funcs = [i for i in items if 'mbrs' not in i]
-        return {
-            'structs': structs,
-            'functions': funcs,
-        }
+        if structs:
+            return {
+                'structs': structs,
+                'functions': funcs,
+            }
+        else:
+            return { 'functions': funcs }
 
     def func(self, items):
         name, args, typ = items[:3]

--- a/bril-txt/briltxt.py
+++ b/bril-txt/briltxt.py
@@ -67,7 +67,7 @@ class JSONTransformer(lark.Transformer):
         structs = [i for i in items if 'mbrs' in i]
         funcs = [i for i in items if 'mbrs' not in i]
         return {
-            'structs' : structs,
+            'structs': structs,
             'functions': funcs,
         }
 
@@ -104,8 +104,8 @@ class JSONTransformer(lark.Transformer):
         name = items.pop(0)
         typ = items.pop(0)
         return {
-            'name' : name,
-            'type' : typ,
+            'name': name,
+            'type': typ,
         }
 
     def arg_list(self, items):

--- a/bril-txt/briltxt.py
+++ b/bril-txt/briltxt.py
@@ -72,7 +72,9 @@ class JSONTransformer(lark.Transformer):
                 'functions': funcs,
             }
         else:
-            return { 'functions': funcs }
+            return {
+                'functions': funcs,
+            }
 
     def func(self, items):
         name, args, typ = items[:3]

--- a/examples/struct-ext/README
+++ b/examples/struct-ext/README
@@ -1,0 +1,5 @@
+The program brilc implements a Bril->LLVM compiler that supports the struct
+extension.
+
+For more on the Struct extension, see the blog post:
+https://www.cs.cornell.edu/courses/cs6120/2020fa/blog/brilc/

--- a/examples/struct-ext/brilc
+++ b/examples/struct-ext/brilc
@@ -1,0 +1,451 @@
+#!/usr/bin/python3
+
+# A Bril to LLVM compiler supporting Bril's struct extenstion.
+
+# This program reads a Bril program (in JSON) from stdin and writes an LLVM
+# program to stdout.
+
+from brilpy import *
+from ssa import to_ssa
+
+# Constant header for every program, including:
+#   - LLVM preamble stuff
+#   - Constants to support Bril primitives
+#   - print_bool, print_int, print_space, print_newline, and print_ptr to be
+#   used by Bril's print builtin
+PROG_HDR = """
+; ModuleID = '{}'
+source_filename = "{}"
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-pc-linux-gnu"
+
+@.str = private unnamed_addr constant [5 x i8] c"true\\00", align 1
+@.str.1 = private unnamed_addr constant [6 x i8] c"false\\00", align 1
+@.str.2 = private unnamed_addr constant [4 x i8] c"%ld\\00", align 1
+@.str.3 = private unnamed_addr constant [9 x i8] c"[object]\\00", align 1
+@.str.4 = private unnamed_addr constant [33 x i8] c"error: expected %d args, got %d\\0A\\00", align 1
+
+; DECLARE LIBRARY CALLS
+declare dso_local i32 @putchar(i32)
+declare dso_local i32 @printf(i8*, ...)
+declare dso_local void @exit(i32)
+declare dso_local i64 @atol(i8*)
+declare dso_local noalias i8* @malloc(i64)
+declare dso_local void @free(i8*)
+
+define dso_local i32 @btoi(i8* %0) #0 {{
+  %2 = alloca i8*, align 8
+  store i8* %0, i8** %2, align 8
+  %3 = load i8*, i8** %2, align 8
+  %4 = load i8, i8* %3, align 1
+  %5 = sext i8 %4 to i32
+  %6 = icmp eq i32 %5, 116
+  %7 = zext i1 %6 to i32
+  ret i32 %7
+}}
+
+define dso_local void @print_bool(i1 %0) {{
+  %2 = icmp ne i1 %0, 0
+  br i1 %2, label %3, label %5
+
+3:
+  %4 = call i32 (i8*, ...) @printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @.str, i64 0, i64 0))
+  br label %7
+
+5:
+  %6 = call i32 (i8*, ...) @printf(i8* getelementptr inbounds ([6 x i8], [6 x i8]* @.str.1, i64 0, i64 0))
+  br label %7
+
+7:
+  ret void
+}}
+
+define dso_local void @print_space() {{
+  %1 = call i32 @putchar(i32 32)
+  ret void
+}}
+
+define dso_local void @print_newline() {{
+  %1 = call i32 @putchar(i32 10)
+  ret void
+}}
+
+define dso_local void @print_int(i64 %0) {{
+  %2 = alloca i64, align 8
+  store i64 %0, i64* %2, align 8
+  %3 = load i64, i64* %2, align 8
+  %4 = call i32 (i8*, ...) @printf(i8* getelementptr inbounds ([4 x i8], [4 x i8]* @.str.2, i64 0, i64 0), i64 %3)
+  ret void
+}}
+
+define dso_local void @print_ptr(i8* %0) {{
+  %2 = alloca i8*, align 8
+  store i8* %0, i8** %2, align 8
+  %3 = call i32 (i8*, ...) @printf(i8* getelementptr inbounds ([9 x i8], [9 x i8]* @.str.3, i64 0, i64 0))
+  ret void
+}}
+"""
+
+# Header / Footer for every function
+FUN_HDR = """
+define dso_local {} @{}({}) {{
+"""
+
+FUN_FTR = """
+}
+"""
+
+# Bril op -> LLVM op
+OPS = {'add' : 'add',
+       'mul' : 'mul',
+       'sub' : 'sub',
+       'div' : 'sdiv',
+       'eq'  : 'icmp eq',
+       'lt'  : 'icmp slt',
+       'gt'  : 'icmp sgt',
+       'le'  : 'icmp sle',
+       'ge'  : 'icmp sge',
+       'and' : 'and',
+       'or'  : 'or',
+}
+
+def is_ptr_type(t):
+    """Decide whether the Bril type t is a pointer"""
+    return (isinstance(t, dict) and 'ptr' in t)
+
+def ttype(briltype):
+    """Given a Bril type, return a string for the corresponding LLVM type"""
+    if briltype == 'int':
+        return 'i64'
+    elif briltype == 'bool':
+        return 'i1'
+
+    elif is_ptr_type(briltype):
+        return ttype(briltype['ptr']) + '*'
+
+    else: # name of a struct
+        return '%' + briltype
+
+# name -> size in bytes (maybe a global isn't the best choice here...)
+struct_sizes = {}
+
+# struct name -> mbr name -> mbr offset idx
+struct_mbr_offsets = {}
+
+def sizeof(briltype):
+    if briltype == 'bool':
+        return 1
+    elif is_ptr_type(briltype):
+        return 8
+    elif briltype in struct_sizes:
+        return struct_sizes[briltype]
+    else: #int
+        return 8
+
+
+class Context:
+    """ Function-level information about bril variables.
+    types: name -> type            -- bril type label for each var.
+    constants: name -> const value -- const values for bril constants
+    canonical: name -> name        -- canonical var. names for bril `id` copies
+    is_main: bool                  -- true iff this is the main func
+    """
+    def __init__(self, func):
+        types = {}
+        consts = {}
+        canon = {}
+        for i in func['instrs']:
+            if 'dest' in i:
+                if i['op'] == 'phi':
+                    types[i['dest']] = types[i['args'][0]]
+                else:
+                    types[i['dest']] = i['type']
+                    if i['op'] == 'id':
+                        if i['args'][0] in consts:
+                            consts[i['dest']] = consts[i['args'][0]]
+                        elif i['args'][0] in canon:
+                            canon[i['dest']] = canon[i['args'][0]]
+                        else:
+                            canon[i['dest']] = i['args'][0]
+            if 'value' in i:
+                if i['type'] == 'bool':
+                    consts[i['dest']] = 1 if i['value'] else 0
+                else:
+                    consts[i['dest']] = i['value']
+        self.types = types
+        self.constants = consts
+        self.canonical = canon
+        self.mainfunc = func['name'] == '__main'
+        self.next_int = 0
+
+    def format_args(self, args, show_types=False):
+        alist = []
+        for a in args:
+            t = self.types[a]
+            if a in self.constants:
+                a = self.constants[a]
+                if is_ptr_type(t) and not a:
+                    a = 'null'
+            elif a in self.canonical:
+                a = '%' + self.canonical[a]
+            else:
+                a = '%' + a
+            s = ttype(t) + ' ' + str(a) if show_types else str(a)
+            alist.append(s)
+        return ', '.join(alist)
+
+    def new_var(self, t):
+        v = 'z' + str(self.next_int)
+        self.next_int += 1
+        self.types[v] = t
+        return v
+
+def emit_instr(instr, ctxt):
+    """Emit LLVM instruction(s) implementing instr, a bril instruction"""
+    args = instr['args'] if 'args' in instr else []
+
+
+    if 'op' in instr:
+
+        # VALUE operations:
+        if 'dest' in instr:
+            if instr['op'] == 'call':
+                print('  %{} = call {} @__{}({})'.format(instr['dest'],
+                                                         ttype(instr['type']),
+                                                         instr['funcs'][0],
+                                                         ctxt.format_args(args, show_types=True)))
+
+            elif instr['op'] == 'not':
+                print('  %{} = xor i1 1, {}'.format(instr['dest'],
+                                                    ctxt.format_args(args)))
+
+            elif instr['op'] in OPS:
+                print('  %{} = {} {} {}'.format(instr['dest'],
+                                                OPS[instr['op']],
+                                                ttype(ctxt.types[args[0]]),
+                                                ctxt.format_args(args)))
+            elif instr['op'] == 'phi':
+                s = '  %{} = phi {} '.format(instr['dest'], ttype(ctxt.types[args[0]]))
+                pairs = []
+                while args:
+                    (a, lbl) = (args.pop(), instr['labels'].pop())
+                    pairs.append('[ {}, %{} ]'.format(ctxt.format_args([a]), lbl))
+                print(s + ', '.join(pairs))
+
+            elif instr['op'] == 'alloc':
+                new_var = ctxt.new_var('int')
+                print('  %{} = mul i64 {}, {}'.format(new_var,
+                                                      ctxt.format_args(args),
+                                                      sizeof(instr['type']['ptr'])))
+
+                ptr = ctxt.new_var(None) # the type is a lie! (but we'll never query for it)
+                print('  %{} = call i8* @malloc({})'.format(ptr,
+                                                            ctxt.format_args([new_var], show_types=True)))
+                print('  %{} = bitcast i8* %{} to {}'.format(instr['dest'],
+                                                             ptr,
+                                                             ttype(instr['type'])))
+            elif instr['op'] == 'load':
+                print('  %{} = load {}, {}'.format(instr['dest'],
+                                                   ttype(instr['type']),
+                                                   ctxt.format_args(args, show_types=True)))
+
+            elif instr['op'] == 'ptradd':
+                print('  %{} = getelementptr inbounds {}, {}'.format(instr['dest'],
+                                                                     ttype(instr['type']['ptr']),
+                                                                     ctxt.format_args(args, show_types=True)))
+            elif instr['op'] == 'getmbr':
+                struct = ctxt.types[args[0]]['ptr']
+                print('  %{} = getelementptr inbounds {}, {}, i64 0, i32 {}'.format(
+                                                        instr['dest'],
+                                                        ttype(struct),
+                                                        ctxt.format_args(args[:1], show_types=True),
+                                                        struct_mbr_offsets[struct][args[1]]))
+            elif instr['op'] == 'isnull':
+                new_var = ctxt.new_var('int')
+                print('  %{} = ptrtoint {} to i64'.format(new_var,
+                                                          ctxt.format_args(args, show_types=True)))
+                print('  %{} = icmp eq i64 0, %{}'.format(instr['dest'],
+                                                          new_var))
+
+
+
+        # EFFECT operations
+        else:
+            # control: br jmp ret
+            if instr['op'] == 'br':
+                print('  br i1 {}, label %{}, label %{}'.format(ctxt.format_args(args),
+                                                                instr['labels'][0],
+                                                                instr['labels'][1]))
+            elif instr['op'] == 'jmp':
+                print('  br label %{}'.format(instr['labels'][0]))
+
+            elif instr['op'] == 'ret':
+                r = ctxt.format_args(args, show_types=True)
+                if not r or ctxt.mainfunc:
+                    r = 'void'
+                print('  ret {}'.format(r))
+
+            # void call
+            elif instr['op'] == 'call':
+                print('  call void @__{}({})'.format(instr['funcs'][0],
+                                                   ctxt.format_args(args, show_types=True)))
+            # print
+            elif instr['op'] == 'print':
+                s = []
+                for a in args:
+                    t = ctxt.types[a]
+                    s.append('  call void @print_{}({})'.format(t, ctxt.format_args([a], show_types=True)))
+                print("\n  call void @print_space()\n".join(s)) # Spaces between args
+                print('  call void @print_newline()')           # Newline at end
+
+            elif instr['op'] == 'free':
+                byte_ptr = ctxt.new_var(None) # the type is a lie! (but we'll never query for it)
+                print('  %{} = bitcast {} to i8*'.format(byte_ptr,
+                                                         ctxt.format_args(args, show_types=True)))
+                print('  call void @free(i8* %{})'.format(byte_ptr))
+
+            elif instr['op'] == 'store':
+                print('  store {}'.format(ctxt.format_args(reversed(args), show_types=True)))
+
+    # LABEL
+    else:
+        print(instr['label'] + ':')
+
+
+def emit_func(f, ctxt):
+
+    # Translate return type
+    rettype = ttype(f['type']) if 'type' in f else 'void'
+
+    # Translate args
+    args = []
+    if 'args' in f:
+        for a in f['args']:
+            args.append(ttype(a['type']) + ' %' + a['name'])
+    args = ', '.join(args)
+
+    # Start emitting the fn
+    print(FUN_HDR.format(rettype, f['name'], args), end='')
+
+    for instr in f['instrs']:
+        emit_instr(instr, ctxt)
+
+    print(FUN_FTR)
+
+
+MAIN = """
+define dso_local i32 @main(i32 %argc, i8** %argv) {{
+  %1 = alloca i32, align 4
+  %2 = alloca i32, align 4
+  %3 = alloca i8**, align 8
+  store i32 0, i32* %1, align 4
+  store i32 %argc, i32* %2, align 4
+  store i8** %argv, i8*** %3, align 8
+  %4 = load i32, i32* %2, align 4
+  %5 = sub nsw i32 %4, 1
+  %6 = icmp ne i32 %5, {}  ; NUM ARGS
+  br i1 %6, label %7, label %11
+
+7:
+  %8 = load i32, i32* %2, align 4
+  %9 = sub nsw i32 %8, 1
+  %10 = call i32 (i8*, ...) @printf(i8* getelementptr inbounds ([33 x i8], [33 x i8]* @.str.4, i64 0, i64 0), i32 {}, i32 %9)
+  call void @exit(i32 2) #3
+  unreachable
+
+11:
+  %12 = load i8**, i8*** %3, align 8
+{}
+  call void @__main({})
+  ret i32 0
+}}
+"""
+
+def get_argv(i, t):
+    """ Return LLVM code to get argv[i], convert, and store in %ai
+        i: index needed
+        t: 'int' or 'bool'
+    """
+    if t == 'int':
+        return """
+  %t{}_0 = getelementptr inbounds i8*, i8** %12, i64 {}
+  %t{}_1 = load i8*, i8** %t{}_0, align 8
+  %a{} = call i64 @atol(i8* %t{}_1)
+  """.format(i, i+1, i, i, i, i)
+    else:
+        return """
+  %t{}_0 = getelementptr inbounds i8*, i8** %12, i64 {}
+  %t{}_1 = load i8*, i8** %t{}_0, align 8
+  %t{}_2 = call i32 @btoi(i8* %t{}_1)
+  %a{} = trunc i32 %t{}_2 to i1
+  """.format(i, i+1, i, i, i, i, i, i)
+
+def emit_main(main_args):
+    """Process command line args and call bril program's main, i.e., __main
+    """
+    arg_setup = ''
+    arg_list = []
+    for i, arg in enumerate(main_args):
+        arg_setup += get_argv(i, arg['type'])
+        arg_list.append(ttype(arg['type']) + ' %a{}'.format(i))
+    arg_list = ', '.join(arg_list)
+
+
+    print(MAIN.format(len(main_args), len(main_args), arg_setup, arg_list))
+
+def main():
+    """ Read a bril program from stdin, convert to ssa, then emit LLVM by function.
+    """
+    f = None
+    fname = ''
+
+    if len(sys.argv) <= 1:
+        f = sys.stdin
+        fname = 'stdin'
+    else:
+        f = open(sys.argv[1])
+        fname = sys.argv[1]
+
+    prog = to_ssa(json.load(f))
+
+    main_args = []
+
+    print(PROG_HDR.format(fname, fname))
+
+    # Compute struct size for allocation,
+    # Build mbr offset reference, and
+    # Emit LLVM declaration.
+    for struct in prog['structs']:
+        name = struct['name']
+        size = 0
+
+        struct_mbr_offsets[name] = {}
+
+        mbrs = []
+        for i, mbr in enumerate(struct['mbrs']):
+            size += sizeof(mbr['type'])
+
+            struct_mbr_offsets[name][mbr['name']] = i
+
+            mbrs.append(ttype(mbr['type']))
+
+        struct_sizes[name] = size
+        print('%{} = type {{ {} }}'.format(name, ', '.join(mbrs)))
+
+
+    # Iterate and emit functions
+    for func in prog['functions']:
+
+        if (func['name'] == 'main'):
+            if 'args' in func:
+                main_args = func['args']
+            if 'type' in func:
+                func.pop('type') # We wouldn't actually return the value anyway
+        func['name'] = '__' + func['name'] # Avoid name collisions in C world
+
+        emit_func(func, Context(func))
+
+    emit_main(main_args)
+
+if __name__ == '__main__':
+    main()

--- a/examples/struct-ext/brilc
+++ b/examples/struct-ext/brilc
@@ -407,6 +407,8 @@ def main():
         fname = sys.argv[1]
 
     prog = to_ssa(json.load(f))
+    if 'structs' not in prog:
+        prog['structs'] = []
 
     main_args = []
 

--- a/examples/struct-ext/brilpy.py
+++ b/examples/struct-ext/brilpy.py
@@ -1,0 +1,281 @@
+#!/usr/bin/python3
+
+# Mark Moeller:
+
+import json
+import sys
+
+TERM = 'jmp', 'br', 'ret'
+
+# From Lesson 2
+def form_blocks(body):
+    cur_block = []
+
+    for inst in body:
+        if 'op' in inst:
+            cur_block.append(inst)
+
+            # check for term
+            if inst['op'] in TERM:
+                yield cur_block
+                cur_block = []
+
+        else: # label
+            if len(cur_block) != 0:
+                yield cur_block
+
+            cur_block = [inst]
+
+    if len(cur_block) != 0:
+        yield cur_block
+
+class CFG:
+    # Constructs a new cfg (names, blocks, edges), where:
+    # names: a list of block names
+    # blocks: the list of blocks themselves
+    # edges: idx->idx map of successors
+    def __init__(self, func):
+        self.names = []
+        self.blocks = []
+
+        # Map label -> block idx for that label
+        labels = {}
+
+        # Edges of the CFG
+        self.edges = []
+
+        # When we encounter jumps to labels that haven't appeared yet, add the
+        # label here with a list of blocks that need to jump TO that label
+        # label -> [list of blocks forward-jumping to it]
+        resolve = {} 
+
+        def make_edge(idx, label):
+            if label in labels:
+                self.edges[idx].append(labels[label])
+            else:
+                if label in resolve:
+                    resolve[label].append(idx)
+                else:
+                    resolve[label] = [idx]
+
+        for i,block in enumerate(form_blocks(func['instrs'])):
+
+            self.blocks.append(block)
+            self.edges.append([])
+
+            name = "b" + str(i)
+
+            if 'label' in block[0]:
+                name = block[0]['label']
+                labels[name] = i
+
+            self.names.append(name)
+
+            if 'op' in block[-1] and (block[-1]['op'] == 'br' or block[-1]['op'] == 'jmp'):
+                for label in block[-1]['labels']:
+                    make_edge(i, label)
+
+            elif 'op' in block[-1] and block[-1]['op'] != 'ret':
+                self.edges[i] = [i+1]
+
+        self.n = len(self.names)
+
+        for lab,idcs in resolve.items():
+            for idx in idcs:
+                self.edges[idx].append(labels[lab])
+
+        # If we added i+1 for the last block, remove it (there is no successor)
+        if self.n in self.edges[-1]:
+            self.edges[-1] = []
+
+        # compute edges_r to get predecessors
+        self.preds = []
+        for i in range(self.n):
+            self.preds.append([])
+
+        for k,v in enumerate(self.edges):
+            for d in v:
+                self.preds[d].append(k)
+
+    # perform a dfs in the specified order, calling pre(i) and post(i) upon
+    # previsit and posvisit of i, respectively.
+    # next_tree is called with no args after each time dfs_visit finishes a
+    # connected component.
+    def dfs(self, order=None, pre=None, post=None, next_tree=None, edges=None):
+
+        if not order:
+            order = list(range(self.n))
+
+        if not edges:
+            edges = self.edges
+
+        WHITE = 0
+        GRAY = 1
+        BLACK = 2
+
+        visited = []
+        colors = [WHITE] * self.n
+
+        def dfs_visit(node):
+            if colors[node] == WHITE:
+                colors[node] = GRAY
+                if pre:
+                    pre(node)
+                for v in edges[node]:
+                    dfs_visit(v)
+                colors[node] = BLACK
+                if post:
+                    post(node)
+
+        for i in order:
+            dfs_visit(i)
+            if next_tree:
+                next_tree()
+
+    # Return the indeces in reverse-post-order 
+    def rpo(self):
+        visited = []
+        def post_visit(i):
+            visited.append(i)
+
+        self.dfs(post=post_visit)
+        visited.reverse()
+        return visited
+
+    # Unused first attempt. Computes SCCs in the graph.
+    def natural_loops(self):
+
+        sccs = []
+        cur = []
+
+        def postv(i):
+            nonlocal cur
+            cur.append(i)
+
+        def nt():
+            nonlocal cur
+            if cur:
+                sccs.append(cur)
+                cur = []
+
+        self.dfs(order=self.rpo(), post=postv, next_tree=nt, edges=self.preds)
+
+        nl_list = []
+
+        for cand in sccs:
+            if len(cand) > 1:
+                nat = True
+                header = -1
+                for b in cand:
+                    for p in self.preds[b]:
+                        if p not in cand:
+                            if header == -1:
+                                header = b
+                            else:
+                                nat = False
+                                break
+                if nat:
+                    cand.remove(header)
+                    nl_list.append([header] + cand)
+
+        return nl_list
+
+
+
+
+    def to_dot(self):
+        s = "digraph g {\n"
+
+        for u,nbrs in enumerate(self.edges):
+            for v in nbrs:
+                s += self.names[u].replace('.','_') + " -> " + self.names[v].replace('.','_') + ";\n"
+
+        s += "}\n"
+        return s
+
+    def print_names(self):
+        for i,n in enumerate(self.names):
+            print("{} {}".format(i, n))
+
+# ------------------------------------------------------------------------------
+# Dataflow functions for SSA Reaching Definitions
+#   Since we assume SSA, we can map from varname->single block defining
+# ------------------------------------------------------------------------------
+
+def rd_init(func, graph):
+    in_b = []
+    out_b = []
+
+    in_b.append({})
+    out_b.append({})
+
+    if 'args' in func:
+        for arg in func['args']:
+            in_b[0][arg['name']] = 0
+
+    for i in range(graph.n - 1):
+        in_b.append({})
+        out_b.append({})
+    return (in_b, out_b)
+
+
+def rd_xfer(in_b, block, idx):
+
+    out_b = in_b.copy()
+
+    for i,inst in enumerate(block):
+        if 'dest' in inst:
+            if inst['dest'] in out_b and out_b[inst['dest']] != idx:
+                print("warning: illegal redef of var `{}`.".format(inst['dest'])
+                + "This function assumes SSA.", file=sys.stderr)
+            out_b[inst['dest']] = idx
+
+    return out_b
+
+def rd_merge(pred_list):
+
+    result = {}
+
+    for p in pred_list:
+        for k,v in p.items():
+            if k in result and v != result[k]:
+                print("warning: illegal redef of var `{}` (multiple blocks).".format(v) +
+                        " This function assumes SSA.", file=sys.stderr)
+            result[k] = v
+
+    return result
+
+
+
+# ------------------------------------------------------------------------------
+# Worklist function
+# func: the function object (as loaded from json)
+# init: (func, graph) -> (in_b, out_b): Computes initial datastructures. in_b
+#                                       and out_b are each arrays of size
+#                                       len(blocks).
+# xfer: (in_b, block) -> out_b:         Compute transfer for a single block.
+# merge: List of out_b -> in_b:         Given a list of predecessors' out_b's,
+#                                       compute a single in_b.
+# ------------------------------------------------------------------------------
+
+def run_worklist(func, init, xfer, merge):
+    graph = CFG(func)
+
+    (in_b, out_b) = init(func, graph)
+
+    worklist = list(range(graph.n))
+
+    while worklist:
+        b = worklist[0]
+        worklist = worklist[1:]
+
+        in_b[b] = merge([out_b[x] for x in graph.preds[b]]) if graph.preds[b] else {}
+
+        out_b_copy = out_b[b].copy()
+
+        out_b[b] = xfer(in_b[b], graph.blocks[b], b)
+
+        if out_b[b] != out_b_copy:
+            worklist += graph.edges[b]
+
+    return (in_b, out_b)

--- a/examples/struct-ext/dom.py
+++ b/examples/struct-ext/dom.py
@@ -1,0 +1,137 @@
+#!/usr/bin/python3
+
+import sys
+import json
+from brilpy import *
+from functools import reduce
+
+class Dominators:
+
+    def __init__(self, func):
+        g = CFG(func)
+
+        # First compute dominators
+        # IMPORTANT: This computes, for each block, the set of blocks that dominate
+        # it, not the other way around
+        self.doms = []
+        self.doms.append(set([0])) # Entry block is special, it's its own dominator
+        for i in range(1,g.n):
+            self.doms.append(set(range(g.n)))
+
+        order = g.rpo()
+
+        changed = True
+        while changed:
+            changed = False
+            for i in order[1:]: # no one can dominate 0 except 0
+                d = {i}
+                if g.preds[i]:
+                    d |= reduce(set.intersection, [self.doms[p] for p in g.preds[i]], set(range(g.n)))
+
+                if d != self.doms[i]:
+                    changed = True
+                    self.doms[i] = d
+
+        # Compute the "other way around" (from above), that is, for each block, the
+        # set of blocks this block dominates
+        self.dom_by = []
+        for i in range(g.n):
+            self.dom_by.append(set())
+
+        for i,d in enumerate(self.doms):
+            for mbr in d:
+                self.dom_by[mbr].add(i)
+
+
+
+        # Compute the dominance tree
+        dt_parent = [None]
+
+        for i in range(1, g.n):
+            for j in self.doms[i]:
+                if i != j:  # j strictly dominates i
+                    immed_dom = True
+                    for k in range(g.n):
+                        if k != j and k != i and j in self.doms[k] and k in self.doms[i]:
+                            immed_dom = False
+                            break
+                    if immed_dom:
+                        dt_parent.append(j)
+                        break
+
+        self.dom_tree = {}
+        for i,p in enumerate(dt_parent):
+            if p in self.dom_tree:
+                self.dom_tree[p].append(i)
+            else:
+                self.dom_tree[p] = [i]
+
+        # Compute dominance frontier
+        self.frontier = []
+        for i in range(g.n):
+            self.frontier.append(set())
+
+        for i,d in enumerate(self.doms):
+            # Union of dominators for this node's preds
+            pre_doms = reduce(set.union, [self.doms[p] for p in g.preds[i]], set())
+            # Subtract out strict dominators for this node
+            pre_doms = pre_doms.difference(self.doms[i].difference(set([i])))
+
+            # This node is in the frontier for the remaining nodes:
+            for p in pre_doms:
+                self.frontier[p].add(i)
+
+
+
+
+
+def main():
+    prog = json.load(sys.stdin)
+
+    for func in prog['functions']:
+
+        print("**Function: {}".format(func['name']))
+
+        g = CFG(func)
+
+        f = open("graphs/" + func['name'] + "-cfg.dot", 'w')
+        f.write(g.to_dot())
+        f.close()
+        print(g.to_dot())
+
+        g.print_names()
+        print("  edges: {}".format(g.edges))
+        print("  preds: {}".format(g.preds))
+
+        d = dominators(func)
+
+        print("\n\n  doms:\n{}\n".format(d.doms))
+        for k,v in enumerate(doms):
+            print("    {}: ".format(g.names[k]), end="")
+            for mbr in v:
+                print("{} ".format(g.names[mbr]), end="")
+            print("")
+
+        # print("dom tree:\ndigraph g {")
+
+        print("  domtree:")
+        f = open("graphs/" + func['name'] + "-dt.dot", 'w')
+        print("digraph g {")
+        f.write("digraph g {\n")
+        for k,v in d.dom_tree.items():
+            for mbr in v:
+                print("{} -> {};".format(g.names[k], g.names[mbr]))
+                f.write("{} -> {};\n".format(g.names[k], g.names[mbr]))
+        print("}")
+        f.write("}\n")
+        f.close()
+
+        print("\n\n  dominance frontier:")
+        for k,v in enumerate(d.frontier):
+            print("    {}: ".format(g.names[k]), end="")
+            for mbr in v:
+                print("{} ".format(g.names[mbr]), end="")
+            print("")
+
+if __name__ == '__main__':
+    main()

--- a/examples/struct-ext/linkedlist.bril
+++ b/examples/struct-ext/linkedlist.bril
@@ -1,0 +1,63 @@
+struct int_list = {
+    elt: int;
+    next: ptr<int_list>;
+}
+
+@cons (head: int, tail:ptr<int_list>): ptr<int_list> {
+    one: int = const 1;
+    p: ptr<int_list> = alloc one;
+
+    phead: ptr<int> = getmbr p elt;
+    ptail: ptr<ptr<int_list>> = getmbr p next;
+
+    store phead head;
+    store ptail tail;
+
+    ret p;
+}
+
+@print_list (list: ptr<int_list>) {
+    empty: bool = isnull list;
+    br empty .end .print;
+.print:
+    xp: ptr<int> = getmbr list elt;
+    x: int = load xp;
+    print x;
+
+    tp: ptr<ptr<int_list>> = getmbr list next;
+    t: ptr<int_list> = load tp;
+    call @print_list t;
+.end:
+    ret;
+}
+
+@free_list (list: ptr<int_list>) {
+    empty: bool = isnull list;
+    br empty .end .freetail;
+.freetail:
+    tp: ptr<ptr<int_list>> = getmbr list next;
+    t: ptr<int_list> = load tp;
+    call @free_list t;
+    free list;
+.end:
+    ret;
+}
+
+@main {
+    a: int = const 2;
+    b: int = const 3;
+    c: int = const 5;
+    d: int = const 8;
+
+    n: ptr<int_list> = const nullptr;
+
+    s0: ptr<int_list> = call @cons a n;
+    s1: ptr<int_list> = call @cons b s0;
+    s2: ptr<int_list> = call @cons c s1;
+    s3: ptr<int_list> = call @cons d s2;
+
+    call @print_list s3;
+    call @free_list s3;
+
+    ret;
+}

--- a/examples/struct-ext/point.bril
+++ b/examples/struct-ext/point.bril
@@ -1,0 +1,39 @@
+struct point = {
+    x: int;
+    y: int;
+}
+
+@print_point(p: ptr<point>) {
+    px: ptr<int> = getmbr p x;
+    py: ptr<int> = getmbr p y;
+
+    xv: int = load px;
+    yv: int = load py;
+    
+    print xv yv;
+}
+
+@main(a: int, b: int) {
+    one: int = const 1;
+    two: int = const 2;
+    z: ptr<point> = alloc two;
+    z1: ptr<point> = ptradd z one;
+
+    z0x: ptr<int> = getmbr z x;
+    z0y: ptr<int> = getmbr z y;
+    store z0x a;
+    store z0y b;
+
+    z1x: ptr<int> = getmbr z1 x;
+    z1y: ptr<int> = getmbr z1 y;
+
+    c: int = mul a b;
+    d: int = add a b;
+    store z1x c;
+    store z1y d;
+
+    call @print_point z;
+    call @print_point z1;
+
+    free z;
+}

--- a/examples/struct-ext/ssa.py
+++ b/examples/struct-ext/ssa.py
@@ -1,0 +1,246 @@
+#!/usr/bin/python
+
+import sys
+import json
+from dom import Dominators
+from brilpy import *
+from functools import reduce
+
+TERM = 'jmp', 'br', 'ret'
+
+def to_ssa(prog):
+    for func in prog['functions']:
+
+        # Add dummy id operations for each argument.
+        # This is a bit of a hack because of the fact that you can reassign to
+        # the args anywhere in the function.
+        # We don't want the first block to be a place we can jump to, because
+        # we can't have a phi as the first instruction to disambiguate args
+        if 'args' in func:
+            if func['args']:
+                for a in func['args']:
+                    func['instrs'] = [{'op':'id', 'args':[a['name']], 'type':a['type'], 'dest':a['name']}] + \
+                                     func['instrs']
+                func['instrs'] = [{'label':'pre_entry'}] + func['instrs']
+
+        # Next we need to canonicalize labels, in case any labels appear
+        # directly in a row, this would break things later
+        label_last = False
+        last = None
+        i = 0
+        while i < len(func['instrs']):
+            inst = func['instrs'][i]
+            if 'label' in inst:
+                if label_last:
+                    for j in func['instrs']:
+                        if 'labels' in j and inst['label'] in j['labels']:
+                            labels = []
+                            for lbl in j['labels']:
+                                if lbl == inst['label']:
+                                    labels.append(last['label'])
+                                else:
+                                    labels.append(lbl)
+                            j['labels'] = labels
+                    func['instrs'].pop(i)
+
+                else:
+                    i += 1
+                    last = inst
+                    label_last = True
+            else:
+                i += 1
+                label_last = False
+
+        # This last bit is just because even after the above, a valid bril
+        # program could end with a label, but we don't want that (i.e., an empty
+        # block
+        if label_last:
+            func['instrs'].append({'op':'ret'});
+
+        g = CFG(func)
+
+        domins = Dominators(func)
+
+        defs = {}
+        for i,b in enumerate(g.blocks):
+            if i == 0 and 'args' in func:
+                for arg in func['args']:
+                    defs[arg['name']] = [i]
+
+            for instr in b:
+                if 'dest' in instr:
+                    if instr['dest'] in defs:
+                        defs[instr['dest']].append(i)
+                    else:
+                        defs[instr['dest']] = [i]
+
+        # for each block, these are the phis we'll add at the end. Each has a
+        # map from orig.var -> to a map that will become the instruction itself,
+        phis = []
+        for i in range(g.n):
+            phis.append({})
+
+        # Following pseudocode from Lesson 5 notes
+        # ``Step one''
+        for v,vdefs in defs.items():
+            for d in vdefs:
+                for b in domins.frontier[d]:
+                    if v not in phis[b]:
+                        phis[b][v] = {'op':'phi', 'args':[], 'labels':[]} # will handle dest/args later
+
+                    if b not in defs[v]:
+                        defs[v].append(b)
+
+        # ``Step two''
+        stack = {}
+        next_name = {}
+        for v in defs.keys():
+            stack[v] = []
+            next_name[v] = 0
+
+        # args' bottom-stack names are their original names
+        if 'args' in func:
+            for arg in func['args']:
+                stack[arg['name']] = [arg['name']]
+
+
+        def new_name(ogvar):
+            n = ogvar + '_' + str(next_name[ogvar])
+            next_name[ogvar] += 1
+            stack[ogvar].append(n)
+            return n
+
+        # b: index of block
+        def rename(b):
+
+
+            # map from vars to count of names pushed (so we can pop them)
+            push_count = {}
+
+            for v,p in phis[b].items():
+                p['dest'] = new_name(v)
+
+            for instr in g.blocks[b]:
+
+                # replace old names with stack names
+                if 'args' in instr:
+                    newargs = []
+                    if 'op' in instr and instr['op'] == 'getmbr':
+                        newargs.append(stack[instr['args'][0]][-1])
+                        newargs.append(instr['args'][1])
+                    else:
+                        for arg in instr['args']:
+                            newargs.append(stack[arg][-1])
+                    instr['args'] = newargs
+
+                # replace destination with new name (and push onto stack)
+                if 'dest' in instr:
+                    name = new_name(instr['dest'])
+                    if instr['dest'] in push_count:
+                        push_count[instr['dest']] += 1
+                    else:
+                        push_count[instr['dest']] = 1
+
+                    instr['dest'] = name
+
+            for s in g.edges[b]:
+
+                for v in set(phis[s].keys()): # (copy keyset so we can remove)
+
+                    # we found a path to this block where it is unassigned: this phi should go away
+                    if not stack[v]: 
+                        phis[s].pop(v)
+
+                    # otherwise update the var-use to use the current name
+                    else:
+                        phis[s][v]['args'].append(stack[v][-1])
+                        phis[s][v]['labels'].append(g.names[b])
+
+            if b in domins.dom_tree:
+                for b_dom in domins.dom_tree[b]:
+                    rename(b_dom)
+
+            # pop all the names
+            for var,count in push_count.items():
+                for j in range(count):
+                    stack[var].pop()
+
+        rename(0)
+
+
+        # Add labels to blocks missing labels, and add jumps to blocks that fall
+        # through
+        for i,b in enumerate(g.blocks):
+            # Add a label if missing
+            if 'label' not in b[0]:
+                b.insert(0, {'label': g.names[i]})
+
+            for v,p in phis[i].items():
+                # don't need a phi if only one label or arg
+                if len(set(p['labels'])) > 1 and len(set(p['args'])) > 1: 
+                    b.insert(1, p)
+
+            # Add a jmp if missing
+            if i > 0 and ('op' not in g.blocks[i-1][-1] or g.blocks[i-1][-1]['op'] not in TERM):
+                g.blocks[i-1].append({'op':'jmp', 'labels':[b[0]['label']]})
+
+
+        # Write all the blocks' instructions to a new "linear" function
+        newinstrs = []
+        for i,b in enumerate(g.blocks):
+            newinstrs += b
+
+        if 'op' not in newinstrs[-1] or newinstrs[-1]['op'] not in TERM:
+            newinstrs.append({'op':'ret'});
+
+        func['instrs'] = newinstrs
+
+    return prog
+
+def from_ssa(prog):
+
+    for func in prog['functions']:
+
+        g = CFG(func)
+
+        # First compute a map from label -> block idx
+        # Note: we assume every block in SSA form has a label (is this true?)
+        block_by_label = {}
+        term = []
+        for i,b in enumerate(g.blocks):
+            block_by_label[b[0]['label']] = i
+
+            # also temporarily save the TERM instruction (so when we add id's we
+            # can just tack them on the end)... this is a bit awkward
+            if 'op' in b[-1] and b[-1]['op'] in TERM:
+                term.append(b.pop())
+            else:
+                term.append(None)
+        
+        # print(term)
+
+        for i,b in enumerate(g.blocks):
+            if len(b) == 1:
+                continue
+
+            j = 1
+            while j < len(b) and 'op' in b[j] and b[j]['op'] == 'phi':
+                for k in range(len(b[j]['args'])):
+                    inst = {'op': 'id', 'dest': b[j]['dest'],
+                            'args':[b[j]['args'][k]]}
+                    g.blocks[block_by_label[b[j]['labels'][k]]].append(inst)
+
+                j += 1
+        
+        # write changes, omitting phis
+        newinstr = []
+        for i,b in enumerate(g.blocks):
+            for inst in b:
+                if not ('op' in inst and inst['op'] == 'phi'):
+                    newinstr.append(inst)
+            if term[i]:
+                newinstr.append(term[i])
+
+        func['instrs'] = newinstr
+
+    return prog


### PR DESCRIPTION
Adds a Bril->LLVM compiler which supports the struct extension to a new examples/struct-ext.

Note that this change modifies bril-txt/briltxt.py to allow parsing of Bril programs that use structs.

Only existing documentation is my blog post:
https://www.cs.cornell.edu/courses/cs6120/2020fa/blog/brilc