### PR TITLE
Add optional source positions

### DIFF
--- a/bril-txt/briltxt.py
+++ b/bril-txt/briltxt.py
@@ -63,6 +63,10 @@ COMMENT: /#.*/
 
 
 class JSONTransformer(lark.Transformer):
+    def __init__(self, include_pos=False):
+        super().__init__()
+        self.include_pos = include_pos
+
     def start(self, items):
         structs = [i for i in items if 'mbrs' in i]
         funcs = [i for i in items if 'mbrs' not in i]
@@ -158,7 +162,7 @@ class JSONTransformer(lark.Transformer):
             out['funcs'] = funcs
         if labels:
             out['labels'] = labels
-        if True:
+        if self.include_pos:
             out['pos'] = {'row': row, 'col': col}
         return out
 
@@ -194,10 +198,14 @@ class JSONTransformer(lark.Transformer):
         return 0
 
 
-def parse_bril(txt):
+def parse_bril(txt, include_pos=False):
+    """Parse a Bril program and return a JSON string.
+
+    Optionally include source position information.
+    """
     parser = lark.Lark(GRAMMAR, maybe_placeholders=True)
     tree = parser.parse(txt)
-    data = JSONTransformer().transform(tree)
+    data = JSONTransformer(include_pos).transform(tree)
     return json.dumps(data, indent=2, sort_keys=True)
 
 
@@ -286,7 +294,7 @@ def print_prog(prog):
 # Command-line entry points.
 
 def bril2json():
-    print(parse_bril(sys.stdin.read()))
+    print(parse_bril(sys.stdin.read(), '-p' in sys.argv[1:]))
 
 
 def bril2txt():

--- a/bril-txt/briltxt.py
+++ b/bril-txt/briltxt.py
@@ -146,6 +146,8 @@ class JSONTransformer(lark.Transformer):
         if type:
             out['type'] = type
         out.update(op)
+        if self.include_pos:
+            out['pos'] = _pos(dest)
         return out
 
     def op(self, items):

--- a/bril-txt/briltxt.py
+++ b/bril-txt/briltxt.py
@@ -62,6 +62,11 @@ COMMENT: /#.*/
 """.strip()
 
 
+def _pos(token):
+    """Generate a position dict from a Lark token."""
+    return {'row': token.line, 'col': token.column}
+
+
 class JSONTransformer(lark.Transformer):
     def __init__(self, include_pos=False):
         super().__init__()
@@ -92,7 +97,7 @@ class JSONTransformer(lark.Transformer):
         if typ:
             func['type'] = typ
         if self.include_pos:
-            func['pos'] = {'row': name.line, 'col': name.column}
+            func['pos'] = _pos(name)
         return func
 
     def arg(self, items):
@@ -132,7 +137,7 @@ class JSONTransformer(lark.Transformer):
         if type:
             out['type'] = type
         if self.include_pos:
-            out['pos'] = {'row': dest.line, 'col': dest.column}
+            out['pos'] = _pos(dest)
         return out
 
     def vop(self, items):
@@ -166,7 +171,7 @@ class JSONTransformer(lark.Transformer):
         if labels:
             out['labels'] = labels
         if self.include_pos:
-            out['pos'] = {'row': op_token.line, 'col': op_token.column}
+            out['pos'] = _pos(op_token)
         return out
 
     def eop(self, items):
@@ -179,7 +184,7 @@ class JSONTransformer(lark.Transformer):
             'label': str(name)[1:]  # Strip `.`.
         }
         if self.include_pos:
-            out['pos'] = {'row': name.line, 'col': name.column}
+            out['pos'] = _pos(name)
         return out
 
     def int(self, items):

--- a/bril-txt/briltxt.py
+++ b/bril-txt/briltxt.py
@@ -131,6 +131,8 @@ class JSONTransformer(lark.Transformer):
         }
         if type:
             out['type'] = type
+        if self.include_pos:
+            out['pos'] = {'row': dest.line, 'col': dest.column}
         return out
 
     def vop(self, items):

--- a/bril-txt/briltxt.py
+++ b/bril-txt/briltxt.py
@@ -136,7 +136,9 @@ class JSONTransformer(lark.Transformer):
         return out
 
     def op(self, items):
-        opcode = str(items.pop(0))
+        op_token = items.pop(0)
+        row, col = op_token.line, op_token.column
+        opcode = str(op_token)
 
         funcs = []
         labels = []
@@ -156,6 +158,8 @@ class JSONTransformer(lark.Transformer):
             out['funcs'] = funcs
         if labels:
             out['labels'] = labels
+        if True:
+            out['pos'] = {'row': row, 'col': col}
         return out
 
     def eop(self, items):

--- a/bril-txt/briltxt.py
+++ b/bril-txt/briltxt.py
@@ -91,6 +91,8 @@ class JSONTransformer(lark.Transformer):
             func['args'] = args
         if typ:
             func['type'] = typ
+        if self.include_pos:
+            func['pos'] = {'row': name.line, 'col': name.column}
         return func
 
     def arg(self, items):

--- a/bril-txt/briltxt.py
+++ b/bril-txt/briltxt.py
@@ -141,7 +141,6 @@ class JSONTransformer(lark.Transformer):
 
     def op(self, items):
         op_token = items.pop(0)
-        row, col = op_token.line, op_token.column
         opcode = str(op_token)
 
         funcs = []
@@ -163,7 +162,7 @@ class JSONTransformer(lark.Transformer):
         if labels:
             out['labels'] = labels
         if self.include_pos:
-            out['pos'] = {'row': row, 'col': col}
+            out['pos'] = {'row': op_token.line, 'col': op_token.column}
         return out
 
     def eop(self, items):
@@ -172,9 +171,12 @@ class JSONTransformer(lark.Transformer):
 
     def label(self, items):
         name, = items
-        return {
+        out = {
             'label': str(name)[1:]  # Strip `.`.
         }
+        if self.include_pos:
+            out['pos'] = {'row': name.line, 'col': name.column}
+        return out
 
     def int(self, items):
         return int(str(items[0]))

--- a/docs/lang/syntax.md
+++ b/docs/lang/syntax.md
@@ -130,4 +130,4 @@ All syntax objects can optionally have a `pos` field to reflect a source positio
 
 The `pos` object has two keys: `row` (the line number) and `col` (the column number within the line).
 Front-end compilers that generate Bril code may add this information to help with debugging, but tools can't require it to exist (or to follow any specific rules).
-The [text format parser](tools/text.md), for example, can optionally add source positions.
+The [text format parser](../tools/text.md), for example, can optionally add source positions.

--- a/docs/lang/syntax.md
+++ b/docs/lang/syntax.md
@@ -120,3 +120,14 @@ In all three cases, these keys may be missing and the semantics are identical to
 
 An Effect Operation is like a Value Operation but it does not produce a value.
 It also has the optional `args`, `funcs`, and `labels` fields.
+
+Source Positions
+----------------
+
+All syntax objects can optionally have a `pos` field to reflect a source position:
+
+    { ..., "pos": {"row": <int>, "col": <int>} }
+
+The `pos` object has two keys: `row` (the line number) and `col` (the column number within the line).
+Front-end compilers that generate Bril code may add this information to help with debugging, but tools can't require it to exist (or to follow any specific rules).
+The [text format parser](tools/text.md), for example, can optionally add source positions.

--- a/docs/lang/syntax.md
+++ b/docs/lang/syntax.md
@@ -124,10 +124,11 @@ It also has the optional `args`, `funcs`, and `labels` fields.
 Source Positions
 ----------------
 
-All syntax objects can optionally have a `pos` field to reflect a source position:
+Any syntax object may optionally have a `pos` field to reflect a source position:
 
     { ..., "pos": {"row": <int>, "col": <int>} }
 
 The `pos` object has two keys: `row` (the line number) and `col` (the column number within the line).
-Front-end compilers that generate Bril code may add this information to help with debugging, but tools can't require it to exist (or to follow any specific rules).
+Front-end compilers that generate Bril code may add this information to help with debugging.
 The [text format parser](../tools/text.md), for example, can optionally add source positions.
+However, tools can't require positions to exist, to consistently exist or not on all syntax objects in a program, or to follow any particular rules.

--- a/docs/tools/text.md
+++ b/docs/tools/text.md
@@ -31,3 +31,24 @@ Gets represented in text like this:
       v3: ptr<int> = alloc v0;
       free v3;
     }
+
+Tools
+-----
+
+[The `bril-txt` parser & pretty printer][briltxt] are written in Python.
+You can install them with [Flit][] by doing something like:
+
+    $ pip install --user flit
+    $ cd bril-txt
+    $ flit install --symlink --user
+
+You'll now have tools called `bril2json` and `bril2txt`.
+Both read from standard input and write to standard output.
+You can try a "round trip" like this, for example:
+
+    $ bril2json < test/parse/add.bril | bril2txt
+
+The `bril2json` parser also supports a `-p` flag to include [source positions](../lang/syntax.md#source-positions).
+
+[flit]: https://flit.readthedocs.io/
+[briltxt]: https://github.com/sampsyo/bril/blob/main/bril-txt/briltxt.py

--- a/test/parse/positions.bril
+++ b/test/parse/positions.bril
@@ -1,0 +1,9 @@
+# ARGS: -p
+@main {
+  v0: int = const 1;
+  v1: int = const 2;
+  jmp .label;
+.label:
+  v2: int = add v0 v1;
+  print v2;
+}

--- a/test/parse/positions.json
+++ b/test/parse/positions.json
@@ -47,7 +47,7 @@
           "dest": "v2",
           "op": "add",
           "pos": {
-            "col": 13,
+            "col": 3,
             "row": 7
           },
           "type": "int"

--- a/test/parse/positions.json
+++ b/test/parse/positions.json
@@ -1,0 +1,65 @@
+{
+  "functions": [
+    {
+      "instrs": [
+        {
+          "dest": "v0",
+          "op": "const",
+          "type": "int",
+          "value": 1
+        },
+        {
+          "dest": "v1",
+          "op": "const",
+          "type": "int",
+          "value": 2
+        },
+        {
+          "labels": [
+            "label"
+          ],
+          "op": "jmp",
+          "pos": {
+            "col": 3,
+            "row": 5
+          }
+        },
+        {
+          "label": "label",
+          "pos": {
+            "col": 1,
+            "row": 6
+          }
+        },
+        {
+          "args": [
+            "v0",
+            "v1"
+          ],
+          "dest": "v2",
+          "op": "add",
+          "pos": {
+            "col": 13,
+            "row": 7
+          },
+          "type": "int"
+        },
+        {
+          "args": [
+            "v2"
+          ],
+          "op": "print",
+          "pos": {
+            "col": 3,
+            "row": 8
+          }
+        }
+      ],
+      "name": "main",
+      "pos": {
+        "col": 1,
+        "row": 2
+      }
+    }
+  ]
+}

--- a/test/parse/positions.json
+++ b/test/parse/positions.json
@@ -5,12 +5,20 @@
         {
           "dest": "v0",
           "op": "const",
+          "pos": {
+            "col": 3,
+            "row": 3
+          },
           "type": "int",
           "value": 1
         },
         {
           "dest": "v1",
           "op": "const",
+          "pos": {
+            "col": 3,
+            "row": 4
+          },
           "type": "int",
           "value": 2
         },

--- a/test/parse/turnt.toml
+++ b/test/parse/turnt.toml
@@ -1,2 +1,2 @@
-command = "bril2json < {filename}"
+command = "bril2json {args} < {filename}"
 output.json = "-"


### PR DESCRIPTION
This adds very simple optional source positions to Bril programs in their native JSON representation. The objects for all AST nodes (functions, labels, instructions…) can optionally include a `pos` object, which has two keys: `row` and `col`. The idea is sort of in service of #155, i.e., giving better error messages in a static type checker. However, the reference interpreter could consider supporting these too for better error messages.

I documented this optional feature in the language reference. I also added support to the `bril2json` parser: positions are off by default, and a new `-p` flag enables them. As a bonus, I expanded the docs for the text format to include actual instructions about how to install and use the tools.

Of course, there are no semantics attached to the actual source position values—other front-end compilers beyond `bril2json` could just as easily associate *their* source language's positions with Bril AST nodes.