### PR TITLE
Adding positions support to bril-rs and brilirs

### DIFF
--- a/bril-rs/Cargo.toml
+++ b/bril-rs/Cargo.toml
@@ -16,6 +16,7 @@ float = []
 memory = []
 ssa = []
 speculate = []
+position = []
 
 [[example]]
 name = "bril2txt"
@@ -24,10 +25,10 @@ path = "examples/bril2txt.rs"
 # However this currently does not work as expected and is being hashed out in https://github.com/rust-lang/rfcs/pull/3020 and https://github.com/rust-lang/rfcs/pull/2887
 # Until a solution is reached, I'm using `required-features` so that these features must be passed by flag. This is less ergonomic at the moment, however the user will get a nicer error that they need a feature flag instead of an Result::unwrap() error.
 # Note: See dev-dependencies for a hack to not need the user to pass that feature flag.
-required-features = ["memory", "float", "ssa", "speculate"]
+required-features = ["memory", "float", "ssa", "speculate", "position"]
 
 [dev-dependencies]
 # trick to enable all features in test
 # This is actually really hacky because it is used in all tests/examples/benchmarks but since we currently only have one example this works for enabling the following feature flags for our users.
 # If the above rfcs every get resolved, then dev-dependencies will no longer be needed.
-bril-rs = { path = ".", features = ["memory", "float", "ssa", "speculate"] }
+bril-rs = { path = ".", features = ["memory", "float", "ssa", "speculate", "position"] }

--- a/bril-rs/Makefile
+++ b/bril-rs/Makefile
@@ -4,3 +4,14 @@ TESTS :=  ../test/print/*.json \
 .PHONY: test
 test:
 	turnt --diff -c turnt_bril_rs.toml $(TESTS)
+
+.PHONY: install
+install:
+	cargo install --path . --example bril2txt
+	cargo install --path ./bril2json
+
+# As more features are added it can be difficult to know if any of them conflict or haven't been appropriately guarded. This command runs cargo check with all possible combinations of feature flags to catch any breakages. Normally you would have to be careful of 2^N explosion but bril-rs builds so fast that this is currently not an issue.
+# cargo install cargo-hack
+.PHONY: features
+features:
+	cargo hack check --feature-powerset --no-dev-deps

--- a/bril-rs/bril2json/Cargo.toml
+++ b/bril-rs/bril2json/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+clap         = { version = "3.0", features = ["derive"] }
 lalrpop-util = {version = "0.19.6", features = ["lexer"]}
 regex = "1"
 
@@ -17,4 +18,4 @@ lalrpop = "0.19.6"
 [dependencies.bril-rs]
 version = "0.1.0"
 path = "../../bril-rs"
-features = ["ssa", "memory", "float", "speculate"]
+features = ["ssa", "memory", "float", "speculate", "position"]

--- a/bril-rs/bril2json/src/bril_grammar.lalrpop
+++ b/bril-rs/bril2json/src/bril_grammar.lalrpop
@@ -5,11 +5,24 @@
 #![allow(clippy::new_without_default)]
 #![allow(clippy::deprecated_cfg_attr)]
 #![allow(clippy::single_char_pattern)]
+#![allow(clippy::no_effect_underscore_binding)]
+#![allow(clippy::unnested_or_patterns)]
+#![allow(clippy::missing_errors_doc)]
+#![allow(clippy::trivially_copy_pass_by_ref)]
+#![allow(clippy::missing_const_for_fn)]
+#![allow(clippy::unnecessary_wraps)]
+#![allow(clippy::redundant_pub_crate)]
+#![allow(clippy::cloned_instead_of_copied)]
+#![allow(clippy::too_many_lines)]
+#![allow(clippy::use_self)]
+#![allow(clippy::needless_pass_by_value)]
+#![allow(clippy::cast_sign_loss)]
 
 use std::str::FromStr;
+use crate::Lines;
 use bril_rs::{AbstractProgram, AbstractFunction, AbstractArgument, AbstractCode, AbstractInstruction, ConstOps, AbstractType, Literal};
 
-grammar;
+grammar(lines : &Lines);
 
 match {
     r"\.(_|%|[A-Za-z])(_|%|\.|[A-Za-z]|[0-9])*", // label
@@ -31,11 +44,12 @@ pub AbstractProgram : AbstractProgram = {
 }
 
 AbstractFunction : AbstractFunction = {
-    <f: Func> <a: (Argument_List)?> <t:OutputType?> "{" <c :(<AbstractCode>)*> "}" => {let a = a.unwrap_or_default(); AbstractFunction {
+    <loc:@L> <f: Func> <a: (Argument_List)?> <t:OutputType?> "{" <c :(<AbstractCode>)*> "}" => {let a = a.unwrap_or_default(); AbstractFunction {
         name : f,
         args : a,
         return_type : t,
         instrs: c,
+        pos : lines.get_position(loc),
     }}
 }
 
@@ -55,27 +69,29 @@ AbstractArgument : AbstractArgument = {
 }
 
 AbstractCode : AbstractCode = {
-    <l: Label> ":" => AbstractCode::Label{ label : l},
+    <loc:@L> <l: Label> ":" => AbstractCode::Label{ label : l, pos : lines.get_position(loc)},
     <i: AbstractInstruction> => AbstractCode::Instruction(i),
 }
 
 AbstractInstruction : AbstractInstruction = {
-    <i:Ident> ":" <t: AbstractType> "=" <c: ConstOps> <l: Literal> ";" => AbstractInstruction::Constant {
+    <loc:@L> <i:Ident> ":" <t: AbstractType> "=" <c: ConstOps> <l: Literal> ";" => AbstractInstruction::Constant {
         op : c,
         dest : i,
         const_type : t,
         value : l,
+        pos : lines.get_position(loc),
     },
-    <i:Ident> ":" <t:AbstractType> "=" <v:Ident> <f :(<Args>)*> ";" => {
+    <loc:@L> <i:Ident> ":" <t:AbstractType> "=" <v:Ident> <f :(<Args>)*> ";" => {
         let mut a_vec = Vec::new();
         let mut f_vec = Vec::new();
         let mut l_vec = Vec::new();
-        f.into_iter().for_each(|x|
+        for x in f {
             if x.starts_with("@") {
-                f_vec.push(x.strip_prefix("@").unwrap().to_owned())
+                f_vec.push(x.strip_prefix("@").unwrap().to_owned());
             } else if x.starts_with(".") {
-                l_vec.push(x.strip_prefix(".").unwrap().to_owned())
-            } else {a_vec.push(x)});
+                l_vec.push(x.strip_prefix(".").unwrap().to_owned());
+            } else {a_vec.push(x);}
+        }
         AbstractInstruction::Value {
             op: v,
             dest: i,
@@ -83,23 +99,26 @@ AbstractInstruction : AbstractInstruction = {
             args: a_vec,
             funcs: f_vec,
             labels: l_vec,
+            pos : lines.get_position(loc),
         }
     },
-    <e:Ident> <f :(<Args>)*> ";" => {
+    <loc:@L> <e:Ident> <f :(<Args>)*> ";" => {
         let mut a_vec = Vec::new();
         let mut f_vec = Vec::new();
         let mut l_vec = Vec::new();
-        f.into_iter().for_each(|x|
+        for x in f {
             if x.starts_with("@") {
-                f_vec.push(x.strip_prefix("@").unwrap().to_owned())
+                f_vec.push(x.strip_prefix("@").unwrap().to_owned());
             } else if x.starts_with(".") {
-                l_vec.push(x.strip_prefix(".").unwrap().to_owned())
-            } else {a_vec.push(x)});
+                l_vec.push(x.strip_prefix(".").unwrap().to_owned());
+            } else {a_vec.push(x);}
+        }
         AbstractInstruction::Effect {
             op: e,
             args: a_vec,
             funcs: f_vec,
             labels: l_vec,
+            pos : lines.get_position(loc),
         }
     }
 

--- a/bril-rs/bril2json/src/bril_grammar.lalrpop
+++ b/bril-rs/bril2json/src/bril_grammar.lalrpop
@@ -74,14 +74,14 @@ AbstractCode : AbstractCode = {
 }
 
 AbstractInstruction : AbstractInstruction = {
-    <loc:@L> <i:Ident> ":" <t: AbstractType> "=" <c: ConstOps> <l: Literal> ";" => AbstractInstruction::Constant {
+    <loc:@L> <i:Ident> ":" <t: AbstractType?> "=" <c: ConstOps> <l: Literal> ";" => AbstractInstruction::Constant {
         op : c,
         dest : i,
         const_type : t,
         value : l,
         pos : lines.get_position(loc),
     },
-    <loc:@L> <i:Ident> ":" <t:AbstractType> "=" <v:Ident> <f :(<Args>)*> ";" => {
+    <loc:@L> <i:Ident> ":" <t:AbstractType?> "=" <v:Ident> <f :(<Args>)*> ";" => {
         let mut a_vec = Vec::new();
         let mut f_vec = Vec::new();
         let mut l_vec = Vec::new();

--- a/bril-rs/bril2json/src/bril_grammar.lalrpop
+++ b/bril-rs/bril2json/src/bril_grammar.lalrpop
@@ -74,14 +74,14 @@ AbstractCode : AbstractCode = {
 }
 
 AbstractInstruction : AbstractInstruction = {
-    <loc:@L> <i:Ident> ":" <t: AbstractType?> "=" <c: ConstOps> <l: Literal> ";" => AbstractInstruction::Constant {
+    <loc:@L> <i:Ident> <t:(":" <AbstractType>)?> "=" <c: ConstOps> <l: Literal> ";" => AbstractInstruction::Constant {
         op : c,
         dest : i,
         const_type : t,
         value : l,
         pos : lines.get_position(loc),
     },
-    <loc:@L> <i:Ident> ":" <t:AbstractType?> "=" <v:Ident> <f :(<Args>)*> ";" => {
+    <loc:@L> <i:Ident> <t:(":" <AbstractType>)?> "=" <v:Ident> <f :(<Args>)*> ";" => {
         let mut a_vec = Vec::new();
         let mut f_vec = Vec::new();
         let mut l_vec = Vec::new();

--- a/bril-rs/bril2json/src/cli.rs
+++ b/bril-rs/bril2json/src/cli.rs
@@ -1,0 +1,9 @@
+use clap::Parser;
+
+#[derive(Parser)]
+#[clap(about, version, author)] // keeps the cli synced with Cargo.toml
+pub struct Cli {
+    /// Flag for whether position information should be included
+    #[clap(short)]
+    pub position: bool,
+}

--- a/bril-rs/bril2json/src/lib.rs
+++ b/bril-rs/bril2json/src/lib.rs
@@ -1,13 +1,65 @@
-pub mod bril_grammar;
-use bril_rs::AbstractProgram;
+#![warn(clippy::all, clippy::pedantic, clippy::nursery, clippy::cargo)]
+// todo these are allowed to appease clippy but should be addressed some day
+#![allow(clippy::must_use_candidate)]
+#![allow(clippy::missing_panics_doc)]
+#![allow(clippy::cargo_common_metadata)]
 
-pub fn load_abstract_program_from_read<R: std::io::Read>(mut input: R) -> AbstractProgram {
+pub mod bril_grammar;
+pub mod cli;
+use bril_rs::{AbstractProgram, Position};
+
+#[derive(Clone)]
+pub struct Lines {
+    use_pos: bool,
+    new_lines: Vec<usize>,
+}
+
+impl Lines {
+    fn new(input: &str, use_pos: bool) -> Self {
+        Self {
+            use_pos,
+            new_lines: input
+                .as_bytes()
+                .iter()
+                .enumerate()
+                .filter_map(|(idx, b)| if *b == b'\n' { Some(idx) } else { None })
+                .collect(),
+        }
+    }
+
+    fn get_position(&self, index: usize) -> Option<Position> {
+        if self.use_pos {
+            Some(self.new_lines.iter().enumerate().fold(
+                Position { col: 1, row: 0 },
+                |current, (line_num, idx)| {
+                    if *idx < index {
+                        Position {
+                            row: (line_num + 2) as u64,
+                            col: (index - idx) as u64,
+                        }
+                    } else {
+                        current
+                    }
+                },
+            ))
+        } else {
+            None
+        }
+    }
+}
+
+pub fn load_abstract_program_from_read<R: std::io::Read>(
+    mut input: R,
+    use_pos: bool,
+) -> AbstractProgram {
     let mut buffer = String::new();
     input.read_to_string(&mut buffer).unwrap();
     let parser = bril_grammar::AbstractProgramParser::new();
-    parser.parse(&buffer).unwrap()
+    parser
+        .parse(&Lines::new(&buffer, use_pos), &buffer)
+        .unwrap()
 }
 
-pub fn load_abstract_program() -> AbstractProgram {
-    load_abstract_program_from_read(std::io::stdin())
+pub fn load_abstract_program(use_pos: bool) -> AbstractProgram {
+    load_abstract_program_from_read(std::io::stdin(), use_pos)
 }

--- a/bril-rs/bril2json/src/lib.rs
+++ b/bril-rs/bril2json/src/lib.rs
@@ -48,7 +48,7 @@ impl Lines {
     }
 }
 
-pub fn load_abstract_program_from_read<R: std::io::Read>(
+pub fn parse_abstract_program_from_read<R: std::io::Read>(
     mut input: R,
     use_pos: bool,
 ) -> AbstractProgram {
@@ -60,6 +60,6 @@ pub fn load_abstract_program_from_read<R: std::io::Read>(
         .unwrap()
 }
 
-pub fn load_abstract_program(use_pos: bool) -> AbstractProgram {
-    load_abstract_program_from_read(std::io::stdin(), use_pos)
+pub fn parse_abstract_program(use_pos: bool) -> AbstractProgram {
+    parse_abstract_program_from_read(std::io::stdin(), use_pos)
 }

--- a/bril-rs/bril2json/src/main.rs
+++ b/bril-rs/bril2json/src/main.rs
@@ -1,6 +1,9 @@
+use bril2json::cli::Cli;
 use bril2json::load_abstract_program;
 use bril_rs::output_abstract_program;
+use clap::Parser;
 
 fn main() {
-    output_abstract_program(&load_abstract_program())
+    let args = Cli::parse();
+    output_abstract_program(&load_abstract_program(args.position))
 }

--- a/bril-rs/src/abstract_program.rs
+++ b/bril-rs/src/abstract_program.rs
@@ -114,7 +114,7 @@ pub enum AbstractInstruction {
         #[serde(skip_serializing_if = "Option::is_none")]
         pos: Option<Position>,
         #[serde(rename = "type")]
-        const_type: AbstractType,
+        const_type: Option<AbstractType>,
         value: Literal,
     },
     Value {
@@ -130,7 +130,7 @@ pub enum AbstractInstruction {
         #[serde(skip_serializing_if = "Option::is_none")]
         pos: Option<Position>,
         #[serde(rename = "type")]
-        op_type: AbstractType,
+        op_type: Option<AbstractType>,
     },
     Effect {
         #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -156,9 +156,10 @@ impl Display for AbstractInstruction {
                 value,
                 #[cfg(feature = "position")]
                     pos: _,
-            } => {
-                write!(f, "{}: {} = {} {};", dest, const_type, op, value)
-            }
+            } => match const_type {
+                Some(const_type) => write!(f, "{}: {} = {} {};", dest, const_type, op, value),
+                None => write!(f, "{} = {} {};", dest, op, value),
+            },
             AbstractInstruction::Value {
                 op,
                 dest,
@@ -169,7 +170,10 @@ impl Display for AbstractInstruction {
                 #[cfg(feature = "position")]
                     pos: _,
             } => {
-                write!(f, "{}: {} = {}", dest, op_type, op)?;
+                match op_type {
+                    Some(op_type) => write!(f, "{}: {} = {}", dest, op_type, op)?,
+                    None => write!(f, "{} = {}", dest, op)?,
+                }
                 for func in funcs {
                     write!(f, " @{}", func)?;
                 }

--- a/bril-rs/src/conversion.rs
+++ b/bril-rs/src/conversion.rs
@@ -42,6 +42,8 @@ impl TryFrom<AbstractFunction> for Function {
             instrs,
             name,
             return_type,
+            #[cfg(feature = "position")]
+            pos,
         }: AbstractFunction,
     ) -> Result<Self, Self::Error> {
         Ok(Self {
@@ -58,6 +60,8 @@ impl TryFrom<AbstractFunction> for Function {
                 None => None,
                 Some(t) => Some(t.try_into()?),
             },
+            #[cfg(feature = "position")]
+            pos,
         })
     }
 }
@@ -78,7 +82,15 @@ impl TryFrom<AbstractCode> for Code {
     type Error = ConversionError;
     fn try_from(c: AbstractCode) -> Result<Self, Self::Error> {
         Ok(match c {
-            AbstractCode::Label { label } => Self::Label { label },
+            AbstractCode::Label {
+                label,
+                #[cfg(feature = "position")]
+                pos,
+            } => Self::Label {
+                label,
+                #[cfg(feature = "position")]
+                pos,
+            },
             AbstractCode::Instruction(i) => Self::Instruction(i.try_into()?),
         })
     }
@@ -93,11 +105,15 @@ impl TryFrom<AbstractInstruction> for Instruction {
                 op,
                 const_type,
                 value,
+                #[cfg(feature = "position")]
+                pos,
             } => Self::Constant {
                 dest,
                 op,
                 const_type: const_type.try_into()?,
                 value,
+                #[cfg(feature = "position")]
+                pos,
             },
             AbstractInstruction::Value {
                 args,
@@ -106,12 +122,16 @@ impl TryFrom<AbstractInstruction> for Instruction {
                 labels,
                 op,
                 op_type,
+                #[cfg(feature = "position")]
+                pos,
             } => Self::Value {
                 args,
                 dest,
                 funcs,
                 labels,
                 op_type: op_type.try_into()?,
+                #[cfg(feature = "position")]
+                pos,
                 op: match op.as_ref() {
                     "add" => ValueOps::Add,
                     "mul" => ValueOps::Mul,
@@ -161,10 +181,14 @@ impl TryFrom<AbstractInstruction> for Instruction {
                 funcs,
                 labels,
                 op,
+                #[cfg(feature = "position")]
+                pos,
             } => Self::Effect {
                 args,
                 funcs,
                 labels,
+                #[cfg(feature = "position")]
+                pos,
                 op: match op.as_ref() {
                     "jmp" => EffectOps::Jump,
                     "br" => EffectOps::Branch,

--- a/bril-rs/src/conversion.rs
+++ b/bril-rs/src/conversion.rs
@@ -1,9 +1,17 @@
+use std::fmt::Display;
+
 use crate::{
     AbstractArgument, AbstractCode, AbstractFunction, AbstractInstruction, AbstractProgram,
-    AbstractType, Argument, Code, EffectOps, Function, Instruction, Program, Type, ValueOps,
+    AbstractType, Argument, Code, EffectOps, Function, Instruction, Position, Program, Type,
+    ValueOps,
 };
 
 use thiserror::Error;
+
+// This is a nifty trick to supply a global value for pos when it is not defined
+#[cfg(not(feature = "position"))]
+#[allow(non_upper_case_globals)]
+const pos: Option<Position> = None;
 
 // Having the #[error(...)] for all variants derives the Display trait as well
 #[derive(Error, Debug)]
@@ -20,10 +28,56 @@ pub enum ConversionError {
 
     #[error("Expected an effect operation, found {0}")]
     InvalidEffectOps(String),
+
+    #[error("Missing type signature")]
+    MissingType,
+}
+
+impl ConversionError {
+    pub fn add_pos(self, pos_var: Option<Position>) -> PositionalConversionError {
+        match self {
+            //Self::PositionalConversionErrorConversion(e) => e,
+            _ => PositionalConversionError {
+                e: Box::new(self),
+                pos: pos_var,
+            },
+        }
+    }
+}
+
+#[derive(Error, Debug)]
+pub struct PositionalConversionError {
+    e: Box<ConversionError>,
+    pos: Option<Position>,
+}
+
+impl PositionalConversionError {
+    pub fn new(e: ConversionError) -> Self {
+        Self {
+            e: Box::new(e),
+            pos: None,
+        }
+    }
+}
+
+impl Display for PositionalConversionError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            #[cfg(feature = "position")]
+            PositionalConversionError { e, pos: Some(pos) } => {
+                write!(f, "Line {}, Column {}: {}", pos.row, pos.col, e)
+            }
+            #[cfg(not(feature = "position"))]
+            PositionalConversionError { e: _, pos: Some(_) } => {
+                unreachable!()
+            }
+            PositionalConversionError { e, pos: None } => write!(f, "{}", e),
+        }
+    }
 }
 
 impl TryFrom<AbstractProgram> for Program {
-    type Error = ConversionError;
+    type Error = PositionalConversionError;
     fn try_from(AbstractProgram { functions }: AbstractProgram) -> Result<Self, Self::Error> {
         Ok(Self {
             functions: functions
@@ -35,7 +89,7 @@ impl TryFrom<AbstractProgram> for Program {
 }
 
 impl TryFrom<AbstractFunction> for Function {
-    type Error = ConversionError;
+    type Error = PositionalConversionError;
     fn try_from(
         AbstractFunction {
             args,
@@ -50,7 +104,8 @@ impl TryFrom<AbstractFunction> for Function {
             args: args
                 .into_iter()
                 .map(std::convert::TryInto::try_into)
-                .collect::<Result<Vec<Argument>, _>>()?,
+                .collect::<Result<Vec<Argument>, _>>()
+                .map_err(|e| e.add_pos(pos))?,
             instrs: instrs
                 .into_iter()
                 .map(std::convert::TryInto::try_into)
@@ -58,7 +113,7 @@ impl TryFrom<AbstractFunction> for Function {
             name,
             return_type: match return_type {
                 None => None,
-                Some(t) => Some(t.try_into()?),
+                Some(t) => Some(t.try_into().map_err(|e: ConversionError| e.add_pos(pos))?),
             },
             #[cfg(feature = "position")]
             pos,
@@ -79,7 +134,7 @@ impl TryFrom<AbstractArgument> for Argument {
 }
 
 impl TryFrom<AbstractCode> for Code {
-    type Error = ConversionError;
+    type Error = PositionalConversionError;
     fn try_from(c: AbstractCode) -> Result<Self, Self::Error> {
         Ok(match c {
             AbstractCode::Label {
@@ -97,7 +152,7 @@ impl TryFrom<AbstractCode> for Code {
 }
 
 impl TryFrom<AbstractInstruction> for Instruction {
-    type Error = ConversionError;
+    type Error = PositionalConversionError;
     fn try_from(i: AbstractInstruction) -> Result<Self, Self::Error> {
         Ok(match i {
             AbstractInstruction::Constant {
@@ -110,7 +165,9 @@ impl TryFrom<AbstractInstruction> for Instruction {
             } => Self::Constant {
                 dest,
                 op,
-                const_type: const_type.try_into()?,
+                const_type: const_type
+                    .try_into()
+                    .map_err(|e: ConversionError| e.add_pos(pos))?,
                 value,
                 #[cfg(feature = "position")]
                 pos,
@@ -129,7 +186,9 @@ impl TryFrom<AbstractInstruction> for Instruction {
                 dest,
                 funcs,
                 labels,
-                op_type: op_type.try_into()?,
+                op_type: op_type
+                    .try_into()
+                    .map_err(|e: ConversionError| e.add_pos(pos))?,
                 #[cfg(feature = "position")]
                 pos,
                 op: match op.as_ref() {
@@ -173,7 +232,10 @@ impl TryFrom<AbstractInstruction> for Instruction {
                     "load" => ValueOps::Load,
                     #[cfg(feature = "memory")]
                     "ptradd" => ValueOps::PtrAdd,
-                    v => return Err(ConversionError::InvalidValueOps(v.to_string())),
+                    v => {
+                        return Err(ConversionError::InvalidValueOps(v.to_string()))
+                            .map_err(|e| e.add_pos(pos))
+                    }
                 },
             },
             AbstractInstruction::Effect {
@@ -206,10 +268,24 @@ impl TryFrom<AbstractInstruction> for Instruction {
                     "commit" => EffectOps::Commit,
                     #[cfg(feature = "speculate")]
                     "guard" => EffectOps::Guard,
-                    e => return Err(ConversionError::InvalidEffectOps(e.to_string())),
+                    e => {
+                        return Err(ConversionError::InvalidEffectOps(e.to_string()))
+                            .map_err(|e| e.add_pos(pos))
+                    }
                 },
             },
         })
+    }
+}
+
+impl TryFrom<Option<AbstractType>> for Type {
+    type Error = ConversionError;
+
+    fn try_from(value: Option<AbstractType>) -> Result<Self, Self::Error> {
+        match value {
+            Some(t) => t.try_into(),
+            None => Err(ConversionError::MissingType),
+        }
     }
 }
 

--- a/bril-rs/src/lib.rs
+++ b/bril-rs/src/lib.rs
@@ -4,6 +4,7 @@
 #![allow(clippy::missing_panics_doc)]
 #![allow(clippy::must_use_candidate)]
 #![allow(clippy::cargo_common_metadata)]
+#![allow(clippy::too_many_lines)]
 
 pub mod conversion;
 pub mod program;

--- a/bril-rs/src/program.rs
+++ b/bril-rs/src/program.rs
@@ -23,6 +23,9 @@ pub struct Function {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub instrs: Vec<Code>,
     pub name: String,
+    #[cfg(feature = "position")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pos: Option<Position>,
     #[serde(rename = "type")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub return_type: Option<Type>,
@@ -69,14 +72,23 @@ impl Display for Argument {
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 #[serde(untagged)]
 pub enum Code {
-    Label { label: String },
+    Label {
+        label: String,
+        #[cfg(feature = "position")]
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pos: Option<Position>,
+    },
     Instruction(Instruction),
 }
 
 impl Display for Code {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
-            Code::Label { label } => write!(f, ".{}:", label),
+            Code::Label {
+                label,
+                #[cfg(feature = "position")]
+                    pos: _,
+            } => write!(f, ".{}:", label),
             Code::Instruction(instr) => write!(f, "  {}", instr),
         }
     }
@@ -88,6 +100,9 @@ pub enum Instruction {
     Constant {
         dest: String,
         op: ConstOps,
+        #[cfg(feature = "position")]
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pos: Option<Position>,
         #[serde(rename = "type")]
         const_type: Type,
         value: Literal,
@@ -101,6 +116,9 @@ pub enum Instruction {
         #[serde(default, skip_serializing_if = "Vec::is_empty")]
         labels: Vec<String>,
         op: ValueOps,
+        #[cfg(feature = "position")]
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pos: Option<Position>,
         #[serde(rename = "type")]
         op_type: Type,
     },
@@ -112,6 +130,9 @@ pub enum Instruction {
         #[serde(default, skip_serializing_if = "Vec::is_empty")]
         labels: Vec<String>,
         op: EffectOps,
+        #[cfg(feature = "position")]
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pos: Option<Position>,
     },
 }
 
@@ -123,6 +144,8 @@ impl Display for Instruction {
                 dest,
                 const_type,
                 value,
+                #[cfg(feature = "position")]
+                    pos: _,
             } => {
                 write!(f, "{}: {} = {} {};", dest, const_type, op, value)
             }
@@ -133,6 +156,8 @@ impl Display for Instruction {
                 args,
                 funcs,
                 labels,
+                #[cfg(feature = "position")]
+                    pos: _,
             } => {
                 write!(f, "{}: {} = {}", dest, op_type, op)?;
                 for func in funcs {
@@ -151,6 +176,8 @@ impl Display for Instruction {
                 args,
                 funcs,
                 labels,
+                #[cfg(feature = "position")]
+                    pos: _,
             } => {
                 write!(f, "{}", op)?;
                 for func in funcs {
@@ -375,4 +402,10 @@ impl Literal {
             Literal::Float(_) => Type::Float,
         }
     }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+pub struct Position {
+    pub col: u64,
+    pub row: u64,
 }

--- a/bril-rs/src/program.rs
+++ b/bril-rs/src/program.rs
@@ -136,6 +136,17 @@ pub enum Instruction {
     },
 }
 
+#[cfg(feature = "position")]
+impl Instruction {
+    pub fn get_pos(&self) -> Option<Position> {
+        match self {
+            Instruction::Constant { pos, .. }
+            | Instruction::Value { pos, .. }
+            | Instruction::Effect { pos, .. } => *pos,
+        }
+    }
+}
+
 impl Display for Instruction {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
@@ -404,7 +415,7 @@ impl Literal {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq)]
 pub struct Position {
     pub col: u64,
     pub row: u64,

--- a/brilirs/src/basic_block.rs
+++ b/brilirs/src/basic_block.rs
@@ -1,4 +1,4 @@
-use bril_rs::{Function, Instruction, Program};
+use bril_rs::{Function, Instruction, Position, Program};
 use error::InterpError;
 use fxhash::FxHashMap;
 
@@ -116,6 +116,7 @@ pub struct BBFunction {
   // These replacements are found for function args and for code in the BasicBlocks
   pub num_of_vars: u32,
   pub args_as_nums: Vec<u32>,
+  pub pos: Option<Position>,
 }
 
 impl BBFunction {
@@ -141,7 +142,7 @@ impl BBFunction {
     let mut curr_block = BasicBlock::new();
     for instr in func.instrs.into_iter() {
       match instr {
-        bril_rs::Code::Label { label } => {
+        bril_rs::Code::Label { label, pos: _ } => {
           if !curr_block.instrs.is_empty() || curr_block.label.is_some() {
             if let Some(old_label) = curr_block.label.as_ref() {
               label_map.insert(old_label.to_string(), blocks.len());
@@ -156,6 +157,7 @@ impl BBFunction {
           args,
           funcs,
           labels,
+          pos,
         }) if op == bril_rs::EffectOps::Jump
           || op == bril_rs::EffectOps::Branch
           || op == bril_rs::EffectOps::Return =>
@@ -165,6 +167,7 @@ impl BBFunction {
             args,
             funcs,
             labels,
+            pos,
           };
           curr_block.numified_instrs.push(NumifiedInstruction::create(
             &i,
@@ -204,6 +207,7 @@ impl BBFunction {
         blocks,
         args_as_nums,
         num_of_vars,
+        pos: func.pos,
       },
       label_map,
     )

--- a/brilirs/src/check.rs
+++ b/brilirs/src/check.rs
@@ -1,4 +1,7 @@
-use crate::basic_block::{BBFunction, BBProgram};
+use crate::{
+  basic_block::{BBFunction, BBProgram},
+  error::PositionalInterpError,
+};
 use bril_rs::{ConstOps, EffectOps, Instruction, Type, ValueOps};
 
 use crate::error::InterpError;
@@ -91,6 +94,7 @@ fn type_check_instruction<'a>(
       dest,
       const_type,
       value,
+      pos: _,
     } => {
       if !(const_type == &Type::Float && value.get_type() == Type::Int) {
         check_asmt_type(const_type, &value.get_type())?;
@@ -104,6 +108,7 @@ fn type_check_instruction<'a>(
       args,
       funcs,
       labels,
+      pos: _,
     } => {
       check_num_args(2, args)?;
       check_num_funcs(0, funcs)?;
@@ -120,6 +125,7 @@ fn type_check_instruction<'a>(
       args,
       funcs,
       labels,
+      pos: _,
     } => {
       check_num_args(2, args)?;
       check_num_funcs(0, funcs)?;
@@ -136,6 +142,7 @@ fn type_check_instruction<'a>(
       args,
       funcs,
       labels,
+      pos: _,
     } => {
       check_num_args(1, args)?;
       check_num_funcs(0, funcs)?;
@@ -151,6 +158,7 @@ fn type_check_instruction<'a>(
       args,
       funcs,
       labels,
+      pos: _,
     } => {
       check_num_args(2, args)?;
       check_num_funcs(0, funcs)?;
@@ -167,6 +175,7 @@ fn type_check_instruction<'a>(
       args,
       funcs,
       labels,
+      pos: _,
     } => {
       check_num_args(1, args)?;
       check_num_funcs(0, funcs)?;
@@ -181,6 +190,7 @@ fn type_check_instruction<'a>(
       args,
       funcs,
       labels,
+      pos: _,
     } => {
       check_num_args(2, args)?;
       check_num_funcs(0, funcs)?;
@@ -197,6 +207,7 @@ fn type_check_instruction<'a>(
       args,
       funcs,
       labels,
+      pos: _,
     } => {
       check_num_args(2, args)?;
       check_num_funcs(0, funcs)?;
@@ -213,6 +224,7 @@ fn type_check_instruction<'a>(
       args,
       funcs,
       labels,
+      pos: _,
     } => {
       check_num_funcs(1, funcs)?;
       check_num_labels(0, labels)?;
@@ -248,6 +260,7 @@ fn type_check_instruction<'a>(
       args,
       funcs,
       labels,
+      pos: _,
     } => {
       if args.len() != labels.len() {
         return Err(InterpError::UnequalPhiNode);
@@ -266,6 +279,7 @@ fn type_check_instruction<'a>(
       args,
       funcs,
       labels,
+      pos: _,
     } => {
       check_num_args(1, args)?;
       check_num_funcs(0, funcs)?;
@@ -281,6 +295,7 @@ fn type_check_instruction<'a>(
       args,
       funcs,
       labels,
+      pos: _,
     } => {
       check_num_args(1, args)?;
       check_num_funcs(0, funcs)?;
@@ -296,6 +311,7 @@ fn type_check_instruction<'a>(
       args,
       funcs,
       labels,
+      pos: _,
     } => {
       check_num_args(2, args)?;
       check_num_funcs(0, funcs)?;
@@ -311,6 +327,7 @@ fn type_check_instruction<'a>(
       args,
       funcs,
       labels,
+      pos: _,
     } => {
       check_num_args(0, args)?;
       check_num_funcs(0, funcs)?;
@@ -322,6 +339,7 @@ fn type_check_instruction<'a>(
       args,
       funcs,
       labels,
+      pos: _,
     } => {
       check_num_args(1, args)?;
       check_asmt_type(&Type::Bool, get_type(env, 0, args)?)?;
@@ -334,6 +352,7 @@ fn type_check_instruction<'a>(
       args,
       funcs,
       labels,
+      pos: _,
     } => {
       check_num_funcs(0, funcs)?;
       check_num_labels(0, labels)?;
@@ -357,6 +376,7 @@ fn type_check_instruction<'a>(
       args,
       funcs,
       labels,
+      pos: _,
     } => {
       check_num_funcs(0, funcs)?;
       check_num_labels(0, labels)?;
@@ -370,6 +390,7 @@ fn type_check_instruction<'a>(
       args,
       funcs,
       labels,
+      pos: _,
     } => {
       check_num_args(0, args)?;
       check_num_funcs(0, funcs)?;
@@ -381,6 +402,7 @@ fn type_check_instruction<'a>(
       args,
       funcs,
       labels,
+      pos: _,
     } => {
       check_num_funcs(1, funcs)?;
       check_num_labels(0, labels)?;
@@ -414,6 +436,7 @@ fn type_check_instruction<'a>(
       args,
       funcs,
       labels,
+      pos: _,
     } => {
       check_num_args(2, args)?;
       check_num_funcs(0, funcs)?;
@@ -427,6 +450,7 @@ fn type_check_instruction<'a>(
       args,
       funcs,
       labels,
+      pos: _,
     } => {
       check_num_args(1, args)?;
       check_num_funcs(0, funcs)?;
@@ -439,13 +463,14 @@ fn type_check_instruction<'a>(
       args: _,
       funcs: _,
       labels: _,
+      pos: _,
     } => {
       unimplemented!()
     }
   }
 }
 
-fn type_check_func(bbfunc: &BBFunction, bbprog: &BBProgram) -> Result<(), InterpError> {
+fn type_check_func(bbfunc: &BBFunction, bbprog: &BBProgram) -> Result<(), PositionalInterpError> {
   let mut env: FxHashMap<&str, &Type> =
     FxHashMap::with_capacity_and_hasher(20, fxhash::FxBuildHasher::default());
   bbfunc.args.iter().for_each(|a| {
@@ -457,10 +482,9 @@ fn type_check_func(bbfunc: &BBFunction, bbprog: &BBProgram) -> Result<(), Interp
 
   while let Some(b) = work_list.pop() {
     let block = bbfunc.blocks.get(b).unwrap();
-    block
-      .instrs
-      .iter()
-      .try_for_each(|i| type_check_instruction(i, bbfunc, bbprog, &mut env))?;
+    block.instrs.iter().try_for_each(|i| {
+      type_check_instruction(i, bbfunc, bbprog, &mut env).map_err(|e| e.add_pos(i.get_pos()))
+    })?;
     done_list.push(b);
     block.exit.iter().for_each(|e| {
       if !done_list.contains(e) && !work_list.contains(e) {
@@ -472,7 +496,7 @@ fn type_check_func(bbfunc: &BBFunction, bbprog: &BBProgram) -> Result<(), Interp
   Ok(())
 }
 
-pub fn type_check(bbprog: &BBProgram) -> Result<(), InterpError> {
+pub fn type_check(bbprog: &BBProgram) -> Result<(), PositionalInterpError> {
   bbprog
     .func_index
     .iter()

--- a/brilirs/src/error.rs
+++ b/brilirs/src/error.rs
@@ -1,3 +1,6 @@
+use std::fmt::Display;
+
+use bril_rs::Position;
 use thiserror::Error;
 
 // Having the #[error(...)] for all variants derives the Display trait as well
@@ -45,4 +48,44 @@ pub enum InterpError {
   BadAsmtType(bril_rs::Type, bril_rs::Type), // (expected, actual). For when the LHS type of an instruction is bad
   #[error("There has been an io error when trying to print: `{0:?}`")]
   IoError(Box<std::io::Error>),
+  #[error("You probably shouldn't see this error, this is here to handle conversions between InterpError and PositionalError")]
+  PositionalInterpErrorConversion(#[from] PositionalInterpError),
+}
+
+impl InterpError {
+  pub fn add_pos(self, pos: Option<Position>) -> PositionalInterpError {
+    match self {
+      Self::PositionalInterpErrorConversion(e) => e,
+      _ => PositionalInterpError {
+        e: Box::new(self),
+        pos,
+      },
+    }
+  }
+}
+
+#[derive(Error, Debug)]
+pub struct PositionalInterpError {
+  e: Box<InterpError>,
+  pos: Option<Position>,
+}
+
+impl PositionalInterpError {
+  pub fn new(e: InterpError) -> Self {
+    Self {
+      e: Box::new(e),
+      pos: None,
+    }
+  }
+}
+
+impl Display for PositionalInterpError {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    match self {
+      PositionalInterpError { e, pos: Some(pos) } => {
+        write!(f, "Line {}, Column {}: {}", pos.row, pos.col, e)
+      }
+      PositionalInterpError { e, pos: None } => write!(f, "{}", e),
+    }
+  }
 }

--- a/brilirs/src/lib.rs
+++ b/brilirs/src/lib.rs
@@ -25,9 +25,9 @@ pub fn run_input<T: std::io::Write>(
   //      - bril_rs takes file.json as input
   //      - bril2json takes file.bril as input
   let prog = if text {
-    bril2json::load_abstract_program_from_read(input, true).try_into()?
+    bril2json::parse_abstract_program_from_read(input, true).try_into()?
   } else {
-    bril_rs::load_program_from_read(input)
+    bril_rs::load_abstract_program_from_read(input).try_into()?
   };
   let bbprog = basic_block::BBProgram::new(prog)?;
   check::type_check(&bbprog)?;

--- a/brilirs/src/lib.rs
+++ b/brilirs/src/lib.rs
@@ -25,7 +25,7 @@ pub fn run_input<T: std::io::Write>(
   //      - bril_rs takes file.json as input
   //      - bril2json takes file.bril as input
   let prog = if text {
-    bril2json::load_abstract_program_from_read(input).try_into()?
+    bril2json::load_abstract_program_from_read(input, true).try_into()?
   } else {
     bril_rs::load_program_from_read(input)
   };

--- a/brilirs/todo_list.txt
+++ b/brilirs/todo_list.txt
@@ -7,5 +7,4 @@
         - replace string lookup with indexing a vec
         - optimize contexts?
 - Improve documentation
-- Better errors with line numbers?
 - Appease Clippy Overlord

--- a/brilirs/todo_list.txt
+++ b/brilirs/todo_list.txt
@@ -1,0 +1,11 @@
+- Support Speculative execution in brilirs
+- Support structs in bril-rs and brilirs
+- bril-rs to LLVM compiler?
+- Optimize brilirs:
+    - replace the naive memory management support with a more optimized version
+    - optimize brilirs for function calls
+        - replace string lookup with indexing a vec
+        - optimize contexts?
+- Improve documentation
+- Better errors with line numbers?
+- Appease Clippy Overlord

--- a/docs/tools/rust.md
+++ b/docs/tools/rust.md
@@ -26,8 +26,7 @@ This library supports fully compatible Rust implementations of `bril2txt` and `b
 
 For ease of use, these tools can be installed and added to your path by running the following in `bril-rs/`:
 
-    $ cargo install --path . --example bril2txt
-    $ cargo install --path ./bril2json
+    $ make install
 
 Make sure that `~/.cargo/bin` is on your path.
 
@@ -39,6 +38,8 @@ To maintain consistency and cleanliness, run:
 ```bash
 cargo fmt
 cargo clippy
+make test
+make features
 ```
 
 [rust]: https://www.rust-lang.org

--- a/test/parse/turnt_bril_rs.toml
+++ b/test/parse/turnt_bril_rs.toml
@@ -1,2 +1,2 @@
-command = "cargo run --manifest-path ../../bril-rs/bril2json/Cargo.toml < {filename}"
+command = "cargo run --manifest-path ../../bril-rs/bril2json/Cargo.toml -- {args} < {filename}"
 output.json = "-"


### PR DESCRIPTION
- c3965bf Adds feature-gated support for positions to bril-rs. Adds `make features` to do a naive check that all features are properly gated. Adds `make install` for the rust versions of `bril2txt` and `bril2json`. Small updates to documentation.
- 34bc048 Adds positions to the rust version of `bril2json` with the `-p` flag. Updates test config to take arguments.
- 16011b9 Adds positions to `brilirs` for more information in error reports when available.
- 1c224c2 and bd45453 Add support to `brilirs` for returning errors when the type signature is missing.

Programs that are ill-formed such that they break parsing will not return nice error messages. `brilirs` should return a position with an error when possible but there are not currently tests for this.

Examples:
```sh
$ bril2json -p < ../benchmarks/mat-inv.bril | cargo run

error: Line 54, Column 3: Missing type signature
```

```sh
$ bril2json -p < ../benchmarks/up-arrow.bril | cargo run -- 2 3 3

error: Line 15, Column 3: Expected type `Bool` for assignment, found `Int`
```
