### PR TITLE
Start a simple type checker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ TESTS := test/parse/*.bril \
 	test/ts*/*.ts \
 	test/mem/*.bril \
 	test/fail/*.bril \
+	test/check/*.bril \
 	examples/test/*/*.bril \
 	benchmarks/*.bril
 

--- a/bril-ts/brilck.ts
+++ b/bril-ts/brilck.ts
@@ -1,0 +1,17 @@
+#!/usr/bin/env node
+import * as bril from './bril';
+import {readStdin} from './util';
+
+function checkProg(prog: bril.Program) {
+  console.log(prog);
+}
+
+async function main() {
+  let prog = JSON.parse(await readStdin()) as bril.Program;
+  checkProg(prog);
+}
+
+// Make unhandled promise rejections terminate.
+process.on('unhandledRejection', e => { throw e });
+
+main();

--- a/bril-ts/brilck.ts
+++ b/bril-ts/brilck.ts
@@ -48,12 +48,26 @@ function addType(env: TypeEnv, id: bril.Ident, type: bril.Type) {
 }
 
 function checkInstr(
-  env: TypeEnv, labels: Set<bril.Ident>, instr: bril.Instruction
+  env: TypeEnv, labels: Set<bril.Ident>, instr: bril.Operation
 ) {
+  let args = instr.args ?? [];
+
   // Check for special cases.
   if (instr.op === "print") {
     if ('type' in instr) {
       console.error(`print should have no result type`);
+    }
+    return;
+  } else if (instr.op === "id") {
+    if (args.length !== 1) {
+      console.error(`id should have one arg, not ${args.length}`);
+      return;
+    }
+    let argType = env.get(args[0]);
+    if (!argType) {
+      console.error(`${args[0]} is undefined`);
+    } else if (instr.type !== argType) {
+      console.error(`id arg type ${argType} does not match type ${instr.type}`);
     }
     return;
   }
@@ -66,12 +80,6 @@ function checkInstr(
   }
 
   // Check the argument count.
-  let args: bril.Ident[];
-  if ('args' in instr && instr.args !== undefined) {
-    args = instr.args;
-  } else {
-    args = [];
-  }
   if (args.length !== opType.args.length) {
     console.error(
       `${instr.op} needs ${opType.args.length} args; found ${args.length}`

--- a/bril-ts/brilck.ts
+++ b/bril-ts/brilck.ts
@@ -87,7 +87,7 @@ function checkArgs(env: Env, args: bril.Ident[], params: bril.Type[]) {
   }
 }
 
-function checkInstr(env: Env, instr: bril.Operation) {
+function checkInstr(env: Env, instr: bril.Operation, ret: bril.Type | undefined) {
   let args = instr.args ?? [];
 
   // Check for special cases.
@@ -141,6 +141,21 @@ function checkInstr(env: Env, instr: bril.Operation) {
       checkArgs(env, args, funcType.args);
     }
 
+    return;
+  } else if (instr.op === "ret") {
+    if (ret) {
+      if (args.length === 0) {
+        console.error(`missing return value in function with return type`);
+      } else if (args.length !== 1) {
+        console.error(`cannot return multiple values`);
+      } else {
+        checkArgs(env, args, [ret]);
+      }
+    } else {
+      if (args.length !== 0) {
+        console.error(`returning value in function without a return type`);
+      }
+    }
     return;
   }
 
@@ -242,7 +257,7 @@ function checkFunc(funcs: FuncEnv, func: bril.Function) {
       if (instr.op === 'const') {
         checkConst(instr);
       } else {
-        checkInstr({vars, labels, funcs}, instr);
+        checkInstr({vars, labels, funcs}, instr, func.type);
       }
     }
   }

--- a/bril-ts/brilck.ts
+++ b/bril-ts/brilck.ts
@@ -10,7 +10,18 @@ interface OpType {
 }
 
 const OP_TYPES: {[key: string]: OpType} = {
-  'add': {'args': ['int', 'int'], 'dest': 'int'}
+  'add': {'args': ['int', 'int'], 'dest': 'int'},
+  'mul': {'args': ['int', 'int'], 'dest': 'int'},
+  'sub': {'args': ['int', 'int'], 'dest': 'int'},
+  'div': {'args': ['int', 'int'], 'dest': 'int'},
+  'eq': {'args': ['int', 'int'], 'dest': 'bool'},
+  'lt': {'args': ['int', 'int'], 'dest': 'bool'},
+  'gt': {'args': ['int', 'int'], 'dest': 'bool'},
+  'le': {'args': ['int', 'int'], 'dest': 'bool'},
+  'ge': {'args': ['int', 'int'], 'dest': 'bool'},
+  'not': {'args': ['bool'], 'dest': 'bool'},
+  'and': {'args': ['bool', 'bool'], 'dest': 'bool'},
+  'or': {'args': ['bool', 'bool'], 'dest': 'bool'},
 };
 
 const CONST_TYPES: {[key: string]: string} = {

--- a/bril-ts/brilck.ts
+++ b/bril-ts/brilck.ts
@@ -16,7 +16,7 @@ const OP_TYPES: {[key: string]: OpType} = {
 const CONST_TYPES: {[key: string]: string} = {
   'int': 'number',
   'float': 'number',
-  'bool': 'bool',
+  'bool': 'boolean',
 };
 
 /**

--- a/bril-ts/brilck.ts
+++ b/bril-ts/brilck.ts
@@ -247,7 +247,11 @@ function checkFunc(funcs: FuncEnv, func: bril.Function) {
     if ('dest' in instr) {
       addType(vars, instr.dest, instr.type);
     } else if ('label' in instr) {
-      labels.add(instr.label);
+      if (labels.has(instr.label)) {
+        console.error(`multiply defined label .${instr.label}`);
+      } else {
+        labels.add(instr.label);
+      }
     }
   }
 

--- a/bril-ts/brilck.ts
+++ b/bril-ts/brilck.ts
@@ -33,6 +33,14 @@ function addType(env: TypeEnv, id: bril.Ident, type: bril.Type) {
 function checkInstr(
   env: TypeEnv, labels: Set<bril.Ident>, instr: bril.Instruction
 ) {
+  // Check for special cases.
+  if (instr.op === "print") {
+    if ('type' in instr) {
+      console.error(`print should have no result type`);
+    }
+    return;
+  }
+
   // Do we know this operation?
   let opType = OP_TYPES[instr.op];
   if (!opType) {

--- a/bril-ts/brilck.ts
+++ b/bril-ts/brilck.ts
@@ -7,6 +7,8 @@ type TypeEnv = Map<bril.Ident, bril.Type>;
 interface OpType {
   args: bril.Type[],
   dest?: bril.Type,
+  labels?: number,
+  funcs?: number,
 }
 
 const OP_TYPES: {[key: string]: OpType} = {
@@ -22,6 +24,8 @@ const OP_TYPES: {[key: string]: OpType} = {
   'not': {'args': ['bool'], 'dest': 'bool'},
   'and': {'args': ['bool', 'bool'], 'dest': 'bool'},
   'or': {'args': ['bool', 'bool'], 'dest': 'bool'},
+  'jmp': {'args': [], 'labels': 1},
+  'br': {'args': ['bool'], 'labels': 2},
 };
 
 const CONST_TYPES: {[key: string]: string} = {
@@ -116,6 +120,19 @@ function checkInstr(
   } else {
     if ('dest' in opType) {
       console.error(`missing result type ${opType.dest} for ${instr.op}`);
+    }
+  }
+  
+  // Check labels.
+  let labs = instr.labels ?? [];
+  let labCount = opType.labels ?? 0;
+  if (labs.length !== labCount) {
+    console.error(`${instr.op} needs ${labCount} labels; found ${labs.length}`);
+  } else {
+    for (let lab of labs) {
+      if (!labels.has(lab)) {
+        console.error(`label .${lab} undefined`);
+      }
     }
   }
 }

--- a/bril-ts/brilck.ts
+++ b/bril-ts/brilck.ts
@@ -26,6 +26,15 @@ const OP_TYPES: {[key: string]: OpType} = {
   'or': {'args': ['bool', 'bool'], 'dest': 'bool'},
   'jmp': {'args': [], 'labels': 1},
   'br': {'args': ['bool'], 'labels': 2},
+  'fadd': {'args': ['float', 'float'], 'dest': 'float'},
+  'fmul': {'args': ['float', 'float'], 'dest': 'float'},
+  'fsub': {'args': ['float', 'float'], 'dest': 'float'},
+  'fdiv': {'args': ['float', 'float'], 'dest': 'float'},
+  'feq': {'args': ['float', 'float'], 'dest': 'bool'},
+  'flt': {'args': ['float', 'float'], 'dest': 'bool'},
+  'fgt': {'args': ['float', 'float'], 'dest': 'bool'},
+  'fle': {'args': ['float', 'float'], 'dest': 'bool'},
+  'fge': {'args': ['float', 'float'], 'dest': 'bool'},
 };
 
 const CONST_TYPES: {[key: string]: string} = {

--- a/bril-ts/brilck.ts
+++ b/bril-ts/brilck.ts
@@ -2,8 +2,63 @@
 import * as bril from './bril';
 import {readStdin} from './util';
 
+type TypeEnv = Map<bril.Ident, bril.Type>;
+
+/**
+ * Set the type of variable `id` to `type` in `env`, checking for conflicts
+ * with the old type for the variable.
+ */
+function addType(env: TypeEnv, id: bril.Ident, type: bril.Type) {
+  let oldType = env.get(id);
+  if (oldType) {
+    if (oldType !== type) {
+      console.error(
+        `new type ${type} for ${id} conflicts with old type ${oldType}`
+      );
+    }
+  } else {
+    env.set(id, type);
+  }
+}
+
+function checkInstr(
+  env: TypeEnv, labels: Set<bril.Ident>, instr: bril.Instruction
+) {
+
+}
+
+function checkFunc(func: bril.Function) {
+  let env: TypeEnv = new Map();
+  let labels = new Set<bril.Ident>();
+
+  // Initilize the type environment with the arguments.
+  if (func.args) {
+    for (let arg of func.args) {
+      addType(env, arg.name, arg.type);
+    }
+  }
+
+  // Gather up all the types of the local variables and all the label names.
+  for (let instr of func.instrs) {
+    if ('dest' in instr) {
+      addType(env, instr.dest, instr.type);
+    } else if ('label' in instr) {
+      labels.add(instr.label);
+    }
+  }
+
+  // Check each instruction.
+  for (let instr of func.instrs) {
+    if ('op' in instr) {
+      checkInstr(env, labels, instr);
+    }
+  }
+}
+
 function checkProg(prog: bril.Program) {
-  console.log(prog);
+  for (let func of prog.functions) {
+    checkFunc(func);
+  }
 }
 
 async function main() {

--- a/bril-ts/package.json
+++ b/bril-ts/package.json
@@ -5,10 +5,11 @@
   "private": true,
   "bin": {
     "ts2bril": "build/ts2bril.js",
-    "brili": "build/brili.js"
+    "brili": "build/brili.js",
+    "brilck": "build/brilck.js"
   },
   "scripts": {
-    "build": "tsc && chmod a+x build/ts2bril.js build/brili.js"
+    "build": "tsc && chmod a+x build/ts2bril.js build/brili.js build/brilck.js"
   },
   "dependencies": {
     "@types/node": "^11.13.5",

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -17,6 +17,7 @@
     - [Fast Interpreter](tools/brilirs.md)
     - [Editor Plugin](tools/plugin.md)
     - [Type Inference](tools/infer.md)
+    - [Type Checker](tools/brilck.md)
     - [Benchmarks](tools/bench.md)
     - [OCaml Library](tools/ocaml.md)
     - [Rust Library](tools/rust.md)

--- a/docs/tools/brilck.md
+++ b/docs/tools/brilck.md
@@ -1,0 +1,22 @@
+# Type Checker
+
+Bril comes with a simple type checker to catch errors statically.
+It checks the types of instructions in the [core language](../lang/core.md) and some extensions, calls and return values, and the labels used in control flow.
+
+Install
+-------
+
+The `brilck` tool comes with the same [TypeScript][] package as the [reference interpreter](interp.md).
+Follow [those instructions](interp.md#install) to install it.
+
+[typescript]: https://www.typescriptlang.org
+
+Check
+-----
+
+Just pipe a Bril program into `brilck`:
+
+    bril2json < benchmarks/fizz-buzz.bril | brilck
+
+It will print any problems it finds to standard error.
+(If it doesn't find any problems, it doesn't print anything at all.)

--- a/examples/test/ssa_roundtrip/turnt.toml
+++ b/examples/test/ssa_roundtrip/turnt.toml
@@ -1,1 +1,1 @@
-command = "bril2json < {filename} | python ../../to_ssa.py | python ../../from_ssa.py | python ../../tdce.py | brili {args}"
+command = "bril2json < {filename} | python3 ../../to_ssa.py | python3 ../../from_ssa.py | python3 ../../tdce.py | brili {args}"

--- a/examples/test/to_ssa/turnt.toml
+++ b/examples/test/to_ssa/turnt.toml
@@ -1,1 +1,1 @@
-command = "bril2json < {filename} | python ../../to_ssa.py | bril2txt"
+command = "bril2json < {filename} | python3 ../../to_ssa.py | bril2txt"

--- a/test/check/argtype.bril
+++ b/test/check/argtype.bril
@@ -1,0 +1,3 @@
+@main(a: int, b: bool) {
+  c: int = add a b;
+}

--- a/test/check/argtype.err
+++ b/test/check/argtype.err
@@ -1,0 +1,1 @@
+b has type bool, but arg 1 should have type int

--- a/test/check/badcall.bril
+++ b/test/check/badcall.bril
@@ -9,6 +9,15 @@
 @argint(x: int) {
 }
 
+@noret {
+  x: int = const 5;
+  ret x;
+}
+
+@yesret(): int {
+  ret;
+}
+
 @main {
   call @foo;
   a: int = call @nothing;

--- a/test/check/badcall.bril
+++ b/test/check/badcall.bril
@@ -1,0 +1,14 @@
+@nothing {
+}
+
+@retint(): int {
+  x: int = const 5;
+  ret x;
+}
+
+@main {
+  call @foo;
+  a: int = call @nothing;
+  call @nothing @nothing;
+  b: bool = call @retint;
+}

--- a/test/check/badcall.bril
+++ b/test/check/badcall.bril
@@ -6,9 +6,15 @@
   ret x;
 }
 
+@argint(x: int) {
+}
+
 @main {
   call @foo;
   a: int = call @nothing;
   call @nothing @nothing;
   b: bool = call @retint;
+  call @argint b;
+  call @argint;
+  call @argint a a;
 }

--- a/test/check/badcall.err
+++ b/test/check/badcall.err
@@ -1,0 +1,5 @@
+unknown opcode ret
+function @foo undefined
+@nothing does not return a value
+call should have one function, not 2
+@retint returns type int, not bool

--- a/test/check/badcall.err
+++ b/test/check/badcall.err
@@ -1,5 +1,9 @@
-unknown opcode ret
+returning value in function without a return type
+missing return value in function with return type
 function @foo undefined
 @nothing does not return a value
 call should have one function, not 2
 @retint returns type int, not bool
+b has type bool, but arg 0 should have type int
+@argint expects 1 args, not 0
+@argint expects 1 args, not 2

--- a/test/check/badconst.bril
+++ b/test/check/badconst.bril
@@ -1,0 +1,4 @@
+@main {
+  a: bool = const 4;
+  b: int = const true;
+}

--- a/test/check/badconst.bril
+++ b/test/check/badconst.bril
@@ -1,4 +1,6 @@
 @main {
   a: bool = const 4;
   b: int = const true;
+  c: ptr<int> = const 2;
+  d: blah = const 0;
 }

--- a/test/check/badconst.err
+++ b/test/check/badconst.err
@@ -1,0 +1,2 @@
+const value 4 does not match type bool
+const value true does not match type int

--- a/test/check/badconst.err
+++ b/test/check/badconst.err
@@ -1,2 +1,4 @@
 const value 4 does not match type bool
 const value true does not match type int
+const of non-primitive type [object Object]
+unknown const type blah

--- a/test/check/badid.bril
+++ b/test/check/badid.bril
@@ -1,0 +1,5 @@
+@main(a: int) {
+  b: bool = id a;
+  id a;
+  c: int = id;
+}

--- a/test/check/badid.err
+++ b/test/check/badid.err
@@ -1,0 +1,3 @@
+id arg type int does not match type bool
+id arg type int does not match type undefined
+id should have one arg, not 0

--- a/test/check/extra.bril
+++ b/test/check/extra.bril
@@ -1,0 +1,3 @@
+@main(a: int, b: int) {
+  c: int = add a b a;
+}

--- a/test/check/extra.err
+++ b/test/check/extra.err
@@ -1,0 +1,2 @@
+add needs 2 args; found 3
+a has type int, but arg 2 should have type undefined

--- a/test/check/labels.bril
+++ b/test/check/labels.bril
@@ -4,4 +4,6 @@
   br b .foo .foo .foo;
   c: bool = not b .foo;
 .foo:
+.bar:
+.bar:
 }

--- a/test/check/labels.bril
+++ b/test/check/labels.bril
@@ -1,0 +1,7 @@
+@main(b: bool) {
+  jmp .bad;
+  br b .foo;
+  br b .foo .foo .foo;
+  c: bool = not b .foo;
+.foo:
+}

--- a/test/check/labels.err
+++ b/test/check/labels.err
@@ -1,0 +1,4 @@
+label .bad undefined
+br needs 2 labels; found 1
+br needs 2 labels; found 3
+not needs 0 labels; found 1

--- a/test/check/labels.err
+++ b/test/check/labels.err
@@ -1,3 +1,4 @@
+multiply defined label .bar
 label .bad undefined
 br needs 2 labels; found 1
 br needs 2 labels; found 3

--- a/test/check/main-args.bril
+++ b/test/check/main-args.bril
@@ -1,0 +1,5 @@
+# ARGS: 1 2
+@main(x: int, y: int) {
+    v: int = add x y;
+    print v;
+}

--- a/test/check/missarg.bril
+++ b/test/check/missarg.bril
@@ -1,0 +1,3 @@
+@main(a: int, b: int) {
+  c: int = add a;
+}

--- a/test/check/missarg.err
+++ b/test/check/missarg.err
@@ -1,0 +1,1 @@
+add needs 2 args; found 1

--- a/test/check/missdest.bril
+++ b/test/check/missdest.bril
@@ -1,0 +1,3 @@
+@main(a: int, b: int) {
+  add a b;
+}

--- a/test/check/missdest.err
+++ b/test/check/missdest.err
@@ -1,0 +1,1 @@
+missing result type int for add

--- a/test/check/printres.bril
+++ b/test/check/printres.bril
@@ -1,0 +1,3 @@
+@main(a: int) {
+  b: int = print a;
+}

--- a/test/check/printres.err
+++ b/test/check/printres.err
@@ -1,0 +1,1 @@
+print should have no result type

--- a/test/check/tiny.bril
+++ b/test/check/tiny.bril
@@ -1,0 +1,4 @@
+@main {
+  v: int = const 5;
+  print v;
+}

--- a/test/check/tiny.err
+++ b/test/check/tiny.err
@@ -1,0 +1,1 @@
+unknown opcode const

--- a/test/check/tiny.err
+++ b/test/check/tiny.err
@@ -1,1 +1,0 @@
-unknown opcode const

--- a/test/check/turnt.toml
+++ b/test/check/turnt.toml
@@ -1,0 +1,2 @@
+command = "bril2json -p < {filename} | brilck"
+output.err = "2"

--- a/test/check/typeconflict.bril
+++ b/test/check/typeconflict.bril
@@ -1,0 +1,4 @@
+@main {
+  a: bool = const true;
+  a: int = const 4;
+}

--- a/test/check/typeconflict.err
+++ b/test/check/typeconflict.err
@@ -1,0 +1,1 @@
+new type int for a conflicts with old type bool

--- a/test/check/undef.bril
+++ b/test/check/undef.bril
@@ -1,0 +1,3 @@
+@main {
+  b: int = add a b;
+}

--- a/test/check/undef.err
+++ b/test/check/undef.err
@@ -1,0 +1,1 @@
+a (arg 0) undefined


### PR DESCRIPTION
Recent bugs, as referenced in #155, made me realize that we don't have a simple, self-contained type checker anywhere. The type inference tool can fix your mistakes for you, which is cool, but it's not focused on reporting errors (and will silently fix many errors for you). The `brilirs -c` mode is great, but I thought something standalone would be a good complement (and useful to for differential testing). So I whipped this up real quick.

This provides a simple `brilck` tool that just prints the errors it finds in an input Bril program. Not much to it. It currently supports the core instructions, the floating point extension, and `call` and `ret`. It enforces, for example, that every variable must have a consistent type throughout a given function. It also checks for multiply defined labels.

If you want to see the current state of things, it's easy to run it on all our benchmark code we have so far:

    for fn in benchmarks/*.bril ; do bril2json < $fn | brilck ; done

Things left to do:

- [ ] Use the source positions (from #161) in the error messages.
- [ ] Support comparisons of parameterized types (e.g., `ptr<int>`).
- [ ] Support the memory extension (which is surprisingly popular).
- [ ] Consider moving the list of operation types to a separate file and sharing that with `brili`.