### PR TITLE
brilck: Support more complex types

### DIFF
--- a/bril-ts/brilck.ts
+++ b/bril-ts/brilck.ts
@@ -1,5 +1,4 @@
 #!/usr/bin/env node
-import { BinaryLike } from 'crypto';
 import * as bril from './bril';
 import {readStdin, unreachable} from './util';
 

--- a/bril-ts/brilck.ts
+++ b/bril-ts/brilck.ts
@@ -96,7 +96,16 @@ function typeFmt(t: bril.Type): string {
   unreachable(t);
 }
 
-function checkArgs(env: Env, args: bril.Ident[], params: bril.Type[]) {
+function checkArgs(env: Env, args: bril.Ident[], params: bril.Type[], name: string) {
+  // Check argument count.
+  if (args.length !== params.length) {
+    console.error(
+      `${name} expects ${params.length} args, not ${args.length}`
+    );
+    return;
+  }
+
+  // Check each argument.
   let argc = Math.min(args.length, params.length);
   for (let i = 0; i < argc; ++i) {
     let argType = env.vars.get(args[i]);
@@ -106,8 +115,8 @@ function checkArgs(env: Env, args: bril.Ident[], params: bril.Type[]) {
     }
     if (!typeEq(params[i], argType)) {
       console.error(
-        `${args[i]} has type ${typeFmt(argType)}, but arg ${i} should ` +
-        `have type ${typeFmt(params[i])}`
+        `${args[i]} has type ${typeFmt(argType)}, but arg ${i} for ${name} ` +
+        `should have type ${typeFmt(params[i])}`
       );
     }
   }
@@ -165,13 +174,7 @@ function checkInstr(env: Env, instr: bril.Operation, ret: bril.Type | undefined)
       console.error(`@${funcs[0]} does not return a value`);
     }
     
-    if (args.length !== funcType.args.length) {
-      console.error(
-        `@${funcs[0]} expects ${funcType.args.length} args, not ${args.length}`
-      );
-    } else {
-      checkArgs(env, args, funcType.args);
-    }
+    checkArgs(env, args, funcType.args, `@${funcs[0]}`);
 
     return;
   } else if (instr.op === "ret") {
@@ -181,7 +184,7 @@ function checkInstr(env: Env, instr: bril.Operation, ret: bril.Type | undefined)
       } else if (args.length !== 1) {
         console.error(`cannot return multiple values`);
       } else {
-        checkArgs(env, args, [ret]);
+        checkArgs(env, args, [ret], 'ret');
       }
     } else {
       if (args.length !== 0) {
@@ -198,15 +201,8 @@ function checkInstr(env: Env, instr: bril.Operation, ret: bril.Type | undefined)
     return;
   }
 
-  // Check the argument count.
-  if (args.length !== opType.args.length) {
-    console.error(
-      `${instr.op} needs ${opType.args.length} args; found ${args.length}`
-    );
-  }
-
   // Check the argument types.
-  checkArgs(env, args, opType.args);
+  checkArgs(env, args, opType.args, instr.op);
 
   // Check destination type.
   if ('type' in instr) {

--- a/bril-ts/brilck.ts
+++ b/bril-ts/brilck.ts
@@ -3,8 +3,8 @@ import * as bril from './bril';
 import {readStdin, unreachable} from './util';
 
 interface FuncType {
-  'ret': bril.Type | undefined,
-  'args': bril.Type[],
+  ret: bril.Type | undefined,
+  args: bril.Type[],
 }
 type VarEnv = Map<bril.Ident, bril.Type>;
 type FuncEnv = Map<bril.Ident, FuncType>;
@@ -23,29 +23,29 @@ interface OpType {
 }
 
 const OP_TYPES: {[key: string]: OpType} = {
-  'add': {'args': ['int', 'int'], 'dest': 'int'},
-  'mul': {'args': ['int', 'int'], 'dest': 'int'},
-  'sub': {'args': ['int', 'int'], 'dest': 'int'},
-  'div': {'args': ['int', 'int'], 'dest': 'int'},
-  'eq': {'args': ['int', 'int'], 'dest': 'bool'},
-  'lt': {'args': ['int', 'int'], 'dest': 'bool'},
-  'gt': {'args': ['int', 'int'], 'dest': 'bool'},
-  'le': {'args': ['int', 'int'], 'dest': 'bool'},
-  'ge': {'args': ['int', 'int'], 'dest': 'bool'},
-  'not': {'args': ['bool'], 'dest': 'bool'},
-  'and': {'args': ['bool', 'bool'], 'dest': 'bool'},
-  'or': {'args': ['bool', 'bool'], 'dest': 'bool'},
-  'jmp': {'args': [], 'labels': 1},
-  'br': {'args': ['bool'], 'labels': 2},
-  'fadd': {'args': ['float', 'float'], 'dest': 'float'},
-  'fmul': {'args': ['float', 'float'], 'dest': 'float'},
-  'fsub': {'args': ['float', 'float'], 'dest': 'float'},
-  'fdiv': {'args': ['float', 'float'], 'dest': 'float'},
-  'feq': {'args': ['float', 'float'], 'dest': 'bool'},
-  'flt': {'args': ['float', 'float'], 'dest': 'bool'},
-  'fgt': {'args': ['float', 'float'], 'dest': 'bool'},
-  'fle': {'args': ['float', 'float'], 'dest': 'bool'},
-  'fge': {'args': ['float', 'float'], 'dest': 'bool'},
+  'add': {args: ['int', 'int'], dest: 'int'},
+  'mul': {args: ['int', 'int'], dest: 'int'},
+  'sub': {args: ['int', 'int'], dest: 'int'},
+  'div': {args: ['int', 'int'], dest: 'int'},
+  'eq': {args: ['int', 'int'], dest: 'bool'},
+  'lt': {args: ['int', 'int'], dest: 'bool'},
+  'gt': {args: ['int', 'int'], dest: 'bool'},
+  'le': {args: ['int', 'int'], dest: 'bool'},
+  'ge': {args: ['int', 'int'], dest: 'bool'},
+  'not': {args: ['bool'], dest: 'bool'},
+  'and': {args: ['bool', 'bool'], dest: 'bool'},
+  'or': {args: ['bool', 'bool'], dest: 'bool'},
+  'jmp': {args: [], 'labels': 1},
+  'br': {args: ['bool'], 'labels': 2},
+  'fadd': {args: ['float', 'float'], dest: 'float'},
+  'fmul': {args: ['float', 'float'], dest: 'float'},
+  'fsub': {args: ['float', 'float'], dest: 'float'},
+  'fdiv': {args: ['float', 'float'], dest: 'float'},
+  'feq': {args: ['float', 'float'], dest: 'bool'},
+  'flt': {args: ['float', 'float'], dest: 'bool'},
+  'fgt': {args: ['float', 'float'], dest: 'bool'},
+  'fle': {args: ['float', 'float'], dest: 'bool'},
+  'fge': {args: ['float', 'float'], dest: 'bool'},
 };
 
 const CONST_TYPES: {[key: string]: string} = {
@@ -183,8 +183,8 @@ function checkInstr(env: Env, instr: bril.Operation, ret: bril.Type | undefined)
       console.error(`missing result type for id`);
     } else {
       checkTypes(env, instr, {
-        'args': [instr.type],
-        'dest': instr.type,
+        args: [instr.type],
+        dest: instr.type,
       });
     }
     return;
@@ -202,8 +202,8 @@ function checkInstr(env: Env, instr: bril.Operation, ret: bril.Type | undefined)
     }
     
     checkTypes(env, instr, {
-      'args': funcType.args,
-      'dest': funcType.ret,
+      args: funcType.args,
+      dest: funcType.ret,
     }, `@${funcs[0]}`);
     return;
   } else if (instr.op === "ret") {
@@ -213,7 +213,7 @@ function checkInstr(env: Env, instr: bril.Operation, ret: bril.Type | undefined)
       } else if (args.length !== 1) {
         console.error(`cannot return multiple values`);
       } else {
-        checkTypes(env, instr, {'args': [ret]});
+        checkTypes(env, instr, {args: [ret]});
       }
     } else {
       if (args.length !== 0) {
@@ -297,8 +297,8 @@ function checkProg(prog: bril.Program) {
   let funcEnv: FuncEnv = new Map();
   for (let func of prog.functions) {
     funcEnv.set(func.name, {
-      'ret': func.type,
-      'args': func.args?.map(a => a.type) ?? [],
+      ret: func.type,
+      args: func.args?.map(a => a.type) ?? [],
     });
   }
 

--- a/bril-ts/brilck.ts
+++ b/bril-ts/brilck.ts
@@ -178,20 +178,13 @@ function checkInstr(env: Env, instr: bril.Operation, ret: bril.Type | undefined)
     }
     return;
   } else if (instr.op === "id") {
-    if (args.length !== 1) {
-      console.error(`id should have one arg, not ${args.length}`);
-      return;
-    }
-    let argType = env.vars.get(args[0]);
-    if (!argType) {
-      console.error(`${args[0]} is undefined`);
-    } else if (!instr.type) {
+    if (!instr.type) {
       console.error(`missing result type for id`);
-    } else if (!typeEq(instr.type, argType)) {
-      console.error(
-        `id arg type ${typeFmt(argType)} does not match ` +
-        `type ${typeFmt(instr.type)}`
-      );
+    } else {
+      checkTypes(env, instr, {
+        'args': [instr.type],
+        'dest': instr.type,
+      });
     }
     return;
   } else if (instr.op == "call") {

--- a/bril-ts/brilck.ts
+++ b/bril-ts/brilck.ts
@@ -213,7 +213,7 @@ function checkInstr(env: Env, instr: bril.Operation, ret: bril.Type | undefined)
       } else if (args.length !== 1) {
         console.error(`cannot return multiple values`);
       } else {
-        checkArgs(env, args, [ret], 'ret');
+        checkTypes(env, instr, {'args': [ret]});
       }
     } else {
       if (args.length !== 0) {

--- a/bril-ts/brilck.ts
+++ b/bril-ts/brilck.ts
@@ -1,11 +1,17 @@
 #!/usr/bin/env node
 import * as bril from './bril';
+import {Signature, FuncType, OP_SIGS} from './types';
 import {readStdin, unreachable} from './util';
 
-interface FuncType {
-  ret: bril.Type | undefined,
-  args: bril.Type[],
-}
+/**
+ * The JavaScript types of Bril constant values.
+ */
+const CONST_TYPES: {[key: string]: string} = {
+  'int': 'number',
+  'float': 'number',
+  'bool': 'boolean',
+};
+
 type VarEnv = Map<bril.Ident, bril.Type>;
 type FuncEnv = Map<bril.Ident, FuncType>;
 
@@ -34,51 +40,6 @@ interface Env {
    */
   ret: bril.Type | undefined;
 }
-
-/**
- * The type signature for an operation.
- * 
- * Describes the shape and types of all the ingredients for a Bril operation
- * instruction: arguments, result, labels, and functions.
- */
-interface Signature {
-  args: bril.Type[],
-  dest?: bril.Type,
-  labels?: number,
-  funcs?: number,
-}
-
-const OP_SIGS: {[key: string]: Signature} = {
-  'add': {args: ['int', 'int'], dest: 'int'},
-  'mul': {args: ['int', 'int'], dest: 'int'},
-  'sub': {args: ['int', 'int'], dest: 'int'},
-  'div': {args: ['int', 'int'], dest: 'int'},
-  'eq': {args: ['int', 'int'], dest: 'bool'},
-  'lt': {args: ['int', 'int'], dest: 'bool'},
-  'gt': {args: ['int', 'int'], dest: 'bool'},
-  'le': {args: ['int', 'int'], dest: 'bool'},
-  'ge': {args: ['int', 'int'], dest: 'bool'},
-  'not': {args: ['bool'], dest: 'bool'},
-  'and': {args: ['bool', 'bool'], dest: 'bool'},
-  'or': {args: ['bool', 'bool'], dest: 'bool'},
-  'jmp': {args: [], 'labels': 1},
-  'br': {args: ['bool'], 'labels': 2},
-  'fadd': {args: ['float', 'float'], dest: 'float'},
-  'fmul': {args: ['float', 'float'], dest: 'float'},
-  'fsub': {args: ['float', 'float'], dest: 'float'},
-  'fdiv': {args: ['float', 'float'], dest: 'float'},
-  'feq': {args: ['float', 'float'], dest: 'bool'},
-  'flt': {args: ['float', 'float'], dest: 'bool'},
-  'fgt': {args: ['float', 'float'], dest: 'bool'},
-  'fle': {args: ['float', 'float'], dest: 'bool'},
-  'fge': {args: ['float', 'float'], dest: 'bool'},
-};
-
-const CONST_TYPES: {[key: string]: string} = {
-  'int': 'number',
-  'float': 'number',
-  'bool': 'boolean',
-};
 
 /**
  * Set the type of variable `id` to `type` in `env`, checking for conflicts

--- a/bril-ts/brilck.ts
+++ b/bril-ts/brilck.ts
@@ -84,6 +84,18 @@ function typeEq(a: bril.Type, b: bril.Type): boolean {
   }
 }
 
+/**
+ * Format a type as a human-readable string.
+ */
+function typeFmt(t: bril.Type): string {
+  if (typeof t === "string") {
+    return t;
+  } else if (typeof t === "object") {
+    return `ptr<${typeFmt(t.ptr)}>`;
+  }
+  return "undefined";  // This shouldn't happen.
+}
+
 function checkArgs(env: Env, args: bril.Ident[], params: bril.Type[]) {
   for (let i = 0; i < args.length; ++i) {
     let argType = env.vars.get(args[i]);
@@ -93,8 +105,8 @@ function checkArgs(env: Env, args: bril.Ident[], params: bril.Type[]) {
     }
     if (!typeEq(params[i], argType)) {
       console.error(
-        `${args[i]} has type ${argType}, but arg ${i} should ` +
-        `have type ${params[i]}`
+        `${args[i]} has type ${typeFmt(argType)}, but arg ${i} should ` +
+        `have type ${typeFmt(params[i])}`
       );
     }
   }
@@ -118,7 +130,10 @@ function checkInstr(env: Env, instr: bril.Operation, ret: bril.Type | undefined)
     if (!argType) {
       console.error(`${args[0]} is undefined`);
     } else if (!typeEq(instr.type, argType)) {
-      console.error(`id arg type ${argType} does not match type ${instr.type}`);
+      console.error(
+        `id arg type ${typeFmt(argType)} does not match ` +
+        `type ${typeFmt(instr.type)}`
+      );
     }
     return;
   } else if (instr.op == "call") {
@@ -138,7 +153,8 @@ function checkInstr(env: Env, instr: bril.Operation, ret: bril.Type | undefined)
       if ('type' in instr) {
         if (!typeEq(instr.type, funcType.ret)) {
           console.error(
-            `@${funcs[0]} returns type ${funcType.ret}, not ${instr.type}`
+            `@${funcs[0]} returns type ${typeFmt(funcType.ret)}, ` +
+            `not ${typeFmt(instr.type)}`
           );
         }
       }
@@ -194,16 +210,18 @@ function checkInstr(env: Env, instr: bril.Operation, ret: bril.Type | undefined)
     if (opType.dest) {
       if (!typeEq(instr.type, opType.dest)) {
         console.error(
-          `result type of ${instr.op} should be ${opType.dest}, ` +
-          `but found ${instr.type}`
+          `result type of ${instr.op} should be ${typeFmt(opType.dest)}, ` +
+          `but found ${typeFmt(instr.type)}`
         );
       }
     } else {
       console.error(`${instr.op} should have no result type`);
     }
   } else {
-    if ('dest' in opType) {
-      console.error(`missing result type ${opType.dest} for ${instr.op}`);
+    if (opType.dest) {
+      console.error(
+        `missing result type ${typeFmt(opType.dest)} for ${instr.op}`
+      );
     }
   }
   
@@ -227,19 +245,19 @@ function checkConst(instr: bril.Constant) {
     return;
   }
   if (typeof instr.type !== 'string') {
-    console.error(`const of non-primitive type ${instr.type}`);
+    console.error(`const of non-primitive type ${typeFmt(instr.type)}`);
     return;
   }
 
   let valType = CONST_TYPES[instr.type];
   if (!valType) {
-    console.error(`unknown const type ${instr.type}`);
+    console.error(`unknown const type ${typeFmt(instr.type)}`);
     return;
   }
 
   if (typeof instr.value !== valType) {
     console.error(
-      `const value ${instr.value} does not match type ${instr.type}`
+      `const value ${instr.value} does not match type ${typeFmt(instr.type)}`
     );
   }
 }

--- a/bril-ts/types.ts
+++ b/bril-ts/types.ts
@@ -1,0 +1,76 @@
+import * as bril from './bril';
+
+/**
+ * The type signature for an operation.
+ *
+ * Describes the shape and types of all the ingredients for a Bril operation
+ * instruction: arguments, result, labels, and functions.
+ */
+export interface Signature {
+  /**
+   * The types of each argument to the operation.
+   */
+  args: bril.Type[],
+
+  /**
+   * The result type, if non-void.
+   */
+  dest?: bril.Type,
+
+  /**
+   * The number of labels required for the operation.
+   */
+  labels?: number,
+
+  /**
+   * The number of function names required for the operation.
+   */
+  funcs?: number,
+}
+
+/**
+ * The type of a Bril function.
+ */
+export interface FuncType {
+  /**
+   * The types of the function's arguments.
+   */
+  args: bril.Type[],
+
+  /**
+   * The function's return type.
+   */
+  ret: bril.Type | undefined,
+}
+
+/**
+ * Type signatures for the Bril operations we know.
+ */
+export const OP_SIGS: {[key: string]: Signature} = {
+  // Core.
+  'add': {args: ['int', 'int'], dest: 'int'},
+  'mul': {args: ['int', 'int'], dest: 'int'},
+  'sub': {args: ['int', 'int'], dest: 'int'},
+  'div': {args: ['int', 'int'], dest: 'int'},
+  'eq': {args: ['int', 'int'], dest: 'bool'},
+  'lt': {args: ['int', 'int'], dest: 'bool'},
+  'gt': {args: ['int', 'int'], dest: 'bool'},
+  'le': {args: ['int', 'int'], dest: 'bool'},
+  'ge': {args: ['int', 'int'], dest: 'bool'},
+  'not': {args: ['bool'], dest: 'bool'},
+  'and': {args: ['bool', 'bool'], dest: 'bool'},
+  'or': {args: ['bool', 'bool'], dest: 'bool'},
+  'jmp': {args: [], 'labels': 1},
+  'br': {args: ['bool'], 'labels': 2},
+
+  // Floating point.
+  'fadd': {args: ['float', 'float'], dest: 'float'},
+  'fmul': {args: ['float', 'float'], dest: 'float'},
+  'fsub': {args: ['float', 'float'], dest: 'float'},
+  'fdiv': {args: ['float', 'float'], dest: 'float'},
+  'feq': {args: ['float', 'float'], dest: 'bool'},
+  'flt': {args: ['float', 'float'], dest: 'bool'},
+  'fgt': {args: ['float', 'float'], dest: 'bool'},
+  'fle': {args: ['float', 'float'], dest: 'bool'},
+  'fge': {args: ['float', 'float'], dest: 'bool'},
+};

--- a/bril-ts/util.ts
+++ b/bril-ts/util.ts
@@ -12,6 +12,6 @@ export function readStdin(): Promise<string> {
   });
 }
 
-export function unreachable(x: never) {
+export function unreachable(x: never): never {
   throw "impossible case reached";
 }

--- a/test/check/argtype.err
+++ b/test/check/argtype.err
@@ -1,1 +1,1 @@
-b has type bool, but arg 1 should have type int
+b has type bool, but arg 1 for add should have type int

--- a/test/check/badcall.err
+++ b/test/check/badcall.err
@@ -1,9 +1,9 @@
 returning value in function without a return type
 missing return value in function with return type
 function @foo undefined
-@nothing does not return a value
+@nothing should have no result type
 call should have one function, not 2
-@retint returns type int, not bool
+result type of @retint should be int, but found bool
 b has type bool, but arg 0 for @argint should have type int
 @argint expects 1 args, not 0
 @argint expects 1 args, not 2

--- a/test/check/badcall.err
+++ b/test/check/badcall.err
@@ -4,6 +4,6 @@ function @foo undefined
 @nothing does not return a value
 call should have one function, not 2
 @retint returns type int, not bool
-b has type bool, but arg 0 should have type int
+b has type bool, but arg 0 for @argint should have type int
 @argint expects 1 args, not 0
 @argint expects 1 args, not 2

--- a/test/check/badconst.err
+++ b/test/check/badconst.err
@@ -1,4 +1,4 @@
 const value 4 does not match type bool
 const value true does not match type int
-const of non-primitive type [object Object]
+const of non-primitive type ptr<int>
 unknown const type blah

--- a/test/check/badid.err
+++ b/test/check/badid.err
@@ -1,3 +1,3 @@
-id arg type int does not match type bool
+a has type int, but arg 0 for id should have type bool
 missing result type for id
-id should have one arg, not 0
+id expects 1 args, not 0

--- a/test/check/badid.err
+++ b/test/check/badid.err
@@ -1,3 +1,3 @@
 id arg type int does not match type bool
-id arg type int does not match type undefined
+missing result type for id
 id should have one arg, not 0

--- a/test/check/extra.err
+++ b/test/check/extra.err
@@ -1,1 +1,1 @@
-add needs 2 args; found 3
+add expects 2 args, not 3

--- a/test/check/extra.err
+++ b/test/check/extra.err
@@ -1,2 +1,1 @@
 add needs 2 args; found 3
-a has type int, but arg 2 should have type undefined

--- a/test/check/missarg.err
+++ b/test/check/missarg.err
@@ -1,1 +1,1 @@
-add needs 2 args; found 1
+add expects 2 args, not 1

--- a/test/check/ptr.bril
+++ b/test/check/ptr.bril
@@ -1,0 +1,4 @@
+@main(a: ptr<int>) {
+  b: ptr<int> = id a;
+  c: ptr<float> = id a;
+}

--- a/test/check/ptr.err
+++ b/test/check/ptr.err
@@ -1,1 +1,1 @@
-id arg type [object Object] does not match type [object Object]
+id arg type ptr<int> does not match type ptr<float>

--- a/test/check/ptr.err
+++ b/test/check/ptr.err
@@ -1,0 +1,1 @@
+id arg type [object Object] does not match type [object Object]

--- a/test/check/ptr.err
+++ b/test/check/ptr.err
@@ -1,1 +1,1 @@
-id arg type ptr<int> does not match type ptr<float>
+a has type ptr<int>, but arg 0 for id should have type ptr<float>


### PR DESCRIPTION
As a follow-on to #168, this adds support for complex types to the new standalone Bril type checker—namely, pointers. It can now compare and pretty-print types like `{"ptr": {"ptr": "int"}}`. A bunch of refactoring also happened to simplify the checker.

This doesn't yet support the instructions in the memory extension. That will be a little more complicated because all of those ops are polymorphic, i.e., operations like `store` work on `ptr<T>` for any type `T`. I have an idea for how to do that in a reasonably general way, without adding a bunch of special-case checking logic.