### PR TITLE
brilck: Support the memory extension, and a concept of parametric polymorphism

### DIFF
--- a/bril-ts/brilck.ts
+++ b/bril-ts/brilck.ts
@@ -98,7 +98,7 @@ function typeEq(a: bril.Type, b: PolyType, tenv?: TypeEnv): boolean {
   if (typeof a === "string" && typeof b === "string") {
     return a == b;
   } else if (typeof a === "object" && typeof b === "object") {
-    return typeEq(a.ptr, b.ptr);
+    return typeEq(a.ptr, b.ptr, tenv);
   } else {
     return false;
   }

--- a/bril-ts/tsconfig.json
+++ b/bril-ts/tsconfig.json
@@ -3,6 +3,7 @@
         "strict": true,
         "outDir": "build",
         "target": "es6",
+        "lib": ["es2019"],
         "module": "commonjs",
         "sourceMap": true
     }

--- a/bril-ts/tsconfig.json
+++ b/bril-ts/tsconfig.json
@@ -3,7 +3,6 @@
         "strict": true,
         "outDir": "build",
         "target": "es6",
-        "lib": ["es2019"],
         "module": "commonjs",
         "sourceMap": true
     }

--- a/bril-ts/types.ts
+++ b/bril-ts/types.ts
@@ -36,7 +36,7 @@ export type Signature = BaseSignature<bril.Type>;
 /**
  * A polymorphic type variable.
  */
-export type TVar = string;
+export type TVar = {"tv": string};
 
 /**
  * Like bril.Type, except that type variables may occur at the leaves.
@@ -86,7 +86,7 @@ export const OP_SIGS: {[key: string]: Signature | PolySignature} = {
   'or': {args: ['bool', 'bool'], dest: 'bool'},
   'jmp': {args: [], 'labels': 1},
   'br': {args: ['bool'], 'labels': 2},
-  'id': {tvar: 'T', sig: {args: ['T'], dest: 'T'}},
+  'id': {tvar: {tv: 'T'}, sig: {args: [{tv: 'T'}], dest: {tv: 'T'}}},
 
   // Floating point.
   'fadd': {args: ['float', 'float'], dest: 'float'},

--- a/bril-ts/types.ts
+++ b/bril-ts/types.ts
@@ -6,16 +6,16 @@ import * as bril from './bril';
  * Describes the shape and types of all the ingredients for a Bril operation
  * instruction: arguments, result, labels, and functions.
  */
-export interface Signature {
+export interface BaseSignature<T> {
   /**
    * The types of each argument to the operation.
    */
-  args: bril.Type[],
+  args: T[],
 
   /**
    * The result type, if non-void.
    */
-  dest?: bril.Type,
+  dest?: T,
 
   /**
    * The number of labels required for the operation.
@@ -26,6 +26,15 @@ export interface Signature {
    * The number of function names required for the operation.
    */
   funcs?: number,
+}
+
+export type Signature = BaseSignature<bril.Type>;
+
+export type TVar = string;
+
+export interface PolySignature {
+    tvar: TVar;
+    sig: BaseSignature<bril.Type | TVar>;
 }
 
 /**
@@ -46,7 +55,7 @@ export interface FuncType {
 /**
  * Type signatures for the Bril operations we know.
  */
-export const OP_SIGS: {[key: string]: Signature} = {
+export const OP_SIGS: {[key: string]: Signature | PolySignature} = {
   // Core.
   'add': {args: ['int', 'int'], dest: 'int'},
   'mul': {args: ['int', 'int'], dest: 'int'},
@@ -62,6 +71,7 @@ export const OP_SIGS: {[key: string]: Signature} = {
   'or': {args: ['bool', 'bool'], dest: 'bool'},
   'jmp': {args: [], 'labels': 1},
   'br': {args: ['bool'], 'labels': 2},
+  'id': {tvar: 'T', sig: {args: ['T'], dest: 'T'}},
 
   // Floating point.
   'fadd': {args: ['float', 'float'], dest: 'float'},

--- a/bril-ts/types.ts
+++ b/bril-ts/types.ts
@@ -98,4 +98,11 @@ export const OP_SIGS: {[key: string]: Signature | PolySignature} = {
   'fgt': {args: ['float', 'float'], dest: 'bool'},
   'fle': {args: ['float', 'float'], dest: 'bool'},
   'fge': {args: ['float', 'float'], dest: 'bool'},
+  
+  // Memory.
+  'alloc': {tvar: {tv: 'T'}, sig: {args: [{tv: 'T'}], dest: {ptr: {tv: 'T'}}}},
+  'free': {tvar: {tv: 'T'}, sig: {args: [{ptr: {tv: 'T'}}]}},
+  'store': {tvar: {tv: 'T'}, sig: {args: [{ptr: {tv: 'T'}}, {tv: 'T'}]}},
+  'load': {tvar: {tv: 'T'}, sig: {args: [{ptr: {tv: 'T'}}], dest: {tv: 'T'}}},
+  'ptradd': {tvar: {tv: 'T'}, sig: {args: [{ptr: {tv: 'T'}}, 'int'], dest: {ptr: {tv: 'T'}}}},
 };

--- a/bril-ts/types.ts
+++ b/bril-ts/types.ts
@@ -1,7 +1,7 @@
 import * as bril from './bril';
 
 /**
- * The type signature for an operation.
+ * An abstract type signature.
  *
  * Describes the shape and types of all the ingredients for a Bril operation
  * instruction: arguments, result, labels, and functions.
@@ -28,13 +28,28 @@ export interface BaseSignature<T> {
   funcs?: number,
 }
 
+/**
+ * The concrete type signature for an operation.
+ */
 export type Signature = BaseSignature<bril.Type>;
 
+/**
+ * A polymorphic type variable.
+ */
 export type TVar = string;
 
+/**
+ * Like bril.Type, except that type variables may occur at the leaves.
+ */
+export type PolyType = bril.PrimType | TVar | {"ptr": PolyType};
+
+/**
+ * A polymorphic type signature, universally quantified over a single
+ * type variable.
+ */
 export interface PolySignature {
     tvar: TVar;
-    sig: BaseSignature<bril.Type | TVar>;
+    sig: BaseSignature<PolyType>;
 }
 
 /**

--- a/bril-ts/types.ts
+++ b/bril-ts/types.ts
@@ -101,7 +101,7 @@ export const OP_SIGS: {[key: string]: Signature | PolySignature} = {
   'fge': {args: ['float', 'float'], dest: 'bool'},
   
   // Memory.
-  'alloc': {tvar: {tv: 'T'}, sig: {args: [{tv: 'T'}], dest: {ptr: {tv: 'T'}}}},
+  'alloc': {tvar: {tv: 'T'}, sig: {args: ['int'], dest: {ptr: {tv: 'T'}}}},
   'free': {tvar: {tv: 'T'}, sig: {args: [{ptr: {tv: 'T'}}]}},
   'store': {tvar: {tv: 'T'}, sig: {args: [{ptr: {tv: 'T'}}, {tv: 'T'}]}},
   'load': {tvar: {tv: 'T'}, sig: {args: [{ptr: {tv: 'T'}}], dest: {tv: 'T'}}},

--- a/bril-ts/types.ts
+++ b/bril-ts/types.ts
@@ -87,6 +87,7 @@ export const OP_SIGS: {[key: string]: Signature | PolySignature} = {
   'jmp': {args: [], 'labels': 1},
   'br': {args: ['bool'], 'labels': 2},
   'id': {tvar: {tv: 'T'}, sig: {args: [{tv: 'T'}], dest: {tv: 'T'}}},
+  'nop': {args: []},
 
   // Floating point.
   'fadd': {args: ['float', 'float'], dest: 'float'},

--- a/test/check/badid.err
+++ b/test/check/badid.err
@@ -1,3 +1,3 @@
 a has type int, but arg 0 for id should have type bool
-missing result type for id
+missing result type T for id
 id expects 1 args, not 0

--- a/test/check/badmem.bril
+++ b/test/check/badmem.bril
@@ -1,0 +1,15 @@
+@main(i: int, f: float) {
+  p: ptr<int> = alloc f;
+  p2: int = alloc i;
+
+  store p f;
+  store i p;
+
+  j: float = load p;
+  i: int = load i;
+
+  q: ptr<float> = ptradd p i;
+  q2: ptr<int> = ptradd i p;
+
+  free i;
+}

--- a/test/check/badmem.err
+++ b/test/check/badmem.err
@@ -1,0 +1,10 @@
+f has type float, but arg 0 for alloc should have type int
+result type of alloc should be ptr<T>, but found int
+f has type float, but arg 1 for store should have type int
+i has type int, but arg 0 for store should have type ptr<T>
+p has type ptr<int>, but arg 0 for load should have type ptr<T>
+i has type int, but arg 0 for load should have type ptr<T>
+p has type ptr<int>, but arg 0 for ptradd should have type ptr<T>
+i has type int, but arg 0 for ptradd should have type ptr<T>
+p has type ptr<int>, but arg 1 for ptradd should have type int
+i has type int, but arg 0 for free should have type ptr<T>

--- a/test/check/badmem.err
+++ b/test/check/badmem.err
@@ -2,9 +2,9 @@ f has type float, but arg 0 for alloc should have type int
 result type of alloc should be ptr<T>, but found int
 f has type float, but arg 1 for store should have type int
 i has type int, but arg 0 for store should have type ptr<T>
-p has type ptr<int>, but arg 0 for load should have type ptr<T>
-i has type int, but arg 0 for load should have type ptr<T>
-p has type ptr<int>, but arg 0 for ptradd should have type ptr<T>
-i has type int, but arg 0 for ptradd should have type ptr<T>
+p has type ptr<int>, but arg 0 for load should have type ptr<float>
+i has type int, but arg 0 for load should have type ptr<int>
+p has type ptr<int>, but arg 0 for ptradd should have type ptr<float>
+i has type int, but arg 0 for ptradd should have type ptr<int>
 p has type ptr<int>, but arg 1 for ptradd should have type int
 i has type int, but arg 0 for free should have type ptr<T>

--- a/test/check/mem.bril
+++ b/test/check/mem.bril
@@ -1,0 +1,7 @@
+@main(i: int) {
+  p: ptr<int> = alloc i;
+  store p i;
+  j: int = load p;
+  q: ptr<int> = ptradd p i;
+  free p;
+}

--- a/test/check/mem.bril
+++ b/test/check/mem.bril
@@ -1,5 +1,6 @@
 @main(i: int) {
   p: ptr<int> = alloc i;
+  r: ptr<float> = alloc i;
   store p i;
   j: int = load p;
   q: ptr<int> = ptradd p i;


### PR DESCRIPTION
Yep, it's another follow-on to #168. This one adds support for the ever-popular [memory extension](https://capra.cs.cornell.edu/bril/lang/memory.html).

To do that, and to avoid special-casing the logic for every pointer-related instruction, I introduced a way to declare polymorphic types for operations: for example, we can say that the `load` instruction takes an argument of type `ptr<T>` and produces a value of type `T`, where `T` is a type variable. See the the declarations in `types.ts` to for examples of what this looks like; the `id` instruction now also uses this polymorphism.

Checking these types just involves eagerly binding the first occurrence of a type variable when checking. We check left-to-right, starting with the return type. So, for example, if `T` binds to something in the return type, we never backtrack on that decision and assume that `T` binds to the same thing in all of the argument types. So it's not Hindley–Milner by any stretch, but it's good enough for us!