### PR TITLE
brilck: Report source positions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,9 +8,19 @@ TESTS := test/parse/*.bril \
 	examples/test/*/*.bril \
 	benchmarks/*.bril
 
+CHECKS := test/parse/*.bril \
+	test/interp*/*.bril \
+	test/mem/*.bril \
+	examples/test/*/*.bril \
+	benchmarks/*.bril
+
 .PHONY: test
 test:
 	turnt $(TURNTARGS) $(TESTS)
+
+.PHONY: check
+check:
+	for fn in $(CHECKS) ; do echo $$fn ; bril2json -p < $$fn | brilck ; done
 
 .PHONY: book
 book:

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ TESTS := test/parse/*.bril \
 	benchmarks/*.bril
 
 CHECKS := test/parse/*.bril \
-	test/interp*/*.bril \
+	test/interp/*.bril \
 	test/mem/*.bril \
 	examples/test/*/*.bril \
 	benchmarks/*.bril
@@ -20,7 +20,7 @@ test:
 
 .PHONY: check
 check:
-	for fn in $(CHECKS) ; do echo $$fn ; bril2json -p < $$fn | brilck ; done
+	for fn in $(CHECKS) ; do bril2json -p < $$fn | brilck $$fn ; done
 
 .PHONY: book
 book:

--- a/bril-ts/bril.ts
+++ b/bril-ts/bril.ts
@@ -15,12 +15,17 @@ export type PrimType = "int" | "bool" | "float";
 /**
  * Parameterized types. (We only have pointers for now.)
  */
-export type ParamType = {"ptr": Type};
+export type ParamType = {ptr: Type};
 
 /**
  * Value types.
  */
 export type Type = PrimType | ParamType;
+
+/**
+ * An (always optional) source code position.
+ */
+export type Position = {row: number, col: number};
 
 /**
  * Common fields in any operation.
@@ -29,6 +34,7 @@ interface Op {
   args?: Ident[];
   funcs?: Ident[];
   labels?: Ident[];
+  pos?: Position;
 }
 
 /**
@@ -70,6 +76,7 @@ export interface Constant {
   value: Value;
   dest: Ident;
   type: Type;
+  pos?: Position;
 }
 
 
@@ -109,6 +116,7 @@ export type OpCode = ValueOpCode | EffectOpCode;
  */
 export interface Label {
   label: Ident;
+  pos?: Position;
 }
 
 /*
@@ -127,6 +135,7 @@ export interface Function {
   args?: Argument[];
   instrs: (Instruction | Label)[];
   type?: Type;
+  pos?: Position;
 }
 
 /**

--- a/bril-ts/brilck.ts
+++ b/bril-ts/brilck.ts
@@ -43,14 +43,21 @@ interface Env {
 }
 
 /**
+ * An optional filename for error messages.
+ */
+let CHECK_FILE: string | undefined;
+
+/**
  * Print an error message, possibly with a source position.
  */
 function err(msg: string, pos: bril.Position | undefined) {
   if (pos) {
-    console.error(`${pos.row}:${pos.col}: ${msg}`);
-  } else {
-    console.error(msg);
+    msg = `${pos.row}:${pos.col}: ${msg}`;
   }
+  if (CHECK_FILE) {
+    msg = `${CHECK_FILE}:${msg}`;
+  }
+  console.error(msg);
 }
 
 /**
@@ -367,6 +374,9 @@ function checkProg(prog: bril.Program) {
 }
 
 async function main() {
+  if (process.argv[2]) {
+    CHECK_FILE = process.argv[2];
+  }
   let prog = JSON.parse(await readStdin()) as bril.Program;
   checkProg(prog);
 }

--- a/docs/tools/brilck.md
+++ b/docs/tools/brilck.md
@@ -20,3 +20,6 @@ Just pipe a Bril program into `brilck`:
 
 It will print any problems it finds to standard error.
 (If it doesn't find any problems, it doesn't print anything at all.)
+
+You can optionally provide a filename as a (sole) command-line argument.
+This filename will appear in any error messages for easier parsing when many files are involved.

--- a/test/check/argtype.err
+++ b/test/check/argtype.err
@@ -1,1 +1,1 @@
-b has type bool, but arg 1 for add should have type int
+2:3: b has type bool, but arg 1 for add should have type int

--- a/test/check/badcall.err
+++ b/test/check/badcall.err
@@ -1,9 +1,9 @@
-returning value in function without a return type
-missing return value in function with return type
-function @foo undefined
-@nothing should have no result type
-call should have one function, not 2
-result type of @retint should be int, but found bool
-b has type bool, but arg 0 for @argint should have type int
-@argint expects 1 args, not 0
-@argint expects 1 args, not 2
+14:3: returning value in function without a return type
+18:3: missing return value in function with return type
+22:3: function @foo undefined
+23:3: @nothing should have no result type
+24:3: call should have one function, not 2
+25:3: result type of @retint should be int, but found bool
+26:3: b has type bool, but arg 0 for @argint should have type int
+27:3: @argint expects 1 args, not 0
+28:3: @argint expects 1 args, not 2

--- a/test/check/badconst.err
+++ b/test/check/badconst.err
@@ -1,4 +1,4 @@
-const value 4 does not match type bool
-const value true does not match type int
-const of non-primitive type ptr<int>
-unknown const type blah
+2:3: const value 4 does not match type bool
+3:3: const value true does not match type int
+4:3: const of non-primitive type ptr<int>
+5:3: unknown const type blah

--- a/test/check/badid.err
+++ b/test/check/badid.err
@@ -1,3 +1,3 @@
-a has type int, but arg 0 for id should have type bool
-missing result type T for id
-id expects 1 args, not 0
+2:3: a has type int, but arg 0 for id should have type bool
+3:3: missing result type T for id
+4:3: id expects 1 args, not 0

--- a/test/check/badmem.err
+++ b/test/check/badmem.err
@@ -1,10 +1,10 @@
-f has type float, but arg 0 for alloc should have type int
-result type of alloc should be ptr<T>, but found int
-f has type float, but arg 1 for store should have type int
-i has type int, but arg 0 for store should have type ptr<T>
-p has type ptr<int>, but arg 0 for load should have type ptr<float>
-i has type int, but arg 0 for load should have type ptr<int>
-p has type ptr<int>, but arg 0 for ptradd should have type ptr<float>
-i has type int, but arg 0 for ptradd should have type ptr<int>
-p has type ptr<int>, but arg 1 for ptradd should have type int
-i has type int, but arg 0 for free should have type ptr<T>
+2:3: f has type float, but arg 0 for alloc should have type int
+3:3: result type of alloc should be ptr<T>, but found int
+5:3: f has type float, but arg 1 for store should have type int
+6:3: i has type int, but arg 0 for store should have type ptr<T>
+8:3: p has type ptr<int>, but arg 0 for load should have type ptr<float>
+9:3: i has type int, but arg 0 for load should have type ptr<int>
+11:3: p has type ptr<int>, but arg 0 for ptradd should have type ptr<float>
+12:3: i has type int, but arg 0 for ptradd should have type ptr<int>
+12:3: p has type ptr<int>, but arg 1 for ptradd should have type int
+14:3: i has type int, but arg 0 for free should have type ptr<T>

--- a/test/check/extra.err
+++ b/test/check/extra.err
@@ -1,1 +1,1 @@
-add expects 2 args, not 3
+2:3: add expects 2 args, not 3

--- a/test/check/labels.err
+++ b/test/check/labels.err
@@ -1,5 +1,5 @@
-multiply defined label .bar
-label .bad undefined
-br needs 2 labels; found 1
-br needs 2 labels; found 3
-not needs 0 labels; found 1
+8:1: multiply defined label .bar
+2:3: label .bad undefined
+3:3: br needs 2 labels; found 1
+4:3: br needs 2 labels; found 3
+5:3: not needs 0 labels; found 1

--- a/test/check/missarg.err
+++ b/test/check/missarg.err
@@ -1,1 +1,1 @@
-add expects 2 args, not 1
+2:3: add expects 2 args, not 1

--- a/test/check/missdest.err
+++ b/test/check/missdest.err
@@ -1,1 +1,1 @@
-missing result type int for add
+2:3: missing result type int for add

--- a/test/check/printres.err
+++ b/test/check/printres.err
@@ -1,1 +1,1 @@
-print should have no result type
+2:3: print should have no result type

--- a/test/check/ptr.err
+++ b/test/check/ptr.err
@@ -1,1 +1,1 @@
-a has type ptr<int>, but arg 0 for id should have type ptr<float>
+3:3: a has type ptr<int>, but arg 0 for id should have type ptr<float>

--- a/test/check/typeconflict.err
+++ b/test/check/typeconflict.err
@@ -1,1 +1,1 @@
-new type int for a conflicts with old type bool
+3:3: new type int for a conflicts with old type bool

--- a/test/check/undef.err
+++ b/test/check/undef.err
@@ -1,1 +1,1 @@
-a (arg 0) undefined
+2:3: a (arg 0) undefined


### PR DESCRIPTION
At last, the unification of #168 and #161! The `brilck` command can report source-code positions for all errors. I also added (and documented) an optional argument to the command to include source filenames for easy parsing.

A new `make check` target runs `brilck` on a bunch of tests and benchmarks. The current output, concealed below, reveals several problems and several unsupported ops.

<details>
<summary>Current output of <code>make check</code>.</summary>
<pre>
test/parse/mem.bril:19:3: vx has type ptr<bool>, but arg 0 for load should have type ptr<ptr<bool>>
test/interp/spec-abort.bril:3:3: unknown opcode speculate
test/interp/spec-abort.bril:6:3: unknown opcode guard
test/interp/spec-abort.bril:7:3: unknown opcode commit
test/interp/spec-commit.bril:3:3: unknown opcode speculate
test/interp/spec-commit.bril:5:3: unknown opcode commit
test/interp/spec-nested.bril:3:3: unknown opcode speculate
test/interp/spec-nested.bril:5:3: unknown opcode speculate
test/interp/spec-nested.bril:8:3: unknown opcode guard
test/interp/spec-nested.bril:13:3: unknown opcode guard
test/interp/spec-nested.bril:14:3: unknown opcode commit
test/interp/spec-noabort.bril:3:3: unknown opcode speculate
test/interp/spec-noabort.bril:6:3: unknown opcode guard
test/interp/spec-noabort.bril:7:3: unknown opcode commit
test/interp/ssa-simple-inv.bril:9:3: unknown opcode phi
test/interp/ssa-simple.bril:9:3: unknown opcode phi
examples/test/lvn/fold-comparisons.bril:6:3: unknown opcode ne
examples/test/lvn/logical-operators.bril:4:3: const value true does not match type int
examples/test/lvn/logical-operators.bril:5:3: const value false does not match type int
examples/test/lvn/logical-operators.bril:7:3: f has type int, but arg 0 for and should have type bool
examples/test/lvn/logical-operators.bril:7:3: t has type int, but arg 1 for and should have type bool
examples/test/lvn/logical-operators.bril:8:3: t has type int, but arg 0 for and should have type bool
examples/test/lvn/logical-operators.bril:8:3: f has type int, but arg 1 for and should have type bool
examples/test/lvn/logical-operators.bril:9:3: t has type int, but arg 0 for or should have type bool
examples/test/lvn/logical-operators.bril:9:3: f has type int, but arg 1 for or should have type bool
examples/test/lvn/logical-operators.bril:10:3: f has type int, but arg 0 for or should have type bool
examples/test/lvn/logical-operators.bril:10:3: t has type int, but arg 1 for or should have type bool
examples/test/lvn/logical-operators.bril:11:3: t has type int, but arg 0 for not should have type bool
examples/test/lvn/logical-operators.bril:12:3: f has type int, but arg 0 for not should have type bool
examples/test/lvn/logical-operators.bril:14:3: f has type int, but arg 0 for and should have type bool
examples/test/lvn/logical-operators.bril:15:3: f has type int, but arg 1 for and should have type bool
examples/test/lvn/logical-operators.bril:16:3: t has type int, but arg 0 for or should have type bool
examples/test/lvn/logical-operators.bril:17:3: t has type int, but arg 1 for or should have type bool
examples/test/lvn/logical-operators.bril:19:3: t has type int, but arg 0 for and should have type bool
examples/test/lvn/logical-operators.bril:20:3: t has type int, but arg 1 for and should have type bool
examples/test/lvn/logical-operators.bril:21:3: f has type int, but arg 0 for or should have type bool
examples/test/lvn/logical-operators.bril:22:3: f has type int, but arg 1 for or should have type bool
examples/test/ssa/if-ssa.bril:12:5: unknown opcode phi
examples/test/ssa/loop-ssa.bril:6:5: unknown opcode phi
examples/test/to_ssa/if-ssa.bril:14:5: unknown opcode phi
benchmarks/mat-inv.bril:10:3: matrix has type ptr<float>, but arg 0 for ptradd should have type ptr<int>
benchmarks/mat-inv.bril:11:3: ptr has type ptr<int>, but arg 0 for load should have type ptr<float>
benchmarks/mat-inv.bril:54:3: missing result type bool for lt
benchmarks/mat-inv.bril:55:3: i_lt_three (arg 0) undefined
benchmarks/mat-inv.bril:147:3: inv has type ptr<float>, but arg 1 for @printarray should have type ptr<bril>
benchmarks/mat-inv.bril:162:3: arr has type ptr<bril>, but arg 0 for ptradd should have type ptr<float>
benchmarks/riemann.bril:29:5: new type bool for b conflicts with old type float
benchmarks/riemann.bril:35:5: new type undefined for sum conflicts with old type float
benchmarks/riemann.bril:36:5: new type undefined for i conflicts with old type float
benchmarks/riemann.bril:39:5: new type undefined for sum conflicts with old type float
benchmarks/riemann.bril:30:5: b has type float, but arg 0 for br should have type bool
benchmarks/riemann.bril:35:5: missing result type float for fadd
benchmarks/riemann.bril:36:5: missing result type float for fsub
benchmarks/riemann.bril:39:5: missing result type float for fmul
benchmarks/riemann.bril:51:5: new type bool for b conflicts with old type float
benchmarks/riemann.bril:57:5: new type undefined for sum conflicts with old type float
benchmarks/riemann.bril:58:5: new type undefined for i conflicts with old type float
benchmarks/riemann.bril:61:5: new type undefined for sum conflicts with old type float
benchmarks/riemann.bril:52:5: b has type float, but arg 0 for br should have type bool
benchmarks/riemann.bril:57:5: missing result type float for fadd
benchmarks/riemann.bril:58:5: missing result type float for fsub
benchmarks/riemann.bril:61:5: missing result type float for fmul
benchmarks/riemann.bril:75:5: new type bool for b conflicts with old type float
benchmarks/riemann.bril:80:5: new type undefined for offset conflicts with old type float
benchmarks/riemann.bril:83:5: new type undefined for sum conflicts with old type float
benchmarks/riemann.bril:84:5: new type undefined for i conflicts with old type float
benchmarks/riemann.bril:87:5: new type undefined for sum conflicts with old type float
benchmarks/riemann.bril:76:5: b has type float, but arg 0 for br should have type bool
benchmarks/riemann.bril:80:5: missing result type float for fadd
benchmarks/riemann.bril:83:5: missing result type float for fadd
benchmarks/riemann.bril:84:5: missing result type float for fsub
benchmarks/riemann.bril:87:5: missing result type float for fmul
benchmarks/up-arrow.bril:15:3: result type of lt should be bool, but found int
benchmarks/up-arrow.bril:16:3: keepgoing has type int, but arg 0 for br should have type bool
</pre>
</details>