### PR TITLE
bril-rs Housekeeping and Github actions for Rust

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -1,0 +1,39 @@
+on:
+  push:
+    branches:
+     - main
+  pull_request:
+    branches:
+     - main
+
+name: Workflow checks for rust code
+
+jobs:
+  rust-ci:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        path: ["brilirs/Cargo.toml", "bril-rs/Cargo.toml", "bril-rs/bril2json/Cargo.toml"]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+          components: rustfmt, clippy
+
+      - uses: actions-rs/cargo@v1
+        with:
+          command: check
+          args: --manifest-path ${{ matrix.path }} --all-targets
+
+      - uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --manifest-path ${{ matrix.path }} --all -- --check
+
+      - uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: --manifest-path ${{ matrix.path }} -- -D warnings

--- a/bril-rs/bril2json/src/bril_grammar.lalrpop
+++ b/bril-rs/bril2json/src/bril_grammar.lalrpop
@@ -17,6 +17,7 @@
 #![allow(clippy::use_self)]
 #![allow(clippy::needless_pass_by_value)]
 #![allow(clippy::cast_sign_loss)]
+#![allow(clippy::must_use_candidate)]
 
 use std::str::FromStr;
 use crate::Lines;

--- a/bril-rs/bril2json/src/lib.rs
+++ b/bril-rs/bril2json/src/lib.rs
@@ -1,6 +1,5 @@
 #![warn(clippy::all, clippy::pedantic, clippy::nursery, clippy::cargo)]
 // todo these are allowed to appease clippy but should be addressed some day
-#![allow(clippy::must_use_candidate)]
 #![allow(clippy::missing_panics_doc)]
 #![allow(clippy::cargo_common_metadata)]
 
@@ -60,6 +59,7 @@ pub fn parse_abstract_program_from_read<R: std::io::Read>(
         .unwrap()
 }
 
+#[must_use]
 pub fn parse_abstract_program(use_pos: bool) -> AbstractProgram {
     parse_abstract_program_from_read(std::io::stdin(), use_pos)
 }

--- a/bril-rs/bril2json/src/lib.rs
+++ b/bril-rs/bril2json/src/lib.rs
@@ -3,6 +3,8 @@
 #![allow(clippy::missing_panics_doc)]
 #![allow(clippy::cargo_common_metadata)]
 
+// Tell the github workflow check to not format the generated rust program bril_grammar.rs
+#[rustfmt::skip]
 pub mod bril_grammar;
 pub mod cli;
 use bril_rs::{AbstractProgram, Position};

--- a/bril-rs/bril2json/src/main.rs
+++ b/bril-rs/bril2json/src/main.rs
@@ -1,9 +1,9 @@
 use bril2json::cli::Cli;
-use bril2json::load_abstract_program;
+use bril2json::parse_abstract_program;
 use bril_rs::output_abstract_program;
 use clap::Parser;
 
 fn main() {
     let args = Cli::parse();
-    output_abstract_program(&load_abstract_program(args.position))
+    output_abstract_program(&parse_abstract_program(args.position))
 }

--- a/bril-rs/src/abstract_program.rs
+++ b/bril-rs/src/abstract_program.rs
@@ -20,7 +20,7 @@ pub struct AbstractProgram {
 impl Display for AbstractProgram {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         for func in &self.functions {
-            writeln!(f, "{}", func)?;
+            writeln!(f, "{func}")?;
         }
         Ok(())
     }
@@ -50,16 +50,16 @@ impl Display for AbstractFunction {
                 if i != 0 {
                     write!(f, ", ")?;
                 }
-                write!(f, "{}", arg)?;
+                write!(f, "{arg}")?;
             }
             write!(f, ")")?;
         }
         if let Some(tpe) = self.return_type.as_ref() {
-            write!(f, ": {}", tpe)?;
+            write!(f, ": {tpe}")?;
         }
         writeln!(f, " {{")?;
         for instr in &self.instrs {
-            writeln!(f, "{}", instr)?;
+            writeln!(f, "{instr}")?;
         }
         write!(f, "}}")?;
         Ok(())
@@ -98,8 +98,8 @@ impl Display for AbstractCode {
                 label,
                 #[cfg(feature = "position")]
                     pos: _,
-            } => write!(f, ".{}:", label),
-            AbstractCode::Instruction(instr) => write!(f, "  {}", instr),
+            } => write!(f, ".{label}:"),
+            AbstractCode::Instruction(instr) => write!(f, "  {instr}"),
         }
     }
 }
@@ -157,8 +157,8 @@ impl Display for AbstractInstruction {
                 #[cfg(feature = "position")]
                     pos: _,
             } => match const_type {
-                Some(const_type) => write!(f, "{}: {} = {} {};", dest, const_type, op, value),
-                None => write!(f, "{} = {} {};", dest, op, value),
+                Some(const_type) => write!(f, "{dest}: {const_type} = {op} {value};"),
+                None => write!(f, "{dest} = {op} {value};"),
             },
             AbstractInstruction::Value {
                 op,
@@ -171,17 +171,17 @@ impl Display for AbstractInstruction {
                     pos: _,
             } => {
                 match op_type {
-                    Some(op_type) => write!(f, "{}: {} = {}", dest, op_type, op)?,
-                    None => write!(f, "{} = {}", dest, op)?,
+                    Some(op_type) => write!(f, "{dest}: {op_type} = {op}")?,
+                    None => write!(f, "{dest} = {op}")?,
                 }
                 for func in funcs {
-                    write!(f, " @{}", func)?;
+                    write!(f, " @{func}")?;
                 }
                 for arg in args {
-                    write!(f, " {}", arg)?;
+                    write!(f, " {arg}")?;
                 }
                 for label in labels {
-                    write!(f, " .{}", label)?;
+                    write!(f, " .{label}")?;
                 }
                 write!(f, ";")
             }
@@ -193,15 +193,15 @@ impl Display for AbstractInstruction {
                 #[cfg(feature = "position")]
                     pos: _,
             } => {
-                write!(f, "{}", op)?;
+                write!(f, "{op}")?;
                 for func in funcs {
-                    write!(f, " @{}", func)?;
+                    write!(f, " @{func}")?;
                 }
                 for arg in args {
-                    write!(f, " {}", arg)?;
+                    write!(f, " {arg}")?;
                 }
                 for label in labels {
-                    write!(f, " .{}", label)?;
+                    write!(f, " .{label}")?;
                 }
                 write!(f, ";")
             }
@@ -292,9 +292,9 @@ impl Serialize for AbstractType {
 impl Display for AbstractType {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
-            AbstractType::Primitive(t) => write!(f, "{}", t),
+            AbstractType::Primitive(t) => write!(f, "{t}"),
 
-            AbstractType::Parameterized(t, at) => write!(f, "{}<{}>", t, at),
+            AbstractType::Parameterized(t, at) => write!(f, "{t}<{at}>"),
         }
     }
 }

--- a/bril-rs/src/conversion.rs
+++ b/bril-rs/src/conversion.rs
@@ -34,6 +34,7 @@ pub enum ConversionError {
 }
 
 impl ConversionError {
+    #[must_use]
     pub fn add_pos(self, pos_var: Option<Position>) -> PositionalConversionError {
         match self {
             //Self::PositionalConversionErrorConversion(e) => e,
@@ -52,6 +53,7 @@ pub struct PositionalConversionError {
 }
 
 impl PositionalConversionError {
+    #[must_use]
     pub fn new(e: ConversionError) -> Self {
         Self {
             e: Box::new(e),
@@ -296,11 +298,11 @@ impl TryFrom<AbstractType> for Type {
             AbstractType::Primitive(t) if t == "int" => Self::Int,
             AbstractType::Primitive(t) if t == "bool" => Self::Bool,
             #[cfg(feature = "float")]
-            AbstractType::Primitive(t) if t == "float" => Type::Float,
+            AbstractType::Primitive(t) if t == "float" => Self::Float,
             AbstractType::Primitive(t) => return Err(ConversionError::InvalidPrimitive(t)),
             #[cfg(feature = "memory")]
             AbstractType::Parameterized(t, ty) if t == "ptr" => {
-                Type::Pointer(Box::new((*ty).try_into()?))
+                Self::Pointer(Box::new((*ty).try_into()?))
             }
             AbstractType::Parameterized(t, ty) => {
                 return Err(ConversionError::InvalidParameterized(t, ty.to_string()))

--- a/bril-rs/src/conversion.rs
+++ b/bril-rs/src/conversion.rs
@@ -65,13 +65,13 @@ impl Display for PositionalConversionError {
         match self {
             #[cfg(feature = "position")]
             PositionalConversionError { e, pos: Some(pos) } => {
-                write!(f, "Line {}, Column {}: {}", pos.row, pos.col, e)
+                write!(f, "Line {}, Column {}: {e}", pos.row, pos.col)
             }
             #[cfg(not(feature = "position"))]
             PositionalConversionError { e: _, pos: Some(_) } => {
                 unreachable!()
             }
-            PositionalConversionError { e, pos: None } => write!(f, "{}", e),
+            PositionalConversionError { e, pos: None } => write!(f, "{e}"),
         }
     }
 }

--- a/bril-rs/src/lib.rs
+++ b/bril-rs/src/lib.rs
@@ -1,8 +1,6 @@
 #![warn(clippy::all, clippy::pedantic, clippy::nursery, clippy::cargo)]
 // todo these are allowed to appease clippy but should be addressed some day
-#![allow(clippy::missing_errors_doc)]
 #![allow(clippy::missing_panics_doc)]
-#![allow(clippy::must_use_candidate)]
 #![allow(clippy::cargo_common_metadata)]
 #![allow(clippy::too_many_lines)]
 
@@ -22,6 +20,7 @@ pub fn load_program_from_read<R: std::io::Read>(mut input: R) -> Program {
     serde_json::from_str(&buffer).unwrap()
 }
 
+#[must_use]
 pub fn load_program() -> Program {
     load_program_from_read(std::io::stdin())
 }
@@ -37,6 +36,7 @@ pub fn load_abstract_program_from_read<R: std::io::Read>(mut input: R) -> Abstra
     serde_json::from_str(&buffer).unwrap()
 }
 
+#[must_use]
 pub fn load_abstract_program() -> AbstractProgram {
     load_abstract_program_from_read(std::io::stdin())
 }

--- a/bril-rs/src/program.rs
+++ b/bril-rs/src/program.rs
@@ -138,7 +138,8 @@ pub enum Instruction {
 
 #[cfg(feature = "position")]
 impl Instruction {
-    pub fn get_pos(&self) -> Option<Position> {
+    #[must_use]
+    pub const fn get_pos(&self) -> Option<Position> {
         match self {
             Instruction::Constant { pos, .. }
             | Instruction::Value { pos, .. }
@@ -405,6 +406,7 @@ impl Display for Literal {
 }
 
 impl Literal {
+    #[must_use]
     pub const fn get_type(&self) -> Type {
         match self {
             Literal::Int(_) => Type::Int,

--- a/bril-rs/src/program.rs
+++ b/bril-rs/src/program.rs
@@ -10,7 +10,7 @@ pub struct Program {
 impl Display for Program {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         for func in &self.functions {
-            writeln!(f, "{}", func)?;
+            writeln!(f, "{func}")?;
         }
         Ok(())
     }
@@ -40,16 +40,16 @@ impl Display for Function {
                 if i != 0 {
                     write!(f, ", ")?;
                 }
-                write!(f, "{}", arg)?;
+                write!(f, "{arg}")?;
             }
             write!(f, ")")?;
         }
         if let Some(tpe) = self.return_type.as_ref() {
-            write!(f, ": {}", tpe)?;
+            write!(f, ": {tpe}")?;
         }
         writeln!(f, " {{")?;
         for instr in &self.instrs {
-            writeln!(f, "{}", instr)?;
+            writeln!(f, "{instr}")?;
         }
         write!(f, "}}")?;
         Ok(())
@@ -88,8 +88,8 @@ impl Display for Code {
                 label,
                 #[cfg(feature = "position")]
                     pos: _,
-            } => write!(f, ".{}:", label),
-            Code::Instruction(instr) => write!(f, "  {}", instr),
+            } => write!(f, ".{label}:"),
+            Code::Instruction(instr) => write!(f, "  {instr}"),
         }
     }
 }
@@ -158,7 +158,7 @@ impl Display for Instruction {
                 #[cfg(feature = "position")]
                     pos: _,
             } => {
-                write!(f, "{}: {} = {} {};", dest, const_type, op, value)
+                write!(f, "{dest}: {const_type} = {op} {value};")
             }
             Instruction::Value {
                 op,
@@ -170,15 +170,15 @@ impl Display for Instruction {
                 #[cfg(feature = "position")]
                     pos: _,
             } => {
-                write!(f, "{}: {} = {}", dest, op_type, op)?;
+                write!(f, "{dest}: {op_type} = {op}")?;
                 for func in funcs {
-                    write!(f, " @{}", func)?;
+                    write!(f, " @{func}")?;
                 }
                 for arg in args {
-                    write!(f, " {}", arg)?;
+                    write!(f, " {arg}")?;
                 }
                 for label in labels {
-                    write!(f, " .{}", label)?;
+                    write!(f, " .{label}")?;
                 }
                 write!(f, ";")
             }
@@ -190,15 +190,15 @@ impl Display for Instruction {
                 #[cfg(feature = "position")]
                     pos: _,
             } => {
-                write!(f, "{}", op)?;
+                write!(f, "{op}")?;
                 for func in funcs {
-                    write!(f, " @{}", func)?;
+                    write!(f, " @{func}")?;
                 }
                 for arg in args {
-                    write!(f, " {}", arg)?;
+                    write!(f, " {arg}")?;
                 }
                 for label in labels {
-                    write!(f, " .{}", label)?;
+                    write!(f, " .{label}")?;
                 }
                 write!(f, ";")
             }
@@ -379,7 +379,7 @@ impl Display for Type {
             #[cfg(feature = "float")]
             Type::Float => write!(f, "float"),
             #[cfg(feature = "memory")]
-            Type::Pointer(tpe) => write!(f, "ptr<{}>", tpe),
+            Type::Pointer(tpe) => write!(f, "ptr<{tpe}>"),
         }
     }
 }
@@ -396,10 +396,10 @@ pub enum Literal {
 impl Display for Literal {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
-            Literal::Int(i) => write!(f, "{}", i),
-            Literal::Bool(b) => write!(f, "{}", b),
+            Literal::Int(i) => write!(f, "{i}"),
+            Literal::Bool(b) => write!(f, "{b}"),
             #[cfg(feature = "float")]
-            Literal::Float(x) => write!(f, "{}", x),
+            Literal::Float(x) => write!(f, "{x}"),
         }
     }
 }

--- a/brilirs/build.rs
+++ b/brilirs/build.rs
@@ -34,10 +34,9 @@ fn main() -> Result<(), Error> {
   };
 
   println!(
-    "cargo:warning={} completion file is generated: {:?}",
-    app.get_name(),
-    path
+    "cargo:warning={} completion file is generated: {path:?}",
+    app.get_name()
   );
-  println!("cargo:warning=enable this by running `source {:?}`", path);
+  println!("cargo:warning=enable this by running `source {path:?}`");
   Ok(())
 }

--- a/brilirs/build.rs
+++ b/brilirs/build.rs
@@ -20,13 +20,13 @@ fn main() -> Result<(), Error> {
   let bin_name = app.get_name().to_string();
 
   // This is an attempt at being smart. Instead, one could just generate completion scripts for all of the shells in a completions/ directory and have the user choose the appropriate one.
-  let path = match env!("SHELL") {
-    s if s.contains("bash") => generate_to(Bash, &mut app, bin_name, out_dir)?,
-    s if s.contains("fish") => generate_to(Fish, &mut app, bin_name, out_dir)?,
-    s if s.contains("zsh") => generate_to(Zsh, &mut app, bin_name, out_dir)?,
-    s if s.contains("elvish") => generate_to(Elvish, &mut app, bin_name, out_dir)?,
-    s if s.contains("powershell") => generate_to(PowerShell, &mut app, bin_name, out_dir)?,
-    _ => {
+  let path = match env::var("SHELL") {
+    Ok(s) if s.contains("bash") => generate_to(Bash, &mut app, bin_name, out_dir)?,
+    Ok(s) if s.contains("fish") => generate_to(Fish, &mut app, bin_name, out_dir)?,
+    Ok(s) if s.contains("zsh") => generate_to(Zsh, &mut app, bin_name, out_dir)?,
+    Ok(s) if s.contains("elvish") => generate_to(Elvish, &mut app, bin_name, out_dir)?,
+    Ok(s) if s.contains("powershell") => generate_to(PowerShell, &mut app, bin_name, out_dir)?,
+    Ok(_) | Err(_) => {
       let mut x = PathBuf::new();
       x.push("Your shell could not be detected from the $SHELL environment variable so no shell completions were generated. Check the build.rs file if you want to see how this was generated.");
       x

--- a/brilirs/src/basic_block.rs
+++ b/brilirs/src/basic_block.rs
@@ -140,7 +140,7 @@ impl BBFunction {
       .collect();
 
     let mut curr_block = BasicBlock::new();
-    for instr in func.instrs.into_iter() {
+    for instr in func.instrs {
       match instr {
         bril_rs::Code::Label { label, pos: _ } => {
           if !curr_block.instrs.is_empty() || curr_block.label.is_some() {
@@ -221,12 +221,7 @@ impl BBFunction {
         // Get the last instruction
         let last_instr = block.instrs.last().cloned();
         if let Some(bril_rs::Instruction::Effect {
-          op: bril_rs::EffectOps::Jump,
-          labels,
-          ..
-        })
-        | Some(bril_rs::Instruction::Effect {
-          op: bril_rs::EffectOps::Branch,
+          op: bril_rs::EffectOps::Jump | bril_rs::EffectOps::Branch,
           labels,
           ..
         }) = last_instr

--- a/brilirs/src/error.rs
+++ b/brilirs/src/error.rs
@@ -83,9 +83,9 @@ impl Display for PositionalInterpError {
   fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
     match self {
       PositionalInterpError { e, pos: Some(pos) } => {
-        write!(f, "Line {}, Column {}: {}", pos.row, pos.col, e)
+        write!(f, "Line {}, Column {}: {e}", pos.row, pos.col)
       }
-      PositionalInterpError { e, pos: None } => write!(f, "{}", e),
+      PositionalInterpError { e, pos: None } => write!(f, "{e}"),
     }
   }
 }

--- a/brilirs/src/interp.rs
+++ b/brilirs/src/interp.rs
@@ -230,7 +230,6 @@ impl<'a> From<&'a Value> for &'a Pointer {
 }
 
 // todo do this with less function arguments
-#[allow(clippy::float_cmp)]
 #[inline(always)]
 fn execute_value_op<'a, T: std::io::Write>(
   prog: &'a BBProgram,

--- a/brilirs/src/interp.rs
+++ b/brilirs/src/interp.rs
@@ -149,10 +149,10 @@ impl Pointer {
 impl fmt::Display for Value {
   fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
     match self {
-      Value::Int(i) => write!(f, "{}", i),
-      Value::Bool(b) => write!(f, "{}", b),
-      Value::Float(v) => write!(f, "{}", v),
-      Value::Pointer(p) => write!(f, "{:?}", p),
+      Value::Int(i) => write!(f, "{i}"),
+      Value::Bool(b) => write!(f, "{b}"),
+      Value::Float(v) => write!(f, "{v}"),
+      Value::Pointer(p) => write!(f, "{p:?}"),
       // This is safe because Uninitialized is only used in relation to memory and immediately errors if this value is returned. Otherwise this value can not appear in the code
       Value::Uninitialized => unsafe { unreachable_unchecked() },
     }
@@ -696,7 +696,7 @@ pub fn execute_main<T: std::io::Write>(
   }
 
   if profiling {
-    eprintln!("total_dyn_inst: {}", instruction_count);
+    eprintln!("total_dyn_inst: {instruction_count}");
   }
 
   Ok(())

--- a/brilirs/src/lib.rs
+++ b/brilirs/src/lib.rs
@@ -1,7 +1,6 @@
 // The group clippy::pedantic is not used as it ends up being more annoying than useful
 #![warn(clippy::all, clippy::nursery, clippy::cargo)]
 // todo these are allowed to appease clippy but should be addressed some day
-#![allow(clippy::missing_errors_doc)]
 #![allow(clippy::cargo_common_metadata)]
 #![allow(clippy::too_many_arguments)]
 

--- a/brilirs/src/main.rs
+++ b/brilirs/src/main.rs
@@ -19,7 +19,7 @@ fn main() {
     args.check,
     args.text,
   ) {
-    eprintln!("error: {}", e);
+    eprintln!("error: {e}");
     std::process::exit(2)
   }
 }


### PR DESCRIPTION
I was separately thinking about a clippy lint for the simpler 2021 edition format arguments like in 7432319 when I realized that I had a small `bril2json` bug in 2ca7f95. With the recent work in support of #155, I was inspired by this bug to suggest a similar set of github actions for running basic checks(`check`, `fmt`, and `clippy`) on the rust code bases in 62cb25c. I've never really used github actions before, but `actions-rs` seems to be leading project for rust actions and with some modification to the code base in f2bc178 to support this, I was pleasantly surprised that it found 8e51666 that I had missed when fiddling with the clippy lints in df247bf. 

One could run more checks through the workflow like running `brilirs --check` against the benchmarks but with the development of `brilck` this is probably becoming less necessary and also more likely to become outdated compared to the main bril toolchain.