### PR TITLE
Rust Library and Brilirs documentation

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -49,3 +49,8 @@ jobs:
         with:
           command: clippy
           args: --manifest-path ${{ matrix.path }} -- -D warnings
+
+      - uses: actions-rs/cargo@v1
+        with:
+          command: doc
+          args: --manifest-path ${{ matrix.path }}

--- a/bril-rs/Cargo.toml
+++ b/bril-rs/Cargo.toml
@@ -3,6 +3,13 @@ name = "bril-rs"
 version = "0.1.0"
 authors = ["Patrick LaFontaine <32135464+Pat-Lafon@users.noreply.github.com>"]
 edition = "2021"
+description = "A rust representation of the Bril language"
+readme = "README.md"
+repository = "https://github.com/sampsyo/bril"
+# license = "MIT"
+license-file = "../LICENSE"
+categories = ["command-line-utilities", "compilers", "data-structures", "parser-implementations"]
+keywords = ["compiler", "bril", "parser", "data-structures", "language"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/bril-rs/README.md
+++ b/bril-rs/README.md
@@ -1,0 +1,3 @@
+# Bril-rs
+
+Bril-rs provides a straightforward representation of structurally valid Bril programs.

--- a/bril-rs/README.md
+++ b/bril-rs/README.md
@@ -1,3 +1,11 @@
 # Bril-rs
 
 Bril-rs provides a straightforward representation of structurally valid Bril programs.
+
+`bril_rs` provides two representations of Bril programs: `Program` and `AbstractProgram`. Both representations parse from JSON using `serde` and are included with helper functions for going between JSON and Rust.
+
+`Program` is the recommended representation for most use-cases of this library as it implements the Bril core with the main extensions in a structured way(using enums). `AbstractProgram` is a less structured version of `Program` using strings. This is useful if you are working with a non-standard extension of Bril or are implementing your own Bril operations and don't want to modify this library.
+
+See the full documentation with `cargo doc --open`.
+
+This library is used to reimplement `bril2txt` and `bril2json` in Rust as a proof of concept. These tools are drop in replacements and can be installed with `make install`. Make sure `$HOME/.cargo/bin` is on your path. You can then use `--help` to check for the flags of each tool.

--- a/bril-rs/bril2json/Cargo.toml
+++ b/bril-rs/bril2json/Cargo.toml
@@ -3,6 +3,13 @@ name = "bril2json"
 version = "0.1.0"
 authors = ["Patrick LaFontaine <32135464+Pat-Lafon@users.noreply.github.com>"]
 edition = "2021"
+description = "A rust parser of the Bril language text representation"
+readme = "README.md"
+repository = "https://github.com/sampsyo/bril"
+# license = "MIT"
+license-file = "../../LICENSE"
+categories = ["command-line-utilities", "compilers", "parser-implementations"]
+keywords = ["compiler", "bril", "parser", "data-structures", "language"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/bril-rs/bril2json/README.md
+++ b/bril-rs/bril2json/README.md
@@ -1,0 +1,3 @@
+# Bril2json
+
+This project is a Rust implementation of the Bril2json tool.

--- a/bril-rs/bril2json/README.md
+++ b/bril-rs/bril2json/README.md
@@ -1,3 +1,5 @@
 # Bril2json
 
 This project is a Rust implementation of the Bril2json tool.
+
+View the interface with `cargo doc --open` or install with `make install` using the Makefile in `bril/bril_rs`.

--- a/bril-rs/bril2json/src/lib.rs
+++ b/bril-rs/bril2json/src/lib.rs
@@ -1,13 +1,16 @@
 #![warn(clippy::all, clippy::pedantic, clippy::nursery, clippy::cargo)]
-// todo these are allowed to appease clippy but should be addressed some day
-#![allow(clippy::missing_panics_doc)]
+#![warn(missing_docs)]
+#![doc = include_str!("../README.md")]
 
 // Tell the github workflow check to not format the generated rust program bril_grammar.rs
+#[doc(hidden)]
 #[rustfmt::skip]
 pub mod bril_grammar;
+#[doc(hidden)]
 pub mod cli;
 use bril_rs::{AbstractProgram, Position};
 
+#[doc(hidden)]
 #[derive(Clone)]
 pub struct Lines {
     use_pos: bool,
@@ -48,6 +51,9 @@ impl Lines {
     }
 }
 
+/// The entrance point to the bril2json parser. It takes an ```input```:[`std::io::Read`] which should be the Bril text file. You can control whether it includes source code positions with ```use_pos```.
+/// # Panics
+/// Will panic if the input is not well-formed Bril text
 pub fn parse_abstract_program_from_read<R: std::io::Read>(
     mut input: R,
     use_pos: bool,
@@ -61,6 +67,7 @@ pub fn parse_abstract_program_from_read<R: std::io::Read>(
 }
 
 #[must_use]
+/// A wrapper around [`parse_abstract_program_from_read`] which assumes [`std::io::Stdin`]
 pub fn parse_abstract_program(use_pos: bool) -> AbstractProgram {
     parse_abstract_program_from_read(std::io::stdin(), use_pos)
 }

--- a/bril-rs/bril2json/src/lib.rs
+++ b/bril-rs/bril2json/src/lib.rs
@@ -1,7 +1,6 @@
 #![warn(clippy::all, clippy::pedantic, clippy::nursery, clippy::cargo)]
 // todo these are allowed to appease clippy but should be addressed some day
 #![allow(clippy::missing_panics_doc)]
-#![allow(clippy::cargo_common_metadata)]
 
 // Tell the github workflow check to not format the generated rust program bril_grammar.rs
 #[rustfmt::skip]

--- a/bril-rs/src/abstract_program.rs
+++ b/bril-rs/src/abstract_program.rs
@@ -12,8 +12,10 @@ use serde::de::{self, Error, MapAccess, Visitor};
 
 use serde::ser::{SerializeMap, Serializer};
 
+/// Equivalent to a file of bril code
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct AbstractProgram {
+    /// A list of functions declared in the program
     pub functions: Vec<AbstractFunction>,
 }
 
@@ -26,16 +28,22 @@ impl Display for AbstractProgram {
     }
 }
 
+/// <https://capra.cs.cornell.edu/bril/lang/syntax.html#function>
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct AbstractFunction {
+    /// Any arguments the function accepts
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub args: Vec<AbstractArgument>,
+    /// The instructions of this function
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub instrs: Vec<AbstractCode>,
+    /// The name of the function
     pub name: String,
+    /// The position of this function in the original source code
     #[cfg(feature = "position")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub pos: Option<Position>,
+    /// The possible return type of this function
     #[serde(rename = "type")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub return_type: Option<AbstractType>,
@@ -66,9 +74,14 @@ impl Display for AbstractFunction {
     }
 }
 
+/// An argument of a function
+/// <https://capra.cs.cornell.edu/bril/lang/syntax.html#function>
+/// Example: a : int
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct AbstractArgument {
+    /// a
     pub name: String,
+    /// int
     #[serde(rename = "type")]
     pub arg_type: AbstractType,
 }
@@ -79,15 +92,21 @@ impl Display for AbstractArgument {
     }
 }
 
+/// <https://capra.cs.cornell.edu/bril/lang/syntax.html#function>
+/// Code is a Label or an Instruction
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 #[serde(untagged)]
 pub enum AbstractCode {
+    /// <https://capra.cs.cornell.edu/bril/lang/syntax.html#label>
     Label {
+        /// The name of the label
         label: String,
+        /// Where the label is located in source code
         #[cfg(feature = "position")]
         #[serde(skip_serializing_if = "Option::is_none")]
         pos: Option<Position>,
     },
+    /// <https://capra.cs.cornell.edu/bril/lang/syntax.html#instruction>
     Instruction(AbstractInstruction),
 }
 
@@ -104,42 +123,63 @@ impl Display for AbstractCode {
     }
 }
 
+/// <https://capra.cs.cornell.edu/bril/lang/syntax.html#instruction>
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 #[serde(untagged)]
 pub enum AbstractInstruction {
+    /// <https://capra.cs.cornell.edu/bril/lang/syntax.html#constant>
     Constant {
+        /// destination variable
         dest: String,
+        /// "const"
         op: ConstOps,
+        /// The source position of the instruction if provided
         #[cfg(feature = "position")]
         #[serde(skip_serializing_if = "Option::is_none")]
         pos: Option<Position>,
+        /// Type of variable
         #[serde(rename = "type")]
         const_type: Option<AbstractType>,
+        /// The literal being stored in the variable
         value: Literal,
     },
+    /// <https://capra.cs.cornell.edu/bril/lang/syntax.html#value-operation>
     Value {
+        /// List of variables as arguments
         #[serde(default, skip_serializing_if = "Vec::is_empty")]
         args: Vec<String>,
+        /// destination variable
         dest: String,
+        /// List of strings as function names
         #[serde(default, skip_serializing_if = "Vec::is_empty")]
         funcs: Vec<String>,
+        /// List of strings as labels
         #[serde(default, skip_serializing_if = "Vec::is_empty")]
         labels: Vec<String>,
+        /// Operation being executed
         op: String,
+        /// The source position of the instruction if provided
         #[cfg(feature = "position")]
         #[serde(skip_serializing_if = "Option::is_none")]
         pos: Option<Position>,
+        /// Type of variable
         #[serde(rename = "type")]
         op_type: Option<AbstractType>,
     },
+    /// <https://capra.cs.cornell.edu/bril/lang/syntax.html#effect-operation>
     Effect {
+        /// List of variables as arguments
         #[serde(default, skip_serializing_if = "Vec::is_empty")]
         args: Vec<String>,
+        /// List of strings as function names
         #[serde(default, skip_serializing_if = "Vec::is_empty")]
         funcs: Vec<String>,
+        /// List of strings as labels
         #[serde(default, skip_serializing_if = "Vec::is_empty")]
         labels: Vec<String>,
+        /// Operation being executed
         op: String,
+        /// The source position of the instruction if provided
         #[cfg(feature = "position")]
         #[serde(skip_serializing_if = "Option::is_none")]
         pos: Option<Position>,
@@ -209,9 +249,12 @@ impl Display for AbstractInstruction {
     }
 }
 
+/// <https://capra.cs.cornell.edu/bril/lang/syntax.html#type>
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum AbstractType {
+    /// For example "bool" => Primitive("bool")
     Primitive(String),
+    /// For example "ptr<bool>" => Parameterized("ptr", Box::new(Primitive("bool")))
     Parameterized(String, Box<Self>),
 }
 

--- a/bril-rs/src/conversion.rs
+++ b/bril-rs/src/conversion.rs
@@ -13,27 +13,35 @@ use thiserror::Error;
 #[allow(non_upper_case_globals)]
 const pos: Option<Position> = None;
 
+/// This is the [`std::error::Error`] implementation for `bril_rs`. This crate currently only supports errors from converting between [`AbstractProgram`] and [Program]
+// todo Should this also wrap Serde errors? In this case, maybe change the name from ConversionError
 // Having the #[error(...)] for all variants derives the Display trait as well
 #[derive(Error, Debug)]
 #[allow(clippy::module_name_repetitions)]
 pub enum ConversionError {
+    /// Expected a primitive type like int or bool, found {0}"
     #[error("Expected a primitive type like int or bool, found {0}")]
     InvalidPrimitive(String),
 
+    /// Expected a parameterized type like ptr, found {0}<{1}>
     #[error("Expected a parameterized type like ptr, found {0}<{1}>")]
     InvalidParameterized(String, String),
 
+    /// Expected an value operation, found {0}
     #[error("Expected an value operation, found {0}")]
     InvalidValueOps(String),
 
+    /// Expected an effect operation, found {0}
     #[error("Expected an effect operation, found {0}")]
     InvalidEffectOps(String),
 
+    /// Missing type signature
     #[error("Missing type signature")]
     MissingType,
 }
 
 impl ConversionError {
+    #[doc(hidden)]
     #[must_use]
     pub fn add_pos(self, pos_var: Option<Position>) -> PositionalConversionError {
         match self {
@@ -46,6 +54,7 @@ impl ConversionError {
     }
 }
 
+/// Wraps [`ConversionError`] to optionally provide source code positions if they are available.
 #[derive(Error, Debug)]
 pub struct PositionalConversionError {
     e: Box<ConversionError>,
@@ -53,6 +62,7 @@ pub struct PositionalConversionError {
 }
 
 impl PositionalConversionError {
+    #[doc(hidden)]
     #[must_use]
     pub fn new(e: ConversionError) -> Self {
         Self {

--- a/bril-rs/src/lib.rs
+++ b/bril-rs/src/lib.rs
@@ -1,45 +1,65 @@
 #![warn(clippy::all, clippy::pedantic, clippy::nursery, clippy::cargo)]
-// todo these are allowed to appease clippy but should be addressed some day
-#![allow(clippy::missing_panics_doc)]
+#![warn(missing_docs)]
+#![doc = include_str!("../README.md")]
 #![allow(clippy::too_many_lines)]
 
-pub mod conversion;
-pub mod program;
-pub use conversion::ConversionError;
-pub use program::*;
-
+/// Provides the unstructured representation of Bril programs
 pub mod abstract_program;
+/// Provides the Error handling and conversion between [`AbstractProgram`] and [Program]
+pub mod conversion;
+/// Provides the structured representation of Bril programs
+pub mod program;
+// todo maybe not reexport the program structs? I don't know the most rust way to provide these especially since abstract_program relies on Literal in program
 pub use abstract_program::*;
+pub use program::*;
 
 use std::io::{self, Write};
 
+// todo Have versions of the output_* functions that take a [std::io::Write]
+// todo possible deprecate/remove the wrapper functions to make the code base cleaner
+// todo Wrap the outputs of serde in an error instead of panic-ing
+
+/// A helper function for parsing a Bril program from ```input``` in JSON format to [Program]
+/// # Panics
+/// Will panic if the input JSON is not well-formed bril JSON
 pub fn load_program_from_read<R: std::io::Read>(mut input: R) -> Program {
     let mut buffer = String::new();
     input.read_to_string(&mut buffer).unwrap();
     serde_json::from_str(&buffer).unwrap()
 }
 
+/// A wrapper of [`load_program_from_read`] which assumes [`std::io::Stdin`]
 #[must_use]
 pub fn load_program() -> Program {
     load_program_from_read(std::io::stdin())
 }
 
+/// Outputs a [Program] to [`std::io::Stdout`]
+/// # Panics
+/// This can panic, though I'm not sure when since serialization should always succeed
 pub fn output_program(p: &Program) {
     serde_json::to_writer_pretty(io::stdout(), p).unwrap();
     io::stdout().write_all(b"\n").unwrap();
 }
 
+/// A helper function for parsing a Bril program from ```input``` in JSON format to [`AbstractProgram`]
+/// # Panics
+/// Will panic if the input JSON is not well-formed bril JSON
 pub fn load_abstract_program_from_read<R: std::io::Read>(mut input: R) -> AbstractProgram {
     let mut buffer = String::new();
     input.read_to_string(&mut buffer).unwrap();
     serde_json::from_str(&buffer).unwrap()
 }
 
+/// A wrapper of [`load_abstract_program_from_read`] which assumes [`std::io::Stdin`]
 #[must_use]
 pub fn load_abstract_program() -> AbstractProgram {
     load_abstract_program_from_read(std::io::stdin())
 }
 
+/// Outputs an [`AbstractProgram`] to [`std::io::Stdout`]
+/// # Panics
+/// This can panic, though I'm not sure when since serialization should always succeed
 pub fn output_abstract_program(p: &AbstractProgram) {
     serde_json::to_writer_pretty(io::stdout(), p).unwrap();
     io::stdout().write_all(b"\n").unwrap();

--- a/bril-rs/src/lib.rs
+++ b/bril-rs/src/lib.rs
@@ -1,7 +1,6 @@
 #![warn(clippy::all, clippy::pedantic, clippy::nursery, clippy::cargo)]
 // todo these are allowed to appease clippy but should be addressed some day
 #![allow(clippy::missing_panics_doc)]
-#![allow(clippy::cargo_common_metadata)]
 #![allow(clippy::too_many_lines)]
 
 pub mod conversion;

--- a/bril-rs/src/program.rs
+++ b/bril-rs/src/program.rs
@@ -2,8 +2,10 @@ use std::fmt::{self, Display, Formatter};
 
 use serde::{Deserialize, Serialize};
 
+/// Equivalent to a file of bril code
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Program {
+    /// A list of functions declared in the program
     pub functions: Vec<Function>,
 }
 
@@ -16,16 +18,22 @@ impl Display for Program {
     }
 }
 
+/// <https://capra.cs.cornell.edu/bril/lang/syntax.html#function>
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Function {
+    /// Any arguments the function accepts
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub args: Vec<Argument>,
+    /// The instructions of this function
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub instrs: Vec<Code>,
+    /// The name of the function
     pub name: String,
+    /// The position of this function in the original source code
     #[cfg(feature = "position")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub pos: Option<Position>,
+    /// The possible return type of this function
     #[serde(rename = "type")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub return_type: Option<Type>,
@@ -56,10 +64,15 @@ impl Display for Function {
     }
 }
 
+/// An argument of a function
+/// <https://capra.cs.cornell.edu/bril/lang/syntax.html#function>
+/// Example: a : int
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Argument {
+    /// a
     pub name: String,
     #[serde(rename = "type")]
+    /// int
     pub arg_type: Type,
 }
 
@@ -69,15 +82,21 @@ impl Display for Argument {
     }
 }
 
+/// <https://capra.cs.cornell.edu/bril/lang/syntax.html#function>
+/// Code is a Label or an Instruction
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 #[serde(untagged)]
 pub enum Code {
+    /// <https://capra.cs.cornell.edu/bril/lang/syntax.html#label>
     Label {
+        /// The name of the label
         label: String,
+        /// Where the label is located in source code
         #[cfg(feature = "position")]
         #[serde(skip_serializing_if = "Option::is_none")]
         pos: Option<Position>,
     },
+    /// <https://capra.cs.cornell.edu/bril/lang/syntax.html#instruction>
     Instruction(Instruction),
 }
 
@@ -94,42 +113,63 @@ impl Display for Code {
     }
 }
 
+/// <https://capra.cs.cornell.edu/bril/lang/syntax.html#instruction>
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 #[serde(untagged)]
 pub enum Instruction {
+    /// <https://capra.cs.cornell.edu/bril/lang/syntax.html#constant>
     Constant {
+        /// destination variable
         dest: String,
+        /// "const"
         op: ConstOps,
         #[cfg(feature = "position")]
+        /// The source position of the instruction if provided
         #[serde(skip_serializing_if = "Option::is_none")]
         pos: Option<Position>,
+        /// Type of variable
         #[serde(rename = "type")]
         const_type: Type,
+        /// The literal being stored in the variable
         value: Literal,
     },
+    /// <https://capra.cs.cornell.edu/bril/lang/syntax.html#value-operation>
     Value {
+        /// List of variables as arguments
         #[serde(default, skip_serializing_if = "Vec::is_empty")]
         args: Vec<String>,
+        /// destination variable
         dest: String,
+        /// List of strings as function names
         #[serde(default, skip_serializing_if = "Vec::is_empty")]
         funcs: Vec<String>,
+        /// List of strings as labels
         #[serde(default, skip_serializing_if = "Vec::is_empty")]
         labels: Vec<String>,
+        /// Operation being executed
         op: ValueOps,
+        /// The source position of the instruction if provided
         #[cfg(feature = "position")]
         #[serde(skip_serializing_if = "Option::is_none")]
         pos: Option<Position>,
+        /// Type of variable
         #[serde(rename = "type")]
         op_type: Type,
     },
+    /// <https://capra.cs.cornell.edu/bril/lang/syntax.html#effect-operation>
     Effect {
+        /// List of variables as arguments
         #[serde(default, skip_serializing_if = "Vec::is_empty")]
         args: Vec<String>,
+        /// List of strings as function names
         #[serde(default, skip_serializing_if = "Vec::is_empty")]
         funcs: Vec<String>,
+        /// List of strings as labels
         #[serde(default, skip_serializing_if = "Vec::is_empty")]
         labels: Vec<String>,
+        /// Operation being executed
         op: EffectOps,
+        /// The source position of the instruction if provided
         #[cfg(feature = "position")]
         #[serde(skip_serializing_if = "Option::is_none")]
         pos: Option<Position>,
@@ -138,6 +178,7 @@ pub enum Instruction {
 
 #[cfg(feature = "position")]
 impl Instruction {
+    /// A helper function to extract the position value if it exists from an instruction
     #[must_use]
     pub const fn get_pos(&self) -> Option<Position> {
         match self {
@@ -207,8 +248,10 @@ impl Display for Instruction {
     }
 }
 
+/// <https://capra.cs.cornell.edu/bril/lang/syntax.html#constant>
 #[derive(Serialize, Deserialize, Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum ConstOps {
+    /// "const"
     #[serde(rename = "const")]
     Const,
 }
@@ -221,26 +264,38 @@ impl Display for ConstOps {
     }
 }
 
+/// <https://capra.cs.cornell.edu/bril/lang/syntax.html#effect-operation>
 #[derive(Serialize, Deserialize, Debug, Copy, Clone, PartialEq, Eq, Hash)]
 #[serde(rename_all = "lowercase")]
 pub enum EffectOps {
+    /// <https://capra.cs.cornell.edu/bril/lang/core.html#control>
     #[serde(rename = "jmp")]
     Jump,
+    /// <https://capra.cs.cornell.edu/bril/lang/core.html#control>
     #[serde(rename = "br")]
     Branch,
+    /// <https://capra.cs.cornell.edu/bril/lang/core.html#control>
     Call,
+    /// <https://capra.cs.cornell.edu/bril/lang/core.html#control>
     #[serde(rename = "ret")]
     Return,
+    /// <https://capra.cs.cornell.edu/bril/lang/core.html#miscellaneous>
     Print,
+    /// <https://capra.cs.cornell.edu/bril/lang/core.html#miscellaneous>
     Nop,
+    /// <https://capra.cs.cornell.edu/bril/lang/memory.html#operations>
     #[cfg(feature = "memory")]
     Store,
+    /// <https://capra.cs.cornell.edu/bril/lang/memory.html#operations>
     #[cfg(feature = "memory")]
     Free,
+    /// <https://capra.cs.cornell.edu/bril/lang/spec.html#operations>
     #[cfg(feature = "speculate")]
     Speculate,
+    /// <https://capra.cs.cornell.edu/bril/lang/spec.html#operations>
     #[cfg(feature = "speculate")]
     Commit,
+    /// <https://capra.cs.cornell.edu/bril/lang/spec.html#operations>
     #[cfg(feature = "speculate")]
     Guard,
 }
@@ -268,47 +323,75 @@ impl Display for EffectOps {
     }
 }
 
+/// <https://capra.cs.cornell.edu/bril/lang/syntax.html#value-operation>
 #[derive(Serialize, Deserialize, Debug, Copy, Clone, PartialEq, Eq, Hash)]
 #[serde(rename_all = "lowercase")]
 pub enum ValueOps {
+    /// <https://capra.cs.cornell.edu/bril/lang/core.html#arithmetic>
     Add,
+    /// <https://capra.cs.cornell.edu/bril/lang/core.html#arithmetic>
     Sub,
+    /// <https://capra.cs.cornell.edu/bril/lang/core.html#arithmetic>
     Mul,
+    /// <https://capra.cs.cornell.edu/bril/lang/core.html#arithmetic>
     Div,
+    /// <https://capra.cs.cornell.edu/bril/lang/core.html#comparison>
     Eq,
+    /// <https://capra.cs.cornell.edu/bril/lang/core.html#comparison>
     Lt,
+    /// <https://capra.cs.cornell.edu/bril/lang/core.html#comparison>
     Gt,
+    /// <https://capra.cs.cornell.edu/bril/lang/core.html#comparison>
     Le,
+    /// <https://capra.cs.cornell.edu/bril/lang/core.html#comparison>
     Ge,
+    /// <https://capra.cs.cornell.edu/bril/lang/core.html#logic>
     Not,
+    /// <https://capra.cs.cornell.edu/bril/lang/core.html#logic>
     And,
+    /// <https://capra.cs.cornell.edu/bril/lang/core.html#logic>
     Or,
+    /// <https://capra.cs.cornell.edu/bril/lang/core.html#control>
     Call,
+    /// <https://capra.cs.cornell.edu/bril/lang/core.html#miscellaneous>
     Id,
+    /// <https://capra.cs.cornell.edu/bril/lang/ssa.html#operations>
     #[cfg(feature = "ssa")]
     Phi,
+    /// <https://capra.cs.cornell.edu/bril/lang/float.html#operations>
     #[cfg(feature = "float")]
     Fadd,
+    /// <https://capra.cs.cornell.edu/bril/lang/float.html#operations>
     #[cfg(feature = "float")]
     Fsub,
+    /// <https://capra.cs.cornell.edu/bril/lang/float.html#operations>
     #[cfg(feature = "float")]
     Fmul,
+    /// <https://capra.cs.cornell.edu/bril/lang/float.html#operations>
     #[cfg(feature = "float")]
     Fdiv,
+    /// <https://capra.cs.cornell.edu/bril/lang/float.html#operations>
     #[cfg(feature = "float")]
     Feq,
+    /// <https://capra.cs.cornell.edu/bril/lang/float.html#operations>
     #[cfg(feature = "float")]
     Flt,
+    /// <https://capra.cs.cornell.edu/bril/lang/float.html#operations>
     #[cfg(feature = "float")]
     Fgt,
+    /// <https://capra.cs.cornell.edu/bril/lang/float.html#operations>
     #[cfg(feature = "float")]
     Fle,
+    /// <https://capra.cs.cornell.edu/bril/lang/float.html#operations>
     #[cfg(feature = "float")]
     Fge,
+    /// <https://capra.cs.cornell.edu/bril/lang/memory.html#operations>
     #[cfg(feature = "memory")]
     Alloc,
+    /// <https://capra.cs.cornell.edu/bril/lang/memory.html#operations>
     #[cfg(feature = "memory")]
     Load,
+    /// <https://capra.cs.cornell.edu/bril/lang/memory.html#operations>
     #[cfg(feature = "memory")]
     PtrAdd,
 }
@@ -360,13 +443,18 @@ impl Display for ValueOps {
     }
 }
 
+/// <https://capra.cs.cornell.edu/bril/lang/syntax.html#type>
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
 #[serde(rename_all = "lowercase")]
 pub enum Type {
+    /// <https://capra.cs.cornell.edu/bril/lang/core.html#types>
     Int,
+    /// <https://capra.cs.cornell.edu/bril/lang/core.html#types>
     Bool,
+    /// <https://capra.cs.cornell.edu/bril/lang/float.html#types>
     #[cfg(feature = "float")]
     Float,
+    /// <https://capra.cs.cornell.edu/bril/lang/memory.html#types>
     #[cfg(feature = "memory")]
     #[serde(rename = "ptr")]
     Pointer(Box<Self>),
@@ -385,11 +473,15 @@ impl Display for Type {
     }
 }
 
+/// A JSON number/value
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 #[serde(untagged)]
 pub enum Literal {
+    /// Integers
     Int(i64),
+    /// Booleans
     Bool(bool),
+    /// Floating Points
     #[cfg(feature = "float")]
     Float(f64),
 }
@@ -406,6 +498,7 @@ impl Display for Literal {
 }
 
 impl Literal {
+    /// A helper function to get the type of literal values
     #[must_use]
     pub const fn get_type(&self) -> Type {
         match self {
@@ -417,8 +510,11 @@ impl Literal {
     }
 }
 
+/// <https://capra.cs.cornell.edu/bril/lang/syntax.html#source-positions>
 #[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq)]
 pub struct Position {
+    /// Column
     pub col: u64,
+    /// Row
     pub row: u64,
 }

--- a/brilirs/Cargo.toml
+++ b/brilirs/Cargo.toml
@@ -3,6 +3,13 @@ name = "brilirs"
 version = "0.1.0"
 authors = ["Wil Thomason <wil.thomason@gmail.com>"]
 edition = "2021"
+description = "A fast interpreter for the Bril language written in Rust"
+readme = "README.md"
+repository = "https://github.com/sampsyo/bril"
+# license = "MIT"
+license-file = "../LICENSE"
+categories = ["command-line-utilities", "compilers", "data-structures", "parser-implementations"]
+keywords = ["compiler", "bril", "interpreter", "data-structures", "language"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [build-dependencies]

--- a/brilirs/README.md
+++ b/brilirs/README.md
@@ -1,0 +1,3 @@
+# Brilirs
+
+Brilirs is a fast interpreter written in Rust.

--- a/brilirs/README.md
+++ b/brilirs/README.md
@@ -1,3 +1,33 @@
 # Brilirs
 
-Brilirs is a fast interpreter written in Rust.
+`brilirs` is a fast interpreter written in Rust.
+
+It is available as both a command-line interface and a rust library.
+
+## Command-line interface
+
+The main use case of `brilirs` is to be a faster `brili`. Using `cargo`; run `cargo install --path .` and make sure `$HOME/.cargo/bin` is on your path. Run `brilirs --help` for all of the supported flags.
+
+## Rust interface
+
+`brilirs` can also be used in your rust code which may be advantageous. Add `brilirs` to your `Cargo.toml` with:
+
+```toml
+[dependencies.brilirs]
+version      = "0.1.0"
+path         = "../brilirs"
+```
+
+Check out `cargo doc --open` for exposed functions. One possible workflow is that you have a `bril_rs::Program` called `program` and a list of `args` that you want to run through the interpreter.
+
+```rust
+let bbprog = BBProgram::new(program)?;
+check::type_check(&bbprog)?;
+interp::execute_main(&bbprog, std::io::stdout(), &args, false)?;
+```
+
+You can also use a `bril_rs::AbstractProgram` called `abstract_program` by converting it into a `bril_rs::Program` using `abstract_program.try_into()?`.
+
+## Contributing
+
+Issues and PRs are welcome. For pull requests, make sure to run the test harness with `make test` and `make benchmark`. There is also `.github/workflows/rust.yaml` which will format your code and check that it is conforming with clippy.

--- a/brilirs/build.rs
+++ b/brilirs/build.rs
@@ -16,7 +16,7 @@ fn main() -> Result<(), Error> {
     Some(out_dir) => out_dir,
   };
 
-  let mut app = Cli::into_app();
+  let mut app = Cli::command();
   let bin_name = app.get_name().to_string();
 
   // This is an attempt at being smart. Instead, one could just generate completion scripts for all of the shells in a completions/ directory and have the user choose the appropriate one.

--- a/brilirs/src/basic_block.rs
+++ b/brilirs/src/basic_block.rs
@@ -4,13 +4,23 @@ use fxhash::FxHashMap;
 
 use crate::error;
 
-// A program represented as basic blocks.
+/// A program represented as basic blocks. This is the IR of brilirs
 #[derive(Debug)]
 pub struct BBProgram {
+  #[doc(hidden)]
   pub func_index: FxHashMap<String, BBFunction>,
 }
 
+impl TryFrom<Program> for BBProgram {
+  type Error = InterpError;
+
+  fn try_from(prog: Program) -> Result<Self, Self::Error> {
+    Self::new(prog)
+  }
+}
+
 impl BBProgram {
+  /// Converts a [`Program`] into a [`BBProgram`]
   pub fn new(prog: Program) -> Result<Self, InterpError> {
     let num_funcs = prog.functions.len();
     let bb = Self {
@@ -27,11 +37,13 @@ impl BBProgram {
     }
   }
 
+  #[doc(hidden)]
   pub fn get(&self, func_name: &str) -> Option<&BBFunction> {
     self.func_index.get(func_name)
   }
 }
 
+#[doc(hidden)]
 #[derive(Debug)]
 pub struct BasicBlock {
   pub label: Option<String>,
@@ -54,6 +66,7 @@ impl BasicBlock {
   }
 }
 
+#[doc(hidden)]
 #[derive(Debug)]
 pub struct NumifiedInstruction {
   pub dest: Option<u32>,
@@ -77,7 +90,7 @@ fn get_num_from_map(
 }
 
 impl NumifiedInstruction {
-  pub fn create(
+  fn create(
     instr: &Instruction,
     num_of_vars: &mut u32,
     num_var_map: &mut FxHashMap<String, u32>,
@@ -105,6 +118,7 @@ impl NumifiedInstruction {
   }
 }
 
+#[doc(hidden)]
 #[derive(Debug)]
 pub struct BBFunction {
   pub name: String,
@@ -120,7 +134,7 @@ pub struct BBFunction {
 }
 
 impl BBFunction {
-  pub fn new(f: Function) -> Self {
+  fn new(f: Function) -> Self {
     let (mut func, label_map) = Self::find_basic_blocks(f);
     func.build_cfg(label_map);
     func

--- a/brilirs/src/check.rs
+++ b/brilirs/src/check.rs
@@ -496,6 +496,9 @@ fn type_check_func(bbfunc: &BBFunction, bbprog: &BBProgram) -> Result<(), Positi
   Ok(())
 }
 
+/// Provides validation of Bril programs. This involves
+/// statically checking the types and number of arguments to Bril
+/// instructions.
 pub fn type_check(bbprog: &BBProgram) -> Result<(), PositionalInterpError> {
   bbprog
     .func_index

--- a/brilirs/src/cli.rs
+++ b/brilirs/src/cli.rs
@@ -1,8 +1,8 @@
-use clap::{AppSettings, Parser};
+use clap::Parser;
 
 #[derive(Parser)]
 #[clap(about, version, author)] // keeps the cli synced with Cargo.toml
-#[clap(setting(AppSettings::AllowHyphenValues))]
+#[clap(allow_hyphen_values(true))]
 pub struct Cli {
   /// Flag to output the total number of dynamic instructions
   #[clap(short, long)]

--- a/brilirs/src/interp.rs
+++ b/brilirs/src/interp.rs
@@ -117,7 +117,7 @@ where
 }
 
 #[derive(Debug, Clone)]
-pub enum Value {
+enum Value {
   Int(i64),
   Bool(bool),
   Float(f64),
@@ -132,7 +132,7 @@ impl Default for Value {
 }
 
 #[derive(Debug, Clone, PartialEq)]
-pub struct Pointer {
+struct Pointer {
   base: usize,
   offset: i64,
 }
@@ -658,6 +658,8 @@ fn parse_args(
   }
 }
 
+/// The entrance point to the interpreter. It runs over a ```prog```:[`BBProgram`] starting at the "main" function with ```input_args``` as input. Print statements output to ```out``` which implements [std::io::Write]. You also need to include whether you want the interpreter to count the number of instructions run with ```profiling```. This information is outputted to [std::io::stderr]
+// todo we could probably output the profiling thing to a user defined location. If the program can output to a file, you should probably also be allowed to output this debug info to a file as well.
 pub fn execute_main<T: std::io::Write>(
   prog: &BBProgram,
   mut out: T,

--- a/brilirs/src/lib.rs
+++ b/brilirs/src/lib.rs
@@ -1,7 +1,6 @@
 // The group clippy::pedantic is not used as it ends up being more annoying than useful
 #![warn(clippy::all, clippy::nursery, clippy::cargo)]
 // todo these are allowed to appease clippy but should be addressed some day
-#![allow(clippy::cargo_common_metadata)]
 #![allow(clippy::too_many_arguments)]
 
 use std::error::Error;

--- a/brilirs/src/lib.rs
+++ b/brilirs/src/lib.rs
@@ -1,16 +1,25 @@
 // The group clippy::pedantic is not used as it ends up being more annoying than useful
 #![warn(clippy::all, clippy::nursery, clippy::cargo)]
-// todo these are allowed to appease clippy but should be addressed some day
+#![warn(missing_docs)]
+#![doc = include_str!("../README.md")]
 #![allow(clippy::too_many_arguments)]
 
 use std::error::Error;
 
-mod basic_block;
-mod check;
+use basic_block::BBProgram;
+use bril_rs::Program;
+
+/// The internal representation of brilirs, provided a ```TryFrom<Program>``` conversion
+pub mod basic_block;
+/// Provides ```check::type_check``` to validate [Program]
+pub mod check;
+#[doc(hidden)]
 pub mod cli;
 mod error;
-mod interp;
+/// Provides ```interp::execute_main``` to execute [Program] that have been converted into [BBProgram]
+pub mod interp;
 
+#[doc(hidden)]
 pub fn run_input<T: std::io::Write>(
   input: Box<dyn std::io::Read>,
   out: T,
@@ -22,12 +31,12 @@ pub fn run_input<T: std::io::Write>(
   // It's a little confusing because of the naming conventions.
   //      - bril_rs takes file.json as input
   //      - bril2json takes file.bril as input
-  let prog = if text {
+  let prog: Program = if text {
     bril2json::parse_abstract_program_from_read(input, true).try_into()?
   } else {
     bril_rs::load_abstract_program_from_read(input).try_into()?
   };
-  let bbprog = basic_block::BBProgram::new(prog)?;
+  let bbprog: BBProgram = prog.try_into()?;
   check::type_check(&bbprog)?;
 
   if !check {

--- a/brilirs/todo_list.txt
+++ b/brilirs/todo_list.txt
@@ -1,10 +1,16 @@
-- Support Speculative execution in brilirs
-- Support structs in bril-rs and brilirs
-- bril-rs to LLVM compiler?
+- Support Speculative execution extension in brilirs
+- Support structs extension in bril-rs and brilirs
+- Revive some of the incomplete extensions like First-class-functions/Sum types
+- A strings extension or support for an array of ints
+- bril-rs to LLVM compiler?(See struct extension compiler)
 - Optimize brilirs:
     - replace the naive memory management support with a more optimized version
     - optimize brilirs for function calls
         - replace string lookup with indexing a vec
         - optimize contexts?
-- Improve documentation
-- Appease Clippy Overlord
+- Fuzzing with cargo-fuzz or Property testing with proptest
+- Replace benchmarking scripts with something more extensible like brench or a better python/rust script
+- Equality Saturation using the egg crate for bril-rs?
+- Formalize bril in Coq/Lean?
+- If one ever wanted to release the bril-rs crate, enforce semvar with https://github.com/rust-lang/rust-semverver
+- Build a rust2bril compiler using syn

--- a/docs/tools/rust.md
+++ b/docs/tools/rust.md
@@ -1,7 +1,7 @@
 Rust Library
 ============
 
-This is a no-frills interface between Bril's JSON and your [Rust][] code. It supports the [Bril core][core] along with the [SSA][], [memory][], [floating point][float], and [speculative execution][spec] extensions.
+This is a no-frills interface between Bril's JSON and your [Rust][] code. It supports the [Bril core][core] along with the [SSA][], [memory][], [floating point][float], [speculative execution][spec], and [source positions][pos] extensions.
 
 Use
 ---
@@ -12,7 +12,7 @@ Include this by adding the following to your `Cargo.toml`:
 [dependencies.bril-rs]
 version = "0.1.0"
 path = "../bril-rs"
-features = ["ssa", "memory", "float", "speculate"]
+features = ["ssa", "memory", "float", "speculate", "position"]
 ```
 
 Each of the extensions to [Bril core][core] is feature gated. To ignore an extension, remove its corresponding string from the `features` list.
@@ -49,3 +49,4 @@ make features
 [memory]: ../lang/memory.md
 [float]: ../lang/float.md
 [spec]: ../lang/spec.md
+[pos]: ../lang/syntax.md


### PR DESCRIPTION
This PR addresses the lack of documentation for the Rust code bases in Bril and some clippy lints.

- 2287ded Now enforcing the `clippy::cargo_common_metadata` lint. This ensures that all of the important metadata fields in `Cargo.toml` are filled out. The important thing to note is the `license-file` field which I've pointed towards the `LICENSE` file in the root of the repository.
- 3c0ec80 Just mentions that `bril_rs` supports source positions in the rust library page. There is also a minor change where "position" was not added as a feature field in the `brilirs` dependency on `bril_rs`. This did not break the build because features are additive in Rust so it was included by the `bril2json` dependency instead during dependency resolution.
- c0a7be4 In recent minor releases of clap, some methods were deprecated and are addressed here.
- 740b440 The driving commit of this pr. While there is documentation of these code bases on the Bril website, its probably not sufficient. This pr leverages `rustdoc`, the builtin documentation support for Rust, to document the higher level design of these code bases. In each directory, one can use `cargo doc --open` to get very basic documentation on the public functions and data structures provided by `bril_rs`, `brilirs`, and `bril2json`. `cargo doc` is also added to the github workflow alongside the other rust actions.

The documentation itself is not detailed however, I think it accomplishes the goal of elevating the useful functions/interfaces of these libraries from the implementation. The expectation is that someone looking to use one of these libraries could use `cargo doc --open` to get exposed to the public functionality of these libraries without getting overwhelmed by the source code. Feedback is appreciated.