### PR TITLE
Allow profiling output location to be provided

### DIFF
--- a/brilirs/README.md
+++ b/brilirs/README.md
@@ -23,7 +23,7 @@ Check out `cargo doc --open` for exposed functions. One possible workflow is tha
 ```rust
 let bbprog = BBProgram::new(program)?;
 check::type_check(&bbprog)?;
-interp::execute_main(&bbprog, std::io::stdout(), &args, false)?;
+interp::execute_main(&bbprog, std::io::stdout(), &args, false, std::io::stderr())?;
 ```
 
 You can also use a `bril_rs::AbstractProgram` called `abstract_program` by converting it into a `bril_rs::Program` using `abstract_program.try_into()?`.

--- a/brilirs/src/interp.rs
+++ b/brilirs/src/interp.rs
@@ -659,12 +659,12 @@ fn parse_args(
 }
 
 /// The entrance point to the interpreter. It runs over a ```prog```:[`BBProgram`] starting at the "main" function with ```input_args``` as input. Print statements output to ```out``` which implements [std::io::Write]. You also need to include whether you want the interpreter to count the number of instructions run with ```profiling```. This information is outputted to [std::io::stderr]
-// todo we could probably output the profiling thing to a user defined location. If the program can output to a file, you should probably also be allowed to output this debug info to a file as well.
-pub fn execute_main<T: std::io::Write>(
+pub fn execute_main<T: std::io::Write, U: std::io::Write>(
   prog: &BBProgram,
   mut out: T,
   input_args: &[String],
   profiling: bool,
+  mut profiling_out: U,
 ) -> Result<(), PositionalInterpError> {
   let main_func = prog
     .get("main")
@@ -697,7 +697,9 @@ pub fn execute_main<T: std::io::Write>(
   }
 
   if profiling {
-    eprintln!("total_dyn_inst: {instruction_count}");
+    writeln!(profiling_out, "total_dyn_inst: {instruction_count}")
+      .and_then(|_| profiling_out.flush())
+      .map_err(|e| PositionalInterpError::new(InterpError::IoError(Box::new(e))))?;
   }
 
   Ok(())

--- a/brilirs/src/lib.rs
+++ b/brilirs/src/lib.rs
@@ -20,11 +20,12 @@ mod error;
 pub mod interp;
 
 #[doc(hidden)]
-pub fn run_input<T: std::io::Write>(
+pub fn run_input<T: std::io::Write, U: std::io::Write>(
   input: Box<dyn std::io::Read>,
   out: T,
   input_args: Vec<String>,
   profiling: bool,
+  profiling_out: U,
   check: bool,
   text: bool,
 ) -> Result<(), Box<dyn Error>> {
@@ -40,7 +41,7 @@ pub fn run_input<T: std::io::Write>(
   check::type_check(&bbprog)?;
 
   if !check {
-    interp::execute_main(&bbprog, out, &input_args, profiling)?;
+    interp::execute_main(&bbprog, out, &input_args, profiling, profiling_out)?;
   }
 
   Ok(())

--- a/brilirs/src/main.rs
+++ b/brilirs/src/main.rs
@@ -11,11 +11,16 @@ fn main() {
     Some(input_file) => Box::new(File::open(input_file).unwrap()),
   };
 
+  /*
+  todo should you be able to supply output locations from the command line interface?
+  Instead of builtin std::io::stdout()/std::io::stderr()
+  */
   if let Err(e) = brilirs::run_input(
     input,
     std::io::stdout(),
     args.args,
     args.profile,
+    std::io::stderr(),
     args.check,
     args.text,
   ) {


### PR DESCRIPTION
This is a minor quality of life change to `brilirs` to allow the user to specify the output location of profiling. 

This will allow a user to execute their program and send the results to `my_program.out` and `my_program.prof` respectively when using `brilirs` as a library. 