### PR TITLE
Convert environment into a stack

### DIFF
--- a/benchmarks/function_call.bril
+++ b/benchmarks/function_call.bril
@@ -1,0 +1,22 @@
+# ARGS: 25
+@main(m: int) {
+  zero: int = const 0;
+  one: int = const 1;
+  two: int = const 2;
+  cond_m: bool = eq m zero;
+  br cond_m .end .m_nonzero;
+.m_nonzero:
+  m:int = sub m one;
+  call @main m;
+  cond_m: bool = eq m zero;
+  br cond_m .end .m_nonzero2;
+.m_nonzero2:
+  m:int = sub m one;
+  call @main m;
+  cond_m: bool = eq m zero;
+  br cond_m .end .m_nonzero3;
+.m_nonzero3:
+  m:int = sub m one;
+  call @main m;
+.end:
+}

--- a/benchmarks/function_call.prof
+++ b/benchmarks/function_call.prof
@@ -1,0 +1,1 @@
+total_dyn_inst: 48607906

--- a/brilirs/benchmark.sh
+++ b/brilirs/benchmark.sh
@@ -7,7 +7,7 @@ files=( "../benchmarks/ackermann.bril" "../benchmarks/binary-fmt.bril" "../bench
         "../benchmarks/orders.bril" "../benchmarks/perfect.bril" "../benchmarks/pythagorean_triple.bril" \
         "../benchmarks/quadratic.bril" "../benchmarks/ray-sphere-intersection.bril" \
         "../benchmarks/recfact.bril" "../benchmarks/sieve.bril" "../benchmarks/sqrt.bril" \
-        "../benchmarks/sum-bits.bril" "../benchmarks/sum-sq-diff.bril"
+        "../benchmarks/sum-bits.bril" "../benchmarks/sum-sq-diff.bril" "../benchmarks/function_call.bril"
         )
 jsons=( "../benchmarks/ackermann.json" "../benchmarks/binary-fmt.json" "../benchmarks/check-primes.json" \
         "../benchmarks/collatz.json" "../benchmarks/digital-root.json" "../benchmarks/eight-queens.json" \
@@ -16,10 +16,10 @@ jsons=( "../benchmarks/ackermann.json" "../benchmarks/binary-fmt.json" "../bench
         "../benchmarks/orders.json" "../benchmarks/perfect.json" "../benchmarks/pythagorean_triple.json" \
         "../benchmarks/quadratic.json" "../benchmarks/ray-sphere-intersection.json" \
         "../benchmarks/recfact.json" "../benchmarks/sieve.json" "../benchmarks/sqrt.json" \
-        "../benchmarks/sum-bits.json" "../benchmarks/sum-sq-diff.json"
+        "../benchmarks/sum-bits.json" "../benchmarks/sum-sq-diff.json" "../benchmarks/function_call.json"
         )
 args=( "3 6" "128" "50" "7" "645634654" "8" "" "10" "101" "4 20" "8" "50 109658" "96 false" "496" "125" \
-        "-5 8 21" "" "8" "100" "" "42" "100")
+        "-5 8 21" "" "8" "100" "" "42" "100" "25")
 
 for i in "${!files[@]}"; do
     bril2json < ${files[i]} > ${jsons[i]}

--- a/brilirs/long_benchmark.sh
+++ b/brilirs/long_benchmark.sh
@@ -4,14 +4,14 @@
 # Feature gate type checking?
 
 files=( "../benchmarks/ackermann.bril" "../benchmarks/eight-queens.bril" \
-        "../benchmarks/mat-mul.bril"
+        "../benchmarks/mat-mul.bril" "../benchmarks/function_call.bril"
 
         )
 jsons=( "../benchmarks/ackermann.json" "../benchmarks/eight-queens.json" \
-        "../benchmarks/mat-mul.json"
+        "../benchmarks/mat-mul.json" "../benchmarks/function_call.json"
 
         )
-args=( "3 6" "8" "50 109658")
+args=( "3 6" "8" "50 109658" "25")
 
 for i in "${!files[@]}"; do
     bril2json < ${files[i]} > ${jsons[i]}

--- a/brilirs/todo_list.txt
+++ b/brilirs/todo_list.txt
@@ -7,7 +7,6 @@
     - replace the naive memory management support with a more optimized version
     - optimize brilirs for function calls
         - replace string lookup with indexing a vec
-        - optimize contexts?
 - Fuzzing with cargo-fuzz or Property testing with proptest
 - Replace benchmarking scripts with something more extensible like brench or a better python/rust script
 - Equality Saturation using the egg crate for bril-rs?


### PR DESCRIPTION
Each time a function is called in `brilirs`, a new environment represented as a vector is allocated. This is costly for functions that are heavily recursive, small, and make multiple function calls in their body. To show this, I've created a benchmark called `function_call.bril` which is an extreme version of this.

To optimize function calls, I've modified the `Environment` struct to act like a stack where there are stack pointers into a `Vec<Value>` representing the frames of the stack. In this way, there is only one `Environment` struct which grows in size on each recursive function call by calling `Environment::push_frame`. Likewise, when a function call returns, the frame is popped with `Environment::pop_frame` which allows for that space to be reused in the next function call.

Some rough numbers for each of the interpreters on `function_call.bril`.

| brili  | Old brilirs | Proposed brilirs |
| ------------- | ------------- | ---------|
| 7.2s ± .2 s  | 347 ms ± 4ms | 321 ms ± 3 ms |

In terms of the other benchmarks, `ackermann.bril` as the current benchmark with the most recursion sees a reduction from 15.2ms -> 13.2ms for brilirs.