### PR TITLE
Brilirs

### DIFF
--- a/brilirs/build.rs
+++ b/brilirs/build.rs
@@ -2,8 +2,8 @@
 
 use clap::IntoApp;
 use clap_complete::{
-  generate_to,
   shells::{Bash, Elvish, Fish, PowerShell, Zsh},
+  Generator,
 };
 use std::io::Error;
 use std::{env, path::PathBuf};
@@ -16,22 +16,33 @@ fn main() -> Result<(), Error> {
     Some(out_dir) => out_dir,
   };
 
-  let mut app = Cli::command();
+  let app = Cli::command();
   let bin_name = app.get_name().to_string();
 
-  // This is an attempt at being smart. Instead, one could just generate completion scripts for all of the shells in a completions/ directory and have the user choose the appropriate one.
-  let path = match env::var("SHELL") {
-    Ok(s) if s.contains("bash") => generate_to(Bash, &mut app, bin_name, out_dir)?,
-    Ok(s) if s.contains("fish") => generate_to(Fish, &mut app, bin_name, out_dir)?,
-    Ok(s) if s.contains("zsh") => generate_to(Zsh, &mut app, bin_name, out_dir)?,
-    Ok(s) if s.contains("elvish") => generate_to(Elvish, &mut app, bin_name, out_dir)?,
-    Ok(s) if s.contains("powershell") => generate_to(PowerShell, &mut app, bin_name, out_dir)?,
+  let shell: Box<dyn Generator> = match env::var("SHELL") {
+    Ok(s) if s.contains("bash") => Box::new(Bash),
+    Ok(s) if s.contains("fish") => Box::new(Fish),
+    Ok(s) if s.contains("zsh") => Box::new(Zsh),
+    Ok(s) if s.contains("elvish") => Box::new(Elvish),
+    Ok(s) if s.contains("powershell") => Box::new(PowerShell),
     Ok(_) | Err(_) => {
-      let mut x = PathBuf::new();
-      x.push("Your shell could not be detected from the $SHELL environment variable so no shell completions were generated. Check the build.rs file if you want to see how this was generated.");
-      x
+      println!(
+        "cargo:warning=Your shell could not be detected from the $SHELL environment variable so no shell completions were generated. Check the build.rs file if you want to see how this was generated.",
+      );
+      println!("cargo:warning=Raise an issue if this doesn't work for you",);
+      return Ok(());
     }
   };
+
+  let mut path = PathBuf::from(out_dir);
+  path.set_file_name(shell.file_name(&bin_name));
+  // Check if tab completions file already exists and return if so
+  if path.is_file() {
+    return Ok(());
+  }
+
+  // This is an attempt at being smart. Instead, one could just generate completion scripts for all of the shells in a completions/ directory and have the user choose the appropriate one.
+  shell.generate(&app, &mut std::fs::File::create(path.clone())?);
 
   println!(
     "cargo:warning={} completion file is generated: {path:?}",

--- a/brilirs/src/basic_block.rs
+++ b/brilirs/src/basic_block.rs
@@ -1,14 +1,15 @@
 use bril_rs::{Function, Instruction, Position, Program};
-use error::InterpError;
 use fxhash::FxHashMap;
 
-use crate::error;
+use crate::error::{InterpError, PositionalInterpError};
 
 /// A program represented as basic blocks. This is the IR of brilirs
 #[derive(Debug)]
 pub struct BBProgram {
   #[doc(hidden)]
-  pub func_index: FxHashMap<String, BBFunction>,
+  pub index_of_main: Option<u32>,
+  #[doc(hidden)]
+  pub func_index: Vec<BBFunction>,
 }
 
 impl TryFrom<Program> for BBProgram {
@@ -23,15 +24,23 @@ impl BBProgram {
   /// Converts a [`Program`] into a [`BBProgram`]
   pub fn new(prog: Program) -> Result<Self, InterpError> {
     let num_funcs = prog.functions.len();
+
+    let func_map: FxHashMap<String, u32> = prog
+      .functions
+      .iter()
+      .enumerate()
+      .map(|(idx, func)| (func.name.clone(), idx as u32))
+      .collect();
+
+    let func_index = prog
+      .functions
+      .into_iter()
+      .map(|func| BBFunction::new(func, &func_map))
+      .collect::<Result<Vec<BBFunction>, InterpError>>()?;
+
     let bb = Self {
-      func_index: prog
-        .functions
-        .into_iter()
-        .map(|func| {
-          let name = func.name.clone();
-          BBFunction::new(func).map(|f| (name, f))
-        })
-        .collect::<Result<FxHashMap<String, BBFunction>, InterpError>>()?,
+      index_of_main: func_map.get(&"main".to_string()).cloned(),
+      func_index,
     };
     if bb.func_index.len() != num_funcs {
       Err(InterpError::DuplicateFunction)
@@ -41,8 +50,8 @@ impl BBProgram {
   }
 
   #[doc(hidden)]
-  pub fn get(&self, func_name: &str) -> Option<&BBFunction> {
-    self.func_index.get(func_name)
+  pub fn get(&self, func_name: u32) -> Option<&BBFunction> {
+    self.func_index.get(func_name as usize)
   }
 }
 
@@ -74,18 +83,21 @@ impl BasicBlock {
 pub struct NumifiedInstruction {
   pub dest: Option<u32>,
   pub args: Vec<u32>,
+  pub funcs: Vec<u32>,
 }
 
 fn get_num_from_map(
-  var: &str,
+  variable_name: &str,
+  // The total number of variables so far. Only grows
   num_of_vars: &mut u32,
+  // A map from variables to numbers
   num_var_map: &mut FxHashMap<String, u32>,
 ) -> u32 {
-  match num_var_map.get(var) {
+  match num_var_map.get(variable_name) {
     Some(i) => *i,
     None => {
       let x = *num_of_vars;
-      num_var_map.insert(var.to_string(), x);
+      num_var_map.insert(variable_name.to_string(), x);
       *num_of_vars += 1;
       x
     }
@@ -93,31 +105,62 @@ fn get_num_from_map(
 }
 
 impl NumifiedInstruction {
-  fn create(
+  fn new(
     instr: &Instruction,
+    // The total number of variables so far. Only grows
     num_of_vars: &mut u32,
+    // A map from variables to numbers
     num_var_map: &mut FxHashMap<String, u32>,
-  ) -> Self {
-    match instr {
+    // A map from function names to numbers
+    func_map: &FxHashMap<String, u32>,
+  ) -> Result<Self, PositionalInterpError> {
+    Ok(match instr {
       Instruction::Constant { dest, .. } => Self {
         dest: Some(get_num_from_map(dest, num_of_vars, num_var_map)),
         args: Vec::new(),
+        funcs: Vec::new(),
       },
-      Instruction::Value { dest, args, .. } => Self {
+      Instruction::Value {
+        dest,
+        args,
+        funcs,
+        pos,
+        ..
+      } => Self {
         dest: Some(get_num_from_map(dest, num_of_vars, num_var_map)),
         args: args
           .iter()
           .map(|v| get_num_from_map(v, num_of_vars, num_var_map))
           .collect(),
+        funcs: funcs
+          .iter()
+          .map(|f| {
+            func_map
+              .get(f)
+              .cloned()
+              .ok_or_else(|| InterpError::FuncNotFound(f.to_string()).add_pos(*pos))
+          })
+          .collect::<Result<Vec<u32>, PositionalInterpError>>()?,
       },
-      Instruction::Effect { args, .. } => Self {
+      Instruction::Effect {
+        args, funcs, pos, ..
+      } => Self {
         dest: None,
         args: args
           .iter()
           .map(|v| get_num_from_map(v, num_of_vars, num_var_map))
           .collect(),
+        funcs: funcs
+          .iter()
+          .map(|f| {
+            func_map
+              .get(f)
+              .cloned()
+              .ok_or_else(|| InterpError::FuncNotFound(f.to_string()).add_pos(*pos))
+          })
+          .collect::<Result<Vec<u32>, PositionalInterpError>>()?,
       },
-    }
+    })
   }
 }
 
@@ -137,13 +180,16 @@ pub struct BBFunction {
 }
 
 impl BBFunction {
-  fn new(f: Function) -> Result<Self, InterpError> {
-    let (mut func, label_map) = Self::find_basic_blocks(f);
+  fn new(f: Function, func_map: &FxHashMap<String, u32>) -> Result<Self, InterpError> {
+    let (mut func, label_map) = Self::find_basic_blocks(f, func_map)?;
     func.build_cfg(label_map)?;
     Ok(func)
   }
 
-  fn find_basic_blocks(func: bril_rs::Function) -> (Self, FxHashMap<String, usize>) {
+  fn find_basic_blocks(
+    func: bril_rs::Function,
+    func_map: &FxHashMap<String, u32>,
+  ) -> Result<(Self, FxHashMap<String, usize>), PositionalInterpError> {
     let mut blocks = Vec::new();
     let mut label_map = FxHashMap::default();
 
@@ -186,11 +232,12 @@ impl BBFunction {
             labels,
             pos,
           };
-          curr_block.numified_instrs.push(NumifiedInstruction::create(
+          curr_block.numified_instrs.push(NumifiedInstruction::new(
             &i,
             &mut num_of_vars,
             &mut num_var_map,
-          ));
+            func_map,
+          )?);
           curr_block.instrs.push(i);
           if let Some(l) = curr_block.label.as_ref() {
             label_map.insert(l.to_string(), blocks.len());
@@ -199,11 +246,12 @@ impl BBFunction {
           curr_block = BasicBlock::new();
         }
         bril_rs::Code::Instruction(code) => {
-          curr_block.numified_instrs.push(NumifiedInstruction::create(
+          curr_block.numified_instrs.push(NumifiedInstruction::new(
             &code,
             &mut num_of_vars,
             &mut num_var_map,
-          ));
+            func_map,
+          )?);
           curr_block.instrs.push(code);
         }
       }
@@ -216,7 +264,7 @@ impl BBFunction {
       blocks.push(curr_block);
     }
 
-    (
+    Ok((
       Self {
         name: func.name,
         args: func.args,
@@ -227,7 +275,7 @@ impl BBFunction {
         pos: func.pos,
       },
       label_map,
-    )
+    ))
   }
 
   fn build_cfg(&mut self, label_map: FxHashMap<String, usize>) -> Result<(), InterpError> {

--- a/brilirs/src/check.rs
+++ b/brilirs/src/check.rs
@@ -1,5 +1,5 @@
 use crate::{
-  basic_block::{BBFunction, BBProgram},
+  basic_block::{BBFunction, BBProgram, NumifiedInstruction},
   error::PositionalInterpError,
 };
 use bril_rs::{ConstOps, EffectOps, Instruction, Type, ValueOps};
@@ -84,6 +84,7 @@ fn get_ptr_type(typ: &bril_rs::Type) -> Result<&bril_rs::Type, InterpError> {
 
 fn type_check_instruction<'a>(
   instr: &'a Instruction,
+  num_instr: &NumifiedInstruction,
   func: &BBFunction,
   prog: &BBProgram,
   env: &mut FxHashMap<&'a str, &'a Type>,
@@ -228,10 +229,7 @@ fn type_check_instruction<'a>(
     } => {
       check_num_funcs(1, funcs)?;
       check_num_labels(0, labels)?;
-      let callee_func = prog
-        .func_index
-        .get(&funcs[0])
-        .ok_or_else(|| InterpError::FuncNotFound(funcs[0].clone()))?;
+      let callee_func = prog.func_index.get(num_instr.funcs[0] as usize).unwrap();
 
       if args.len() != callee_func.args.len() {
         return Err(InterpError::BadNumArgs(callee_func.args.len(), args.len()));
@@ -406,10 +404,7 @@ fn type_check_instruction<'a>(
     } => {
       check_num_funcs(1, funcs)?;
       check_num_labels(0, labels)?;
-      let callee_func = prog
-        .func_index
-        .get(&funcs[0])
-        .ok_or_else(|| InterpError::FuncNotFound(funcs[0].clone()))?;
+      let callee_func = prog.func_index.get(num_instr.funcs[0] as usize).unwrap();
 
       if args.len() != callee_func.args.len() {
         return Err(InterpError::BadNumArgs(callee_func.args.len(), args.len()));
@@ -482,9 +477,14 @@ fn type_check_func(bbfunc: &BBFunction, bbprog: &BBProgram) -> Result<(), Positi
 
   while let Some(b) = work_list.pop() {
     let block = bbfunc.blocks.get(b).unwrap();
-    block.instrs.iter().try_for_each(|i| {
-      type_check_instruction(i, bbfunc, bbprog, &mut env).map_err(|e| e.add_pos(i.get_pos()))
-    })?;
+    block
+      .instrs
+      .iter()
+      .zip(block.numified_instrs.iter())
+      .try_for_each(|(i, num_i)| {
+        type_check_instruction(i, num_i, bbfunc, bbprog, &mut env)
+          .map_err(|e| e.add_pos(i.get_pos()))
+      })?;
     done_list.push(b);
     block.exit.iter().for_each(|e| {
       if !done_list.contains(e) && !work_list.contains(e) {
@@ -503,5 +503,5 @@ pub fn type_check(bbprog: &BBProgram) -> Result<(), PositionalInterpError> {
   bbprog
     .func_index
     .iter()
-    .try_for_each(|(_, bbfunc)| type_check_func(bbfunc, bbprog))
+    .try_for_each(|bbfunc| type_check_func(bbfunc, bbprog))
 }

--- a/brilirs/src/check.rs
+++ b/brilirs/src/check.rs
@@ -229,7 +229,7 @@ fn type_check_instruction<'a>(
     } => {
       check_num_funcs(1, funcs)?;
       check_num_labels(0, labels)?;
-      let callee_func = prog.func_index.get(num_instr.funcs[0] as usize).unwrap();
+      let callee_func = prog.func_index.get(num_instr.funcs[0]).unwrap();
 
       if args.len() != callee_func.args.len() {
         return Err(InterpError::BadNumArgs(callee_func.args.len(), args.len()));
@@ -404,7 +404,7 @@ fn type_check_instruction<'a>(
     } => {
       check_num_funcs(1, funcs)?;
       check_num_labels(0, labels)?;
-      let callee_func = prog.func_index.get(num_instr.funcs[0] as usize).unwrap();
+      let callee_func = prog.func_index.get(num_instr.funcs[0]).unwrap();
 
       if args.len() != callee_func.args.len() {
         return Err(InterpError::BadNumArgs(callee_func.args.len(), args.len()));

--- a/brilirs/src/interp.rs
+++ b/brilirs/src/interp.rs
@@ -297,143 +297,139 @@ fn make_func_args<'a>(callee_func: &'a BBFunction, args: &[u32], vars: &mut Envi
     })
 }
 
-// todo do this with less function arguments
 #[inline(always)]
 fn execute_value_op<'a, T: std::io::Write>(
-  prog: &'a BBProgram,
+  state: &'a mut State<T>,
   op: &bril_rs::ValueOps,
   dest: u32,
   args: &[u32],
   labels: &[String],
   funcs: &[String],
-  out: &mut T,
-  value_store: &mut Environment,
-  heap: &mut Heap,
   last_label: Option<&String>,
-  instruction_count: &mut u32,
 ) -> Result<(), InterpError> {
   use bril_rs::ValueOps::*;
   match *op {
     Add => {
-      let arg0 = get_arg::<i64>(value_store, 0, args);
-      let arg1 = get_arg::<i64>(value_store, 1, args);
-      value_store.set(dest, Value::Int(arg0.wrapping_add(arg1)));
+      let arg0 = get_arg::<i64>(&state.env, 0, args);
+      let arg1 = get_arg::<i64>(&state.env, 1, args);
+      state.env.set(dest, Value::Int(arg0.wrapping_add(arg1)));
     }
     Mul => {
-      let arg0 = get_arg::<i64>(value_store, 0, args);
-      let arg1 = get_arg::<i64>(value_store, 1, args);
-      value_store.set(dest, Value::Int(arg0.wrapping_mul(arg1)));
+      let arg0 = get_arg::<i64>(&state.env, 0, args);
+      let arg1 = get_arg::<i64>(&state.env, 1, args);
+      state.env.set(dest, Value::Int(arg0.wrapping_mul(arg1)));
     }
     Sub => {
-      let arg0 = get_arg::<i64>(value_store, 0, args);
-      let arg1 = get_arg::<i64>(value_store, 1, args);
-      value_store.set(dest, Value::Int(arg0.wrapping_sub(arg1)));
+      let arg0 = get_arg::<i64>(&state.env, 0, args);
+      let arg1 = get_arg::<i64>(&state.env, 1, args);
+      state.env.set(dest, Value::Int(arg0.wrapping_sub(arg1)));
     }
     Div => {
-      let arg0 = get_arg::<i64>(value_store, 0, args);
-      let arg1 = get_arg::<i64>(value_store, 1, args);
-      value_store.set(dest, Value::Int(arg0.wrapping_div(arg1)));
+      let arg0 = get_arg::<i64>(&state.env, 0, args);
+      let arg1 = get_arg::<i64>(&state.env, 1, args);
+      state.env.set(dest, Value::Int(arg0.wrapping_div(arg1)));
     }
     Eq => {
-      let arg0 = get_arg::<i64>(value_store, 0, args);
-      let arg1 = get_arg::<i64>(value_store, 1, args);
-      value_store.set(dest, Value::Bool(arg0 == arg1));
+      let arg0 = get_arg::<i64>(&state.env, 0, args);
+      let arg1 = get_arg::<i64>(&state.env, 1, args);
+      state.env.set(dest, Value::Bool(arg0 == arg1));
     }
     Lt => {
-      let arg0 = get_arg::<i64>(value_store, 0, args);
-      let arg1 = get_arg::<i64>(value_store, 1, args);
-      value_store.set(dest, Value::Bool(arg0 < arg1));
+      let arg0 = get_arg::<i64>(&state.env, 0, args);
+      let arg1 = get_arg::<i64>(&state.env, 1, args);
+      state.env.set(dest, Value::Bool(arg0 < arg1));
     }
     Gt => {
-      let arg0 = get_arg::<i64>(value_store, 0, args);
-      let arg1 = get_arg::<i64>(value_store, 1, args);
-      value_store.set(dest, Value::Bool(arg0 > arg1));
+      let arg0 = get_arg::<i64>(&state.env, 0, args);
+      let arg1 = get_arg::<i64>(&state.env, 1, args);
+      state.env.set(dest, Value::Bool(arg0 > arg1));
     }
     Le => {
-      let arg0 = get_arg::<i64>(value_store, 0, args);
-      let arg1 = get_arg::<i64>(value_store, 1, args);
-      value_store.set(dest, Value::Bool(arg0 <= arg1));
+      let arg0 = get_arg::<i64>(&state.env, 0, args);
+      let arg1 = get_arg::<i64>(&state.env, 1, args);
+      state.env.set(dest, Value::Bool(arg0 <= arg1));
     }
     Ge => {
-      let arg0 = get_arg::<i64>(value_store, 0, args);
-      let arg1 = get_arg::<i64>(value_store, 1, args);
-      value_store.set(dest, Value::Bool(arg0 >= arg1));
+      let arg0 = get_arg::<i64>(&state.env, 0, args);
+      let arg1 = get_arg::<i64>(&state.env, 1, args);
+      state.env.set(dest, Value::Bool(arg0 >= arg1));
     }
     Not => {
-      let arg0 = get_arg::<bool>(value_store, 0, args);
-      value_store.set(dest, Value::Bool(!arg0));
+      let arg0 = get_arg::<bool>(&state.env, 0, args);
+      state.env.set(dest, Value::Bool(!arg0));
     }
     And => {
-      let arg0 = get_arg::<bool>(value_store, 0, args);
-      let arg1 = get_arg::<bool>(value_store, 1, args);
-      value_store.set(dest, Value::Bool(arg0 && arg1));
+      let arg0 = get_arg::<bool>(&state.env, 0, args);
+      let arg1 = get_arg::<bool>(&state.env, 1, args);
+      state.env.set(dest, Value::Bool(arg0 && arg1));
     }
     Or => {
-      let arg0 = get_arg::<bool>(value_store, 0, args);
-      let arg1 = get_arg::<bool>(value_store, 1, args);
-      value_store.set(dest, Value::Bool(arg0 || arg1));
+      let arg0 = get_arg::<bool>(&state.env, 0, args);
+      let arg1 = get_arg::<bool>(&state.env, 1, args);
+      state.env.set(dest, Value::Bool(arg0 || arg1));
     }
     Id => {
-      let src = get_value(value_store, 0, args).clone();
-      value_store.set(dest, src);
+      let src = get_value(&state.env, 0, args).clone();
+      state.env.set(dest, src);
     }
     Fadd => {
-      let arg0 = get_arg::<f64>(value_store, 0, args);
-      let arg1 = get_arg::<f64>(value_store, 1, args);
-      value_store.set(dest, Value::Float(arg0 + arg1));
+      let arg0 = get_arg::<f64>(&state.env, 0, args);
+      let arg1 = get_arg::<f64>(&state.env, 1, args);
+      state.env.set(dest, Value::Float(arg0 + arg1));
     }
     Fmul => {
-      let arg0 = get_arg::<f64>(value_store, 0, args);
-      let arg1 = get_arg::<f64>(value_store, 1, args);
-      value_store.set(dest, Value::Float(arg0 * arg1));
+      let arg0 = get_arg::<f64>(&state.env, 0, args);
+      let arg1 = get_arg::<f64>(&state.env, 1, args);
+      state.env.set(dest, Value::Float(arg0 * arg1));
     }
     Fsub => {
-      let arg0 = get_arg::<f64>(value_store, 0, args);
-      let arg1 = get_arg::<f64>(value_store, 1, args);
-      value_store.set(dest, Value::Float(arg0 - arg1));
+      let arg0 = get_arg::<f64>(&state.env, 0, args);
+      let arg1 = get_arg::<f64>(&state.env, 1, args);
+      state.env.set(dest, Value::Float(arg0 - arg1));
     }
     Fdiv => {
-      let arg0 = get_arg::<f64>(value_store, 0, args);
-      let arg1 = get_arg::<f64>(value_store, 1, args);
-      value_store.set(dest, Value::Float(arg0 / arg1));
+      let arg0 = get_arg::<f64>(&state.env, 0, args);
+      let arg1 = get_arg::<f64>(&state.env, 1, args);
+      state.env.set(dest, Value::Float(arg0 / arg1));
     }
     Feq => {
-      let arg0 = get_arg::<f64>(value_store, 0, args);
-      let arg1 = get_arg::<f64>(value_store, 1, args);
-      value_store.set(dest, Value::Bool(arg0 == arg1));
+      let arg0 = get_arg::<f64>(&state.env, 0, args);
+      let arg1 = get_arg::<f64>(&state.env, 1, args);
+      state.env.set(dest, Value::Bool(arg0 == arg1));
     }
     Flt => {
-      let arg0 = get_arg::<f64>(value_store, 0, args);
-      let arg1 = get_arg::<f64>(value_store, 1, args);
-      value_store.set(dest, Value::Bool(arg0 < arg1));
+      let arg0 = get_arg::<f64>(&state.env, 0, args);
+      let arg1 = get_arg::<f64>(&state.env, 1, args);
+      state.env.set(dest, Value::Bool(arg0 < arg1));
     }
     Fgt => {
-      let arg0 = get_arg::<f64>(value_store, 0, args);
-      let arg1 = get_arg::<f64>(value_store, 1, args);
-      value_store.set(dest, Value::Bool(arg0 > arg1));
+      let arg0 = get_arg::<f64>(&state.env, 0, args);
+      let arg1 = get_arg::<f64>(&state.env, 1, args);
+      state.env.set(dest, Value::Bool(arg0 > arg1));
     }
     Fle => {
-      let arg0 = get_arg::<f64>(value_store, 0, args);
-      let arg1 = get_arg::<f64>(value_store, 1, args);
-      value_store.set(dest, Value::Bool(arg0 <= arg1));
+      let arg0 = get_arg::<f64>(&state.env, 0, args);
+      let arg1 = get_arg::<f64>(&state.env, 1, args);
+      state.env.set(dest, Value::Bool(arg0 <= arg1));
     }
     Fge => {
-      let arg0 = get_arg::<f64>(value_store, 0, args);
-      let arg1 = get_arg::<f64>(value_store, 1, args);
-      value_store.set(dest, Value::Bool(arg0 >= arg1));
+      let arg0 = get_arg::<f64>(&state.env, 0, args);
+      let arg1 = get_arg::<f64>(&state.env, 1, args);
+      state.env.set(dest, Value::Bool(arg0 >= arg1));
     }
     Call => {
-      let callee_func = prog
+      let callee_func = state
+        .prog
         .get(&funcs[0])
         .ok_or_else(|| InterpError::FuncNotFound(funcs[0].clone()))?;
 
-      make_func_args(callee_func, args, value_store);
+      make_func_args(callee_func, args, &mut state.env);
 
-      let result = execute(prog, callee_func, out, value_store, heap, instruction_count)?.unwrap();
+      let result = execute(state, callee_func)?.unwrap();
 
-      value_store.pop_frame();
+      state.env.pop_frame();
 
-      value_store.set(dest, result)
+      state.env.set(dest, result)
     }
     Phi => match last_label {
       None => return Err(InterpError::NoLastLabel),
@@ -442,45 +438,40 @@ fn execute_value_op<'a, T: std::io::Write>(
           .iter()
           .position(|l| l == last_label)
           .ok_or_else(|| InterpError::PhiMissingLabel(last_label.to_string()))
-          .map(|i| get_value(value_store, i, args))?
+          .map(|i| get_value(&state.env, i, args))?
           .clone();
-        value_store.set(dest, arg);
+        state.env.set(dest, arg);
       }
     },
     Alloc => {
-      let arg0 = get_arg::<i64>(value_store, 0, args);
-      let res = heap.alloc(arg0)?;
-      value_store.set(dest, res)
+      let arg0 = get_arg::<i64>(&state.env, 0, args);
+      let res = state.heap.alloc(arg0)?;
+      state.env.set(dest, res)
     }
     Load => {
-      let arg0 = get_arg::<&Pointer>(value_store, 0, args);
-      let res = heap.read(arg0)?;
-      value_store.set(dest, res.clone())
+      let arg0 = get_arg::<&Pointer>(&state.env, 0, args);
+      let res = state.heap.read(arg0)?;
+      state.env.set(dest, res.clone())
     }
     PtrAdd => {
-      let arg0 = get_arg::<&Pointer>(value_store, 0, args);
-      let arg1 = get_arg::<i64>(value_store, 1, args);
+      let arg0 = get_arg::<&Pointer>(&state.env, 0, args);
+      let arg1 = get_arg::<i64>(&state.env, 1, args);
       let res = Value::Pointer(arg0.add(arg1));
-      value_store.set(dest, res)
+      state.env.set(dest, res)
     }
   }
   Ok(())
 }
 
-// todo do this with less function arguments
 #[inline(always)]
 fn execute_effect_op<'a, T: std::io::Write>(
-  prog: &'a BBProgram,
+  state: &'a mut State<T>,
   func: &BBFunction,
   op: &bril_rs::EffectOps,
   args: &[u32],
   funcs: &[String],
   curr_block: &BasicBlock,
-  out: &mut T,
-  value_store: &mut Environment,
-  heap: &mut Heap,
   next_block_idx: &mut Option<usize>,
-  instruction_count: &mut u32,
 ) -> Result<Option<Value>, InterpError> {
   use bril_rs::EffectOps::*;
   match op {
@@ -488,7 +479,7 @@ fn execute_effect_op<'a, T: std::io::Write>(
       *next_block_idx = Some(curr_block.exit[0]);
     }
     Branch => {
-      let bool_arg0 = get_arg::<bool>(value_store, 0, args);
+      let bool_arg0 = get_arg::<bool>(&state.env, 0, args);
       let exit_idx = if bool_arg0 { 0 } else { 1 };
       *next_block_idx = Some(curr_block.exit[exit_idx]);
     }
@@ -497,43 +488,44 @@ fn execute_effect_op<'a, T: std::io::Write>(
         func
           .return_type
           .as_ref()
-          .map(|_| get_value(value_store, 0, args).clone()),
+          .map(|_| get_value(&state.env, 0, args).clone()),
       )
     }
     Print => {
       writeln!(
-        out,
+        state.out,
         "{}",
         args
           .iter()
-          .map(|a| value_store.get(a).to_string())
+          .map(|a| state.env.get(a).to_string())
           .collect::<Vec<String>>()
           .join(" ")
       )
       // We call flush here in case `out` is a https://doc.rust-lang.org/std/io/struct.BufWriter.html
       // Otherwise we would expect this flush to be a nop.
-      .and_then(|_| out.flush())
+      .and_then(|_| state.out.flush())
       .map_err(|e| InterpError::IoError(Box::new(e)))?;
     }
     Nop => {}
     Call => {
-      let callee_func = prog
+      let callee_func = state
+        .prog
         .get(&funcs[0])
         .ok_or_else(|| InterpError::FuncNotFound(funcs[0].clone()))?;
 
-      make_func_args(callee_func, args, value_store);
+      make_func_args(callee_func, args, &mut state.env);
 
-      execute(prog, callee_func, out, value_store, heap, instruction_count)?;
-      value_store.pop_frame();
+      execute(state, callee_func)?;
+      state.env.pop_frame();
     }
     Store => {
-      let arg0 = get_arg::<&Pointer>(value_store, 0, args);
-      let arg1 = get_value(value_store, 1, args);
-      heap.write(arg0, arg1.clone())?
+      let arg0 = get_arg::<&Pointer>(&state.env, 0, args);
+      let arg1 = get_value(&state.env, 1, args);
+      state.heap.write(arg0, arg1.clone())?
     }
     Free => {
-      let arg0 = get_arg::<&Pointer>(value_store, 0, args);
-      heap.free(arg0)?
+      let arg0 = get_arg::<&Pointer>(&state.env, 0, args);
+      state.heap.free(arg0)?
     }
     Speculate | Commit | Guard => unimplemented!(),
   }
@@ -541,12 +533,8 @@ fn execute_effect_op<'a, T: std::io::Write>(
 }
 
 fn execute<'a, T: std::io::Write>(
-  prog: &'a BBProgram,
+  state: &mut State<'a, T>,
   func: &'a BBFunction,
-  out: &mut T,
-  value_store: &mut Environment,
-  heap: &mut Heap,
-  instruction_count: &mut u32,
 ) -> Result<Option<Value>, PositionalInterpError> {
   let mut last_label;
   let mut current_label = None;
@@ -558,7 +546,7 @@ fn execute<'a, T: std::io::Write>(
     let curr_instrs = &curr_block.instrs;
     let curr_numified_instrs = &curr_block.numified_instrs;
     // WARNING!!! We can add the # of instructions at once because you can only jump to a new block at the end. This may need to be changed if speculation is implemented
-    *instruction_count += curr_instrs.len() as u32;
+    state.instruction_count += curr_instrs.len() as u32;
     last_label = current_label;
     current_label = curr_block.label.as_ref();
 
@@ -581,16 +569,18 @@ fn execute<'a, T: std::io::Write>(
           // Integer literals can be promoted to Floating point
           if const_type == &bril_rs::Type::Float {
             match value {
-              bril_rs::Literal::Int(i) => {
-                value_store.set(numified_code.dest.unwrap(), Value::Float(*i as f64))
-              }
+              bril_rs::Literal::Int(i) => state
+                .env
+                .set(numified_code.dest.unwrap(), Value::Float(*i as f64)),
               bril_rs::Literal::Float(f) => {
-                value_store.set(numified_code.dest.unwrap(), Value::Float(*f))
+                state.env.set(numified_code.dest.unwrap(), Value::Float(*f))
               }
               bril_rs::Literal::Bool(_) => unreachable!(),
             }
           } else {
-            value_store.set(numified_code.dest.unwrap(), Value::from(value));
+            state
+              .env
+              .set(numified_code.dest.unwrap(), Value::from(value));
           };
         }
         Instruction::Value {
@@ -603,17 +593,13 @@ fn execute<'a, T: std::io::Write>(
           pos,
         } => {
           execute_value_op(
-            prog,
+            state,
             op,
             numified_code.dest.unwrap(),
             &numified_code.args,
             labels,
             funcs,
-            out,
-            value_store,
-            heap,
             last_label,
-            instruction_count,
           )
           .map_err(|e| e.add_pos(*pos))?;
         }
@@ -625,17 +611,13 @@ fn execute<'a, T: std::io::Write>(
           pos,
         } => {
           result = execute_effect_op(
-            prog,
+            state,
             func,
             op,
             &numified_code.args,
             funcs,
             curr_block,
-            out,
-            value_store,
-            heap,
             &mut next_block_idx,
-            instruction_count,
           )
           .map_err(|e| e.add_pos(*pos))?;
         }
@@ -707,10 +689,31 @@ fn parse_args(
   }
 }
 
+// State captures the parts of the interpreter that are used across function boundaries
+struct State<'a, T: std::io::Write> {
+  prog: &'a BBProgram,
+  env: Environment,
+  heap: Heap,
+  out: T,
+  instruction_count: u32,
+}
+
+impl<'a, T: std::io::Write> State<'a, T> {
+  fn new(prog: &'a BBProgram, env: Environment, heap: Heap, out: T) -> Self {
+    Self {
+      prog,
+      env,
+      heap,
+      out,
+      instruction_count: 0,
+    }
+  }
+}
+
 /// The entrance point to the interpreter. It runs over a ```prog```:[`BBProgram`] starting at the "main" function with ```input_args``` as input. Print statements output to ```out``` which implements [std::io::Write]. You also need to include whether you want the interpreter to count the number of instructions run with ```profiling```. This information is outputted to [std::io::stderr]
 pub fn execute_main<T: std::io::Write, U: std::io::Write>(
   prog: &BBProgram,
-  mut out: T,
+  out: T,
   input_args: &[String],
   profiling: bool,
   mut profiling_out: U,
@@ -724,29 +727,22 @@ pub fn execute_main<T: std::io::Write, U: std::io::Write>(
       .map_err(|e| e.add_pos(main_func.pos));
   }
 
-  let env = Environment::new(main_func.num_of_vars);
-  let mut heap = Heap::default();
+  let mut env = Environment::new(main_func.num_of_vars);
+  let heap = Heap::default();
 
-  let mut value_store = parse_args(env, &main_func.args, &main_func.args_as_nums, input_args)
+  env = parse_args(env, &main_func.args, &main_func.args_as_nums, input_args)
     .map_err(|e| e.add_pos(main_func.pos))?;
 
-  let mut instruction_count = 0;
+  let mut state = State::new(prog, env, heap, out);
 
-  execute(
-    prog,
-    main_func,
-    &mut out,
-    &mut value_store,
-    &mut heap,
-    &mut instruction_count,
-  )?;
+  execute(&mut state, main_func)?;
 
-  if !heap.is_empty() {
+  if !state.heap.is_empty() {
     return Err(InterpError::MemLeak).map_err(|e| e.add_pos(main_func.pos));
   }
 
   if profiling {
-    writeln!(profiling_out, "total_dyn_inst: {instruction_count}")
+    writeln!(profiling_out, "total_dyn_inst: {}", state.instruction_count)
       // We call flush here in case `profiling_out` is a https://doc.rust-lang.org/std/io/struct.BufWriter.html
       // Otherwise we would expect this flush to be a nop.
       .and_then(|_| profiling_out.flush())

--- a/brilirs/src/lib.rs
+++ b/brilirs/src/lib.rs
@@ -2,7 +2,6 @@
 #![warn(clippy::all, clippy::nursery, clippy::cargo)]
 #![warn(missing_docs)]
 #![doc = include_str!("../README.md")]
-#![allow(clippy::too_many_arguments)]
 
 use std::error::Error;
 

--- a/brilirs/todo_list.txt
+++ b/brilirs/todo_list.txt
@@ -5,8 +5,6 @@
 - bril-rs to LLVM compiler?(See struct extension compiler)
 - Optimize brilirs:
     - replace the naive memory management support with a more optimized version
-    - optimize brilirs for function calls
-        - replace string lookup with indexing a vec
 - Fuzzing with cargo-fuzz or Property testing with proptest
 - Replace benchmarking scripts with something more extensible like brench or a better python/rust script
 - Equality Saturation using the egg crate for bril-rs?


### PR DESCRIPTION
Most of this pr is cleanup via:
- 3539fd3: Mostly comments and stylistic changes.
- 51779f9: Reworks `build.rs` to have a better control flow and to not create a tab completions file if it already exists.
- 7c3822c: Addressing `#![allow(clippy::too_many_arguments)]` by refactoring the interpreter to use a `State` struct. This is similar to the `State` struct used in `brili` except there is only one instance which is passed by `&mut`.
- e03f0be: Previously, indexing was being done by keeping track of `u32` values and then casting to `usize`. This just now uses `usize` values directly.

I've been sporadically adding more comments to the code base as I've forgotten what my past self meant by some of it... see https://xkcd.com/1421/

2dfee99 tackles the second half of optimizing function calls in `brilirs` started in #188. Previously, functions were stored in a `HashMap<String, BBFunction>` in `BBProgram`. This meant that on each function call, the string name needs to be hashed and looked up in the map. Since all of the functions are know statically, we can instead create a `vec<BBFunction>` to be indexed into in a similar optimization for what is done with the variable names of instructions(originally introduced in the blog post https://www.cs.cornell.edu/courses/cs6120/2019fa/blog/faster-interpreter/). 

The performance on`function_call.bril`.

| brili  | Old brilirs | Proposed brilirs |
| ------------- | ------------- | ---------|
| 7.1s ± .1 s  | 328 ms ± 2ms | 251 ms ± 2 ms |

In comparison to #188, there is a much bigger reduction in run time which was surprising to me. It could be that hashing and indexing into a map are more expensive that I had thought. It could also be that this benchmark is too simple to for there to be a significant benefit from #188. Since it just calling the same function repeatedly, each allocation is the same size(same number of variables on the stack) which allows the allocator to be fast whereas the performance of #188 shouldn't be as affected by changes in stack size.

Either way, good benchmarking is non-trivial and all of these performance numbers should be taken with a grain of salt.
