### PR TITLE
Using source code in Brilirs error messages

### DIFF
--- a/bril-rs/src/conversion.rs
+++ b/bril-rs/src/conversion.rs
@@ -43,11 +43,11 @@ pub enum ConversionError {
 impl ConversionError {
     #[doc(hidden)]
     #[must_use]
-    pub fn add_pos(self, pos_var: Option<Position>) -> PositionalConversionError {
+    pub const fn add_pos(self, pos_var: Option<Position>) -> PositionalConversionError {
         match self {
             //Self::PositionalConversionErrorConversion(e) => e,
             _ => PositionalConversionError {
-                e: Box::new(self),
+                e: self,
                 pos: pos_var,
             },
         }
@@ -57,18 +57,17 @@ impl ConversionError {
 /// Wraps [`ConversionError`] to optionally provide source code positions if they are available.
 #[derive(Error, Debug)]
 pub struct PositionalConversionError {
-    e: Box<ConversionError>,
-    pos: Option<Position>,
+    #[doc(hidden)]
+    pub e: ConversionError,
+    #[doc(hidden)]
+    pub pos: Option<Position>,
 }
 
 impl PositionalConversionError {
     #[doc(hidden)]
     #[must_use]
-    pub fn new(e: ConversionError) -> Self {
-        Self {
-            e: Box::new(e),
-            pos: None,
-        }
+    pub const fn new(e: ConversionError) -> Self {
+        Self { e, pos: None }
     }
 }
 

--- a/brilirs/src/basic_block.rs
+++ b/brilirs/src/basic_block.rs
@@ -279,6 +279,9 @@ impl BBFunction {
   }
 
   fn build_cfg(&mut self, label_map: FxHashMap<String, usize>) -> Result<(), InterpError> {
+    if self.blocks.is_empty() {
+      return Ok(());
+    }
     let last_idx = self.blocks.len() - 1;
     for (i, block) in self.blocks.iter_mut().enumerate() {
       // If we're before the last block

--- a/brilirs/src/cli.rs
+++ b/brilirs/src/cli.rs
@@ -22,4 +22,12 @@ pub struct Cli {
 
   /// Arguments for the main function
   pub args: Vec<String>,
+
+  /// This is the original source file that the file input was generated from.
+  /// You would want to provide this if the bril file you are providing to the
+  /// interpreter is in JSON form with source positions and you what brilirs to
+  /// include sections of the source file in its error messages.
+  /// If --text/-t is provided, that will be assumed to be the source file if none are provided.
+  #[clap(short, long)]
+  pub source: Option<String>,
 }

--- a/brilirs/src/interp.rs
+++ b/brilirs/src/interp.rs
@@ -712,7 +712,7 @@ pub fn execute_main<T: std::io::Write, U: std::io::Write>(
   let main_func = prog
     .index_of_main
     .map(|i| prog.get(i).unwrap())
-    .ok_or_else(|| PositionalInterpError::new(InterpError::NoMainFunction))?;
+    .ok_or(InterpError::NoMainFunction)?;
 
   if main_func.return_type.is_some() {
     return Err(InterpError::NonEmptyRetForFunc(main_func.name.clone()))
@@ -738,7 +738,7 @@ pub fn execute_main<T: std::io::Write, U: std::io::Write>(
       // We call flush here in case `profiling_out` is a https://doc.rust-lang.org/std/io/struct.BufWriter.html
       // Otherwise we would expect this flush to be a nop.
       .and_then(|_| profiling_out.flush())
-      .map_err(|e| PositionalInterpError::new(InterpError::IoError(Box::new(e))))?;
+      .map_err(|e| InterpError::IoError(Box::new(e)))?;
   }
 
   Ok(())

--- a/brilirs/src/lib.rs
+++ b/brilirs/src/lib.rs
@@ -3,10 +3,9 @@
 #![warn(missing_docs)]
 #![doc = include_str!("../README.md")]
 
-use std::error::Error;
-
 use basic_block::BBProgram;
 use bril_rs::Program;
+use error::PositionalInterpError;
 
 /// The internal representation of brilirs, provided a ```TryFrom<Program>``` conversion
 pub mod basic_block;
@@ -14,20 +13,21 @@ pub mod basic_block;
 pub mod check;
 #[doc(hidden)]
 pub mod cli;
-mod error;
+#[doc(hidden)]
+pub mod error;
 /// Provides ```interp::execute_main``` to execute [Program] that have been converted into [BBProgram]
 pub mod interp;
 
 #[doc(hidden)]
 pub fn run_input<T: std::io::Write, U: std::io::Write>(
-  input: Box<dyn std::io::Read>,
+  input: impl std::io::Read,
   out: T,
   input_args: Vec<String>,
   profiling: bool,
   profiling_out: U,
   check: bool,
   text: bool,
-) -> Result<(), Box<dyn Error>> {
+) -> Result<(), PositionalInterpError> {
   // It's a little confusing because of the naming conventions.
   //      - bril_rs takes file.json as input
   //      - bril2json takes file.bril as input

--- a/brilirs/src/main.rs
+++ b/brilirs/src/main.rs
@@ -1,22 +1,32 @@
 use brilirs::cli::Cli;
+use brilirs::error::PositionalInterpError;
 use clap::Parser;
 use std::fs::File;
+use std::io::Read;
 
 fn main() {
   let args = Cli::parse();
 
-  let input: Box<dyn std::io::Read> = match args.file {
+  let mut input: Box<dyn std::io::Read> = match args.file {
     None => Box::new(std::io::stdin()),
 
     Some(input_file) => Box::new(File::open(input_file).unwrap()),
   };
 
+  // Here we are reading out the input into a string so that we have it for error reporting
+  // This will be done again during parsing inside of run_input because of the current interface
+  // This is inefficient but probably not meaningfully so since benchmarking has shown that parsing quickly gets out weighted by program execution
+  // If this does matter to you in your profiling, split up parse_abstract_program_from_read/load_abstract_program_from_read so that they can take a string instead of a `Read`
+  let mut input_string = String::new();
+  input.read_to_string(&mut input_string).unwrap();
+
   /*
   todo should you be able to supply output locations from the command line interface?
   Instead of builtin std::io::stdout()/std::io::stderr()
   */
+
   if let Err(e) = brilirs::run_input(
-    input,
+    input_string.as_bytes(),
     std::io::stdout(),
     args.args,
     args.profile,
@@ -24,7 +34,35 @@ fn main() {
     args.check,
     args.text,
   ) {
-    eprintln!("error: {e}");
+    let mut source_file = None;
+    if args.text {
+      source_file = Some(&input_string);
+    }
+
+    let mut tmp_string = String::new();
+    if let Some(s) = args.source {
+      File::open(s)
+        .unwrap()
+        .read_to_string(&mut tmp_string)
+        .unwrap();
+      source_file = Some(&tmp_string);
+    }
+
+    if let (
+      Some(f),
+      PositionalInterpError {
+        e: _,
+        pos: Some(pos),
+      },
+    ) = (source_file, &e)
+    {
+      let mut lines = f.split('\n');
+      eprintln!("error: {e}");
+      eprintln!("{}", lines.nth((pos.row - 1) as usize).unwrap());
+      eprintln!("{:>width$}", "^", width = pos.col as usize);
+    } else {
+      eprintln!("error: {e}");
+    }
     std::process::exit(2)
   }
 }


### PR DESCRIPTION
I've felt inspired to bring together the work of #137 (which allows brilirs to handle Bril text files as input) and #167 (which implements source positions) in implementing error messages from brilirs which contain the source code of where error occurred(Inspired by Rust and other languages with nice error messages).

- fd969de adds an optional flag to the cli `--source/-s` which allows for an arbitrary source file to be provided for error messages. The only assumptions made on this source file is that each line is separated by a `\n` character and that the `col` position indicates the number of space characters into the line(meaning, I haven't considered tabs or other characters that could be only one character in terms of the `col` position of the source code but are multiple space characters in size). If this flag is not provided, but `--text/-t` is, then the input Bril text file will be assumed to be the source file. Source code will only be used in errors if there is an associated position for the error which might not be true if the provided Bril JSON file does not contain source positions or if brilirs does not assign a position for the error(for example, the `NoMainFunction` error).
- c20d39b fixes a crash when the function body is empty.

An example error message:
```
❯ brilirs --text --file test/interp-error/call-wrong-arity.bril 
error: Line 5, Column 5: Expected `2` instruction arguments, found `3`
    call @addboth x y z;
    ^
```

The errors/error messages in brilirs are not that well tested. I only found out about the edge case that caused c20d39b from running some for the `interp-fail` tests by hand. brilirs is currently not tested against the `interp-fail` and `check` tests but is tested against `fail` because the setup of both seem to be comparing against `*.err` files(note that brilirs error messages are not the same as brili or brilck error messages) whereas `fail` compares the output against `*.out` files(I'm not really sure why the test suite does this, all of the `*.out` files are empty). It seems like the minimum that should be done is to just check the error code brilirs gives to check that it provides errors/doesn't crash. I'm not sure if turnt will just let me diff error codes and not files or if I should create empty `*.out` files for `interp-fail` and `check`(or if there is a third, better option).

Brilirs error messages are best effort and haven't been check that thoroughly.