### PR TITLE
Brilirs update

### DIFF
--- a/bril-rs/bril2json/src/lib.rs
+++ b/bril-rs/bril2json/src/lib.rs
@@ -33,11 +33,11 @@ impl Lines {
     fn get_position(&self, index: usize) -> Option<Position> {
         if self.use_pos {
             Some(self.new_lines.iter().enumerate().fold(
-                Position { col: 1, row: 0 },
+                Position { col: 1, row: 1 },
                 |current, (line_num, idx)| {
                     if *idx < index {
                         Position {
-                            row: (line_num + 2) as u64,
+                            row: (line_num + 1) as u64,
                             col: (index - idx) as u64,
                         }
                     } else {

--- a/brilirs/Makefile
+++ b/brilirs/Makefile
@@ -1,6 +1,8 @@
 TESTS :=  ../test/interp/*.bril \
 	../test/mem/*.bril \
-	../test/fail/*.bril
+	../test/fail/*.bril \
+	../test/interp-error/*.bril \
+	../test/check/*.bril
 
 BENCHMARKS := ../benchmarks/*.bril
 

--- a/brilirs/src/basic_block.rs
+++ b/brilirs/src/basic_block.rs
@@ -42,7 +42,7 @@ impl BBProgram {
       index_of_main: func_map.get(&"main".to_string()).cloned(),
       func_index,
     };
-    if bb.func_index.len() != num_funcs {
+    if func_map.len() != num_funcs {
       Err(InterpError::DuplicateFunction)
     } else {
       Ok(bb)

--- a/brilirs/src/interp.rs
+++ b/brilirs/src/interp.rs
@@ -208,6 +208,8 @@ impl fmt::Display for Value {
     match self {
       Value::Int(i) => write!(f, "{i}"),
       Value::Bool(b) => write!(f, "{b}"),
+      Value::Float(v) if v.is_infinite() && v.is_sign_positive() => write!(f, "Infinity"),
+      Value::Float(v) if v.is_infinite() && v.is_sign_negative() => write!(f, "-Infinity"),
       Value::Float(v) => write!(f, "{v}"),
       Value::Pointer(p) => write!(f, "{p:?}"),
       Value::Uninitialized => unreachable!(),

--- a/docs/tools/bench.md
+++ b/docs/tools/bench.md
@@ -24,6 +24,7 @@ The current benchmarks are:
 * `factors`: Print the factors of the *n* using the [trial division][trialdivision] method.
 * `fib`: Calculate the *n*th Fibonacci number by allocating and filling an [array](../lang/memory.md) of numbers up to that point.
 * `fizz-buzz`: The infamous [programming test][fizzbuzz].
+* `function_call`: For benchmarking the overhead of simple function calls.
 * `gcd`: Calculate Greatest Common Divisor (GCD) of two input positive integer using [Euclidean algorithm][euclidean_into].
 * `loopfact`: Compute *n!* imperatively using a loop.
 * `mat-inv` : Calculates the inverse of a 3x3 matrix and prints it out.

--- a/test/check/turnt_brilirs.toml
+++ b/test/check/turnt_brilirs.toml
@@ -1,0 +1,3 @@
+command = "cargo run --manifest-path ../../brilirs/Cargo.toml -- --check --file {filename} --text {args}"
+return_code = 2
+output = {}

--- a/test/interp-error/turnt_brilirs.toml
+++ b/test/interp-error/turnt_brilirs.toml
@@ -1,3 +1,3 @@
 command = "cargo run --manifest-path ../../brilirs/Cargo.toml -- --file {filename} --text {args}"
 return_code = 2
-output.err = "2"
+output = {}

--- a/test/interp/float_divide_by_zero.bril
+++ b/test/interp/float_divide_by_zero.bril
@@ -1,0 +1,11 @@
+@main {
+  v0: float = const -1.0;
+  v1: float = const 1.0;
+  zero: float = const 0.0;
+  res: float = fdiv v0 zero;
+  print res;
+  res: float = fdiv v1 zero;
+  print res;
+  res: float = fdiv zero zero;
+  print res;
+}

--- a/test/interp/float_divide_by_zero.out
+++ b/test/interp/float_divide_by_zero.out
@@ -1,0 +1,3 @@
+-Infinity
+Infinity
+NaN


### PR DESCRIPTION
- d448240 Adds documentation for the function_call benchmark added in #188 
- 86e6db5 / cbfd761 bugfixes
- 2ed5d33 Have brilirs match the exact text output for floating point Infinity values, see my comment in #139
- 7e58b63 To my surprise `output = {}` seems to work how I wanted in #191. `brilirs --check` is now run against `test/check/` and `brilirs` is run against `test/interp-error`. In both cases, only checking error codes. The expectation is that `brilirs` passes all of the current tests that don't included the speculation extension.