### PR TITLE
Brilift

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ node_modules/
 hypothesis_*
 __pycache__
 .vscode
+
+**/*.o

--- a/brilift/Makefile
+++ b/brilift/Makefile
@@ -1,9 +1,25 @@
 TARGET := x86_64-unknown-darwin-macho
 RUST_TARGET := x86_64-apple-darwin
 
+TESTS :=  ../test/interp/*.bril
+BENCHMARKS := ../benchmarks/*.bril
+TOML := turnt_brilift.toml
+
 .PHONY: build
 build:
 	cargo build
+
+.PHONY: install
+install:
+	cargo install --path .
+
+.PHONY: test
+test:
+	turnt -c $(TOML) $(TESTS)
+
+.PHONY: benchmark
+benchmark:
+	turnt -c $(TOML) $(BENCHMARKS)
 
 rt.o: rt.c
 	cc -target $(TARGET) -c -o $@ $^

--- a/brilift/src/main.rs
+++ b/brilift/src/main.rs
@@ -319,9 +319,9 @@ fn gen_binary(
 }
 
 /// An environment for translating Bril into CLIF.
-struct CompileEnv {
+struct CompileEnv<'a> {
     vars: HashMap<String, Variable>,
-    var_types: HashMap<String, bril::Type>,
+    var_types: HashMap<&'a String, &'a bril::Type>,
     rt_refs: EnumMap<RTFunc, ir::FuncRef>,
     blocks: HashMap<String, ir::Block>,
     func_refs: HashMap<String, ir::FuncRef>,
@@ -566,11 +566,6 @@ impl<M: Module> Translator<M> {
             })
             .collect();
 
-        // Cloning this map is not so great, but I am pretty bad at Rust!
-        let var_types = var_types
-            .into_iter()
-            .map(|(k, v)| (k.clone(), v.clone()))
-            .collect();
         let env = CompileEnv {
             vars,
             var_types,

--- a/test/interp/turnt_brilift.toml
+++ b/test/interp/turnt_brilift.toml
@@ -1,0 +1,1 @@
+command = "bril2json < {filename} | ../../brilift/run.sh {args}"


### PR DESCRIPTION
I would like to propose some code changes.

d7bf0ab - object files should probably be ignored
70bc6b3 - I would like to recommend running turnt via `make test` and `make benchmark` which is what I do for `brilirs`.
e69e3db - There was a comment about an unnecessary clone. I resolved this issue by adding a lifetime to the struct so it can contain references. Given the current structure of the code base, this works rather seamlessly but I haven't really thought about how it would affect future development. I'm not sure if you had already considered this design and found an issue with it. Feel free to ignore this commit if that is the case.