### PR TITLE
Brilift: Enable JIT mode

### DIFF
--- a/brilift/src/main.rs
+++ b/brilift/src/main.rs
@@ -273,7 +273,7 @@ impl Translator<JITModule> {
     fn jit_builder() -> JITBuilder {
         let mut flag_builder = settings::builder();
         flag_builder.set("use_colocated_libcalls", "false").unwrap();
-        flag_builder.set("is_pic", "false").unwrap();  // PIC unsupported on ARM.
+        flag_builder.set("is_pic", "false").unwrap(); // PIC unsupported on ARM.
         let isa_builder = cranelift_native::builder().unwrap();
         let isa = isa_builder
             .finish(settings::Flags::new(flag_builder))

--- a/brilift/src/main.rs
+++ b/brilift/src/main.rs
@@ -2,6 +2,7 @@ mod rt;
 
 use argh::FromArgs;
 use bril_rs as bril;
+use core::mem;
 use cranelift_codegen::entity::EntityRef;
 use cranelift_codegen::ir::condcodes::IntCC;
 use cranelift_codegen::ir::InstBuilder;
@@ -14,7 +15,6 @@ use cranelift_object::{ObjectBuilder, ObjectModule};
 use enum_map::{enum_map, Enum, EnumMap};
 use std::collections::HashMap;
 use std::fs;
-use core::mem;
 
 /// Runtime functions used by ordinary Bril instructions.
 #[derive(Debug, Enum)]
@@ -260,26 +260,6 @@ impl Translator<ObjectModule> {
 unsafe fn run(main_ptr: *const u8) {
     let func = mem::transmute::<_, fn() -> ()>(main_ptr);
     func();
-}
-
-#[no_mangle]
-pub extern "C" fn rt_print_int(i: i64) {
-    print!("{}", i);
-}
-
-#[no_mangle]
-pub extern "C" fn rt_print_bool(b: bool) {
-    print!("{}", b);
-}
-
-#[no_mangle]
-pub extern "C" fn rt_print_sep() {
-    print!(" ");
-}
-
-#[no_mangle]
-pub extern "C" fn rt_print_end() {
-    print!("\n");
 }
 
 /// JIT compiler that totally does not work yet.

--- a/brilift/src/main.rs
+++ b/brilift/src/main.rs
@@ -284,7 +284,7 @@ impl Translator<JITModule> {
     // The normal way to set up a JIT builder.
     #[cfg(not(target_arch = "aarch64"))]
     fn jit_builder() -> JITBuilder {
-        JITBuilder::new(cranelift_module::default_libcall_names()).unwrap();
+        JITBuilder::new(cranelift_module::default_libcall_names()).unwrap()
     }
 
     fn new() -> Self {

--- a/brilift/src/main.rs
+++ b/brilift/src/main.rs
@@ -264,9 +264,34 @@ unsafe fn run(main_ptr: *const u8) {
 
 /// JIT compiler that totally does not work yet.
 impl Translator<JITModule> {
+    // `cranelift_jit` does not yet support PIC on AArch64:
+    // https://github.com/bytecodealliance/wasmtime/issues/2735
+    // The default initialization path for `JITBuilder` is hard-coded to use PIC, so we manually
+    // disable it here. Once this is fully supported in `cranelift_jit`, we can switch to the
+    // generic versin below unconditionally.
+    #[cfg(target_arch = "aarch64")]
+    fn jit_builder() -> JITBuilder {
+        let mut flag_builder = settings::builder();
+        flag_builder.set("use_colocated_libcalls", "false").unwrap();
+        flag_builder.set("is_pic", "false").unwrap();  // PIC unsupported on ARM.
+        let isa_builder = cranelift_native::builder().unwrap();
+        let isa = isa_builder
+            .finish(settings::Flags::new(flag_builder))
+            .unwrap();
+        JITBuilder::with_isa(isa, cranelift_module::default_libcall_names())
+    }
+
+    // The normal way to set up a JIT builder.
+    #[cfg(not(target_arch = "aarch64"))]
+    fn jit_builder() -> JITBuilder {
+        JITBuilder::new(cranelift_module::default_libcall_names()).unwrap();
+    }
+
     fn new() -> Self {
+        // Set up the JIT.
+        let mut builder = Self::jit_builder();
+
         // Provide runtime functions.
-        let mut builder = JITBuilder::new(cranelift_module::default_libcall_names()).unwrap();
         enum_map! {
             rtfunc => {
                 let f: RTFunc = rtfunc;

--- a/brilift/src/rt.rs
+++ b/brilift/src/rt.rs
@@ -15,5 +15,5 @@ pub extern "C" fn print_sep() {
 
 #[no_mangle]
 pub extern "C" fn print_end() {
-    print!("\n");
+    println!();
 }

--- a/brilift/src/rt.rs
+++ b/brilift/src/rt.rs
@@ -1,0 +1,19 @@
+#[no_mangle]
+pub extern "C" fn print_int(i: i64) {
+    print!("{}", i);
+}
+
+#[no_mangle]
+pub extern "C" fn print_bool(b: bool) {
+    print!("{}", b);
+}
+
+#[no_mangle]
+pub extern "C" fn print_sep() {
+    print!(" ");
+}
+
+#[no_mangle]
+pub extern "C" fn print_end() {
+    print!("\n");
+}

--- a/docs/tools/brilift.md
+++ b/docs/tools/brilift.md
@@ -1,12 +1,12 @@
 Cranelift Compiler
 ==================
 
-Brilift is a compiler from Bril to native code using the [Cranelift][] code generator.
+Brilift is a ahead-of-time or just-in-time compiler from Bril to native code using the [Cranelift][] code generator.
 It supports [core Bril][core] only.
 
-Brilift is an ahead-of-time compiler.
-It emits `.o` files and also provides a simple run-time library.
+In AOT mode, Brilift emits `.o` files and also provides a simple run-time library.
 By linking these together, you get a complete native executable.
+In JIT mode, Brilift mimics an interpreter.
 
 [cranelift]: https://github.com/bytecodealliance/wasmtime/tree/main/cranelift
 [core]: ../lang/core.md
@@ -25,8 +25,8 @@ You can build it using [Cargo][]:
 [bril-rs]: rust.md
 [cargo]: https://doc.rust-lang.org/cargo/
 
-Compile Stuff
--------------
+Ahead-of-Time Compilation
+-------------------------
 
 Provide the `brilift` executable with a Bril JSON program:
 
@@ -46,18 +46,27 @@ Then, you will want to link `rt.o` and `bril.o` to produce an executable:
 
 If your Bril `@main` function takes arguments, those are now command-line arguments to the `myprog` executable.
 
+Just-in-Time Compilation
+------------------------
+
+Use the `-j` flag to compile and run the program immediately:
+
+    $ bril2json < something.bril | brilift -j
+
 Options
 -------
 
 Type `brilift --help` to see the full list of options:
 
-* `-o <FILE>`: Place the output object file in `<FILE>` instead of `bril.o` (the default).
-* `-t <TARGET>`: Specify the target triple, as interpreted by Cranelift. These triples resemble the [target triples][triple] that LLVM also understands, for example. For instance, `x86_64-unknown-darwin-macho` is the triple for macOS on Intel processors.
+* `-j`: JIT-compile the code and run it immediately, instead of AOT-compiling an object file (the default).
 * `-O [none|speed|speed_and_size]`: An [optimization level][opt_level], according to Cranelift. The default is `none`.
 * `-v`: Enable lots of logging from the Cranelift library.
 * `-d`: Dump the Cranelift IR text for debugging.
 
-There is also a `-j` option that tries to use a JIT to run the code immediately, instead of the default AOT mode, but that does not work at all yet.
+These options are only relevant in AOT mode:
+
+* `-o <FILE>`: Place the output object file in `<FILE>` instead of `bril.o` (the default).
+* `-t <TARGET>`: Specify the target triple, as interpreted by Cranelift. These triples resemble the [target triples][triple] that LLVM also understands, for example. For instance, `x86_64-unknown-darwin-macho` is the triple for macOS on Intel processors.
 
 [opt_level]: https://docs.rs/cranelift-codegen/0.84.0/cranelift_codegen/settings/struct.Flags.html#method.opt_level
 [triple]: https://clang.llvm.org/docs/CrossCompilation.html#target-triple


### PR DESCRIPTION
Using the incredibly convenient [`cranelift_jit` crate](https://docs.rs/cranelift-jit/latest/cranelift_jit/), this enables a JIT mode for the Brilift compiler. There are two main things here:

* An implementation of the runtime library in (non-`no_std`) Rust. The generated code can call directly into these Rust functions, which is awfully nice. One could imagine getting rid of the C runtime once again and trying to use the same implementation for both the AOT and JIT paths. Or maybe we just need a standard interface and want to share this with the other native-code Bril compilers that are out there.
* A workaround for an issue in `cranelift_jit`, https://github.com/bytecodealliance/wasmtime/issues/2735, that made the default setup not work on ARM. The workaround just disables PIC on ARM only. The upshot is that `brilift -j` works on macOS with Apple Silicon, for example (whereas AOT mode does not, yet, and requires specifying an x86 target).

`@main` arguments are not supported yet; that's the next step. I have a hopefully-simple idea for how to do this by generating a wrapper that gets arguments from memory via an array of pointers to `bril_rs::Literal`-wrapped values. I hope that's not too bad.