### PR TITLE
Spruce up Brilift testing

### DIFF
--- a/brilift/Makefile
+++ b/brilift/Makefile
@@ -3,7 +3,6 @@ RUST_TARGET := x86_64-apple-darwin
 
 TESTS :=  ../test/interp/core/*.bril
 BENCHMARKS := ../benchmarks/*.bril
-TOML := turnt_brilift_aot.toml
 
 .PHONY: build
 build:
@@ -15,11 +14,13 @@ install:
 
 .PHONY: test
 test: rt.o
-	turnt -c $(TOML) $(TESTS)
+	turnt -c turnt_brilift_aot.toml $(TESTS)
+	turnt -c turnt_brilift_jit.toml $(TESTS)
 
 .PHONY: benchmark
 benchmark: rt.o
-	turnt -c $(TOML) $(BENCHMARKS)
+	turnt -c turnt_brilift_aot.toml $(BENCHMARKS)
+	turnt -c turnt_brilift_jit.toml $(BENCHMARKS)
 
 rt.o: rt.c
 	cc -target $(TARGET) -c -o $@ $^

--- a/brilift/Makefile
+++ b/brilift/Makefile
@@ -1,8 +1,13 @@
 TARGET := x86_64-unknown-darwin-macho
 RUST_TARGET := x86_64-apple-darwin
 
+# Brilift only supports core Bril for now, so we select those tests &
+# benchmarks.
 TESTS :=  ../test/interp/core/*.bril
-BENCHMARKS := ../benchmarks/*.bril
+BENCHMARKS := $(shell grep -L 'ptr\|float' ../benchmarks/*.bril)
+
+foo:
+	echo $(BENCHMARKS)
 
 .PHONY: build
 build:

--- a/test/interp/turnt_brilift_jit.toml
+++ b/test/interp/turnt_brilift_jit.toml
@@ -1,1 +1,1 @@
-command = "bril2json < {filename} | ../../../brilift/target/release/brilift -j -- {args}"
+command = "bril2json < {filename} | ../../brilift/target/release/brilift -j -- {args}"


### PR DESCRIPTION
Just tweaks the testing setup a little so it's easy to run both the AOT and the JIT tests in one fell swoop. And to only attempt to run core-only benchmarks rather than all of them.