### PR TITLE
Docs cleanup

### DIFF
--- a/docs/lang/import.md
+++ b/docs/lang/import.md
@@ -14,13 +14,13 @@ Implementations of this extension must define a method of resolving the relative
 Bril programs that use the import extension can also be imported and should maintain the above semantics. The programmer is allowed to create cycles of imports.
 
 Syntax
-======
+------
 
 The Bril JSON representation is as shown:
 
     {
         "functions": [
-            ...
+            …
         ],
         "imports": [
             {

--- a/docs/tools/brilirs.md
+++ b/docs/tools/brilirs.md
@@ -3,12 +3,13 @@ Fast Interpreter in Rust
 
 The `brilirs` directory contains a fast Bril interpreter written in [Rust][].
 It is a drop-in replacement for the [reference interpreter](interp.md) that prioritizes speed over completeness and hackability.
-It implements [core Bril](../lang/core.md) and the [SSA][], [memory][], and [floating point][float] extensions.
+It implements [core Bril](../lang/core.md) along with the [SSA][], [memory][], and [floating point][float] extensions.
 
 Read [more about the implementation][blog], which is originally by Wil Thomason and Daniel Glus.
 
 Install
 -------
+
 To use `brilirs` you will need to [install Rust](https://www.rust-lang.org/tools/install). Use `echo $PATH` to check that `$HOME/.cargo/bin` is on your [path](https://unix.stackexchange.com/a/26059/61192).
 
 In the `brilirs` directory, install the interpreter with:
@@ -25,12 +26,11 @@ or
 
     $ brilirs --text --file myprogram.bril
 
-Similar to [type-infer](infer.md), `brilirs` can be used to typecheck and validate your Bril JSON program by passing the `--check` flag (similar to `cargo --check`).
+Similar to [brilck](brilck.md), `brilirs` can be used to typecheck and validate your Bril JSON program by passing the `--check` flag (similar to `cargo --check`).
 
 To see all of the supported flags, run:
 
     $ brilirs --help
-
 
 [rust]: https://www.rust-lang.org
 [ssa]: ../lang/ssa.md

--- a/docs/tools/rust.md
+++ b/docs/tools/rust.md
@@ -20,7 +20,7 @@ Each of the extensions to [Bril core][core] is feature gated. To ignore an exten
 There are two helper functions: `load_program` will read a valid Bril program from stdin, and `output_program` will write your Bril program to stdout. Otherwise, this library can be treated like any other [serde][] JSON representation.
 
 Tools
----
+-----
 
 This library supports fully compatible Rust implementations of `bril2txt` and `bril2json`. This library also implements the [import][] extension with a static linker called `brild`.
 
@@ -38,6 +38,7 @@ To maintain consistency and cleanliness, run:
 ```bash
 cargo fmt
 cargo clippy
+cargo doc
 make test
 make features
 ```


### PR DESCRIPTION
This pr is to follow up on https://github.com/sampsyo/bril/pull/197#pullrequestreview-978450064 in terms of cleaning up some of the documentation. I'm interested in any feedback for the import extension documentation, but would also be happy to do any `bril-rs`/`brilirs` related changes.