### PR TITLE
Small cleanups for brilirs

### DIFF
--- a/bril-rs/bril2json/Cargo.toml
+++ b/bril-rs/bril2json/Cargo.toml
@@ -14,13 +14,13 @@ keywords = ["compiler", "bril", "parser", "data-structures", "language"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-clap         = { version = "3.0", features = ["derive"] }
-lalrpop-util = {version = "0.19.6", features = ["lexer"]}
-regex = "1"
+clap         = { version = "3.1", features = ["derive"] }
+lalrpop-util = { version = "0.19", features = ["lexer"] }
+regex = "1.5"
 
 # Add a build-time dependency on the lalrpop library:
 [build-dependencies]
-lalrpop = "0.19.6"
+lalrpop = "0.19"
 
 [dependencies.bril-rs]
 version = "0.1.0"

--- a/bril-rs/brild/Cargo.toml
+++ b/bril-rs/brild/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["compiler", "bril", "parser", "data-structures", "language"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-clap         = { version = "3.0", features = ["derive"] }
+clap         = { version = "3.1", features = ["derive"] }
 
 [dependencies.bril2json]
 version      = "0.1.0"

--- a/brilirs/.gitignore
+++ b/brilirs/.gitignore
@@ -18,6 +18,3 @@ Cargo.lock
 # Intellij
 .idea/*
 *.iml
-
-# tab completions file
-brilirs.*

--- a/brilirs/Cargo.toml
+++ b/brilirs/Cargo.toml
@@ -13,12 +13,12 @@ keywords = ["compiler", "bril", "interpreter", "data-structures", "language"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [build-dependencies]
-clap         = { version = "3.0", features = ["derive"] }
-clap_complete= "3.0"
+clap         = { version = "3.1", features = ["derive"] }
+clap_complete= "3.1"
 
 [dependencies]
 thiserror    = "1.0"
-clap         = { version = "3.0", features = ["derive"] }
+clap         = { version = "3.1", features = ["derive"] }
 fxhash       = "0.2"
 mimalloc     = "0.1"
 

--- a/brilirs/build.rs
+++ b/brilirs/build.rs
@@ -11,12 +11,17 @@ use std::{env, path::PathBuf};
 include!("src/cli.rs");
 
 fn main() -> Result<(), Error> {
-  let out_dir = match env::var_os("CARGO_MANIFEST_DIR") {
-    None => return Ok(()),
+  // Waiting on https://github.com/rust-lang/cargo/issues/5457 / https://github.com/rust-lang/cargo/issues/6790 to clean this up
+  let out_dir = match env::var_os("OUT_DIR") {
+    None => {println!(
+        "cargo:warning=Did not find out dir",
+      ); return Ok(())},
     Some(out_dir) => out_dir,
   };
 
-  let app = Cli::command();
+  let mut app = Cli::command();
+  app.set_bin_name("brilirs");
+
   let bin_name = app.get_name().to_string();
 
   let shell: Box<dyn Generator> = match env::var("SHELL") {

--- a/brilirs/build.rs
+++ b/brilirs/build.rs
@@ -13,9 +13,10 @@ include!("src/cli.rs");
 fn main() -> Result<(), Error> {
   // Waiting on https://github.com/rust-lang/cargo/issues/5457 / https://github.com/rust-lang/cargo/issues/6790 to clean this up
   let out_dir = match env::var_os("OUT_DIR") {
-    None => {println!(
-        "cargo:warning=Did not find out dir",
-      ); return Ok(())},
+    None => {
+      println!("cargo:warning=Did not find out dir",);
+      return Ok(());
+    }
     Some(out_dir) => out_dir,
   };
 

--- a/brilirs/src/check.rs
+++ b/brilirs/src/check.rs
@@ -8,34 +8,30 @@ use crate::error::InterpError;
 
 use fxhash::FxHashMap;
 
-#[inline(always)]
 const fn check_num_args(expected: usize, args: &[String]) -> Result<(), InterpError> {
-  if expected != args.len() {
+  if expected == args.len() {
+    Ok(())
+  } else {
     Err(InterpError::BadNumArgs(expected, args.len()))
-  } else {
-    Ok(())
   }
 }
 
-#[inline(always)]
 const fn check_num_funcs(expected: usize, funcs: &[String]) -> Result<(), InterpError> {
-  if expected != funcs.len() {
+  if expected == funcs.len() {
+    Ok(())
+  } else {
     Err(InterpError::BadNumFuncs(expected, funcs.len()))
-  } else {
-    Ok(())
   }
 }
 
-#[inline(always)]
 const fn check_num_labels(expected: usize, labels: &[String]) -> Result<(), InterpError> {
-  if expected != labels.len() {
-    Err(InterpError::BadNumLabels(expected, labels.len()))
-  } else {
+  if expected == labels.len() {
     Ok(())
+  } else {
+    Err(InterpError::BadNumLabels(expected, labels.len()))
   }
 }
 
-#[inline(always)]
 fn check_asmt_type(expected: &bril_rs::Type, actual: &bril_rs::Type) -> Result<(), InterpError> {
   if expected == actual {
     Ok(())
@@ -44,7 +40,6 @@ fn check_asmt_type(expected: &bril_rs::Type, actual: &bril_rs::Type) -> Result<(
   }
 }
 
-#[inline(always)]
 fn update_env<'a>(
   env: &mut FxHashMap<&'a str, &'a Type>,
   dest: &'a str,
@@ -59,7 +54,6 @@ fn update_env<'a>(
   }
 }
 
-#[inline(always)]
 fn get_type<'a>(
   env: &'a FxHashMap<&'a str, &'a Type>,
   index: usize,
@@ -74,7 +68,6 @@ fn get_type<'a>(
     .ok_or_else(|| InterpError::VarUndefined(args[index].to_string()))
 }
 
-#[inline(always)]
 fn get_ptr_type(typ: &bril_rs::Type) -> Result<&bril_rs::Type, InterpError> {
   match typ {
     bril_rs::Type::Pointer(ptr_type) => Ok(ptr_type),
@@ -488,9 +481,9 @@ fn type_check_func(bbfunc: &BBFunction, bbprog: &BBProgram) -> Result<(), Positi
     done_list.push(b);
     block.exit.iter().for_each(|e| {
       if !done_list.contains(e) && !work_list.contains(e) {
-        work_list.push(*e)
+        work_list.push(*e);
       }
-    })
+    });
   }
 
   Ok(())
@@ -499,6 +492,8 @@ fn type_check_func(bbfunc: &BBFunction, bbprog: &BBProgram) -> Result<(), Positi
 /// Provides validation of Bril programs. This involves
 /// statically checking the types and number of arguments to Bril
 /// instructions.
+/// # Errors
+/// Will return an error if typechecking fails or if the input program is not well-formed.
 pub fn type_check(bbprog: &BBProgram) -> Result<(), PositionalInterpError> {
   bbprog
     .func_index

--- a/brilirs/src/error.rs
+++ b/brilirs/src/error.rs
@@ -58,6 +58,7 @@ pub enum InterpError {
 }
 
 impl InterpError {
+  #[must_use]
   pub fn add_pos(self, pos: Option<Position>) -> PositionalInterpError {
     match self {
       Self::PositionalInterpErrorConversion(e) => e,

--- a/brilirs/src/interp.rs
+++ b/brilirs/src/interp.rs
@@ -77,7 +77,7 @@ impl Environment {
           self.current_pointer + self.current_frame_size,
         ),
         Value::default(),
-      )
+      );
     }
   }
 
@@ -108,14 +108,12 @@ impl Heap {
   }
 
   fn alloc(&mut self, amount: i64) -> Result<Value, InterpError> {
-    if amount < 0 {
-      return Err(InterpError::CannotAllocSize(amount));
-    }
+    let amount: usize = amount
+      .try_into()
+      .map_err(|_| InterpError::CannotAllocSize(amount))?;
     let base = self.base_num_counter;
     self.base_num_counter += 1;
-    self
-      .memory
-      .insert(base, vec![Value::default(); amount as usize]);
+    self.memory.insert(base, vec![Value::default(); amount]);
     Ok(Value::Pointer(Pointer { base, offset: 0 }))
   }
 
@@ -128,9 +126,14 @@ impl Heap {
   }
 
   fn write(&mut self, key: &Pointer, val: Value) -> Result<(), InterpError> {
+    // Will check that key.offset is >=0
+    let offset: usize = key
+      .offset
+      .try_into()
+      .map_err(|_| InterpError::InvalidMemoryAccess(key.base, key.offset))?;
     match self.memory.get_mut(&key.base) {
-      Some(vec) if vec.len() > (key.offset as usize) && key.offset >= 0 => {
-        vec[key.offset as usize] = val;
+      Some(vec) if vec.len() > offset => {
+        vec[offset] = val;
         Ok(())
       }
       Some(_) | None => Err(InterpError::InvalidMemoryAccess(key.base, key.offset)),
@@ -138,10 +141,15 @@ impl Heap {
   }
 
   fn read(&self, key: &Pointer) -> Result<&Value, InterpError> {
+    // Will check that key.offset is >=0
+    let offset: usize = key
+      .offset
+      .try_into()
+      .map_err(|_| InterpError::InvalidMemoryAccess(key.base, key.offset))?;
     self
       .memory
       .get(&key.base)
-      .and_then(|vec| vec.get(key.offset as usize))
+      .and_then(|vec| vec.get(offset))
       .ok_or(InterpError::InvalidMemoryAccess(key.base, key.offset))
       .and_then(|val| match val {
         Value::Uninitialized => Err(InterpError::UsingUninitializedMemory),
@@ -278,20 +286,23 @@ fn make_func_args<'a>(callee_func: &'a BBFunction, args: &[usize], vars: &mut En
     .for_each(|(arg_name, expected_arg)| {
       let arg = vars.get_from_last_frame(arg_name).clone();
       vars.set(*expected_arg, arg);
-    })
+    });
 }
 
 fn execute_value_op<'a, T: std::io::Write>(
   state: &'a mut State<T>,
-  op: &bril_rs::ValueOps,
+  op: bril_rs::ValueOps,
   dest: usize,
   args: &[usize],
   labels: &[String],
   funcs: &[usize],
   last_label: Option<&String>,
 ) -> Result<(), InterpError> {
-  use bril_rs::ValueOps::*;
-  match *op {
+  use bril_rs::ValueOps::{
+    Add, Alloc, And, Call, Div, Eq, Fadd, Fdiv, Feq, Fge, Fgt, Fle, Flt, Fmul, Fsub, Ge, Gt, Id,
+    Le, Load, Lt, Mul, Not, Or, Phi, PtrAdd, Sub,
+  };
+  match op {
     Add => {
       let arg0 = get_arg::<i64>(&state.env, 0, args);
       let arg1 = get_arg::<i64>(&state.env, 1, args);
@@ -412,7 +423,7 @@ fn execute_value_op<'a, T: std::io::Write>(
 
       state.env.pop_frame();
 
-      state.env.set(dest, result)
+      state.env.set(dest, result);
     }
     Phi => match last_label {
       None => return Err(InterpError::NoLastLabel),
@@ -429,18 +440,18 @@ fn execute_value_op<'a, T: std::io::Write>(
     Alloc => {
       let arg0 = get_arg::<i64>(&state.env, 0, args);
       let res = state.heap.alloc(arg0)?;
-      state.env.set(dest, res)
+      state.env.set(dest, res);
     }
     Load => {
       let arg0 = get_arg::<&Pointer>(&state.env, 0, args);
       let res = state.heap.read(arg0)?;
-      state.env.set(dest, res.clone())
+      state.env.set(dest, res.clone());
     }
     PtrAdd => {
       let arg0 = get_arg::<&Pointer>(&state.env, 0, args);
       let arg1 = get_arg::<i64>(&state.env, 1, args);
       let res = Value::Pointer(arg0.add(arg1));
-      state.env.set(dest, res)
+      state.env.set(dest, res);
     }
   }
   Ok(())
@@ -449,13 +460,15 @@ fn execute_value_op<'a, T: std::io::Write>(
 fn execute_effect_op<'a, T: std::io::Write>(
   state: &'a mut State<T>,
   func: &BBFunction,
-  op: &bril_rs::EffectOps,
+  op: bril_rs::EffectOps,
   args: &[usize],
   funcs: &[usize],
   curr_block: &BasicBlock,
   next_block_idx: &mut Option<usize>,
 ) -> Result<Option<Value>, InterpError> {
-  use bril_rs::EffectOps::*;
+  use bril_rs::EffectOps::{
+    Branch, Call, Commit, Free, Guard, Jump, Nop, Print, Return, Speculate, Store,
+  };
   match op {
     Jump => {
       *next_block_idx = Some(curr_block.exit[0]);
@@ -500,11 +513,11 @@ fn execute_effect_op<'a, T: std::io::Write>(
     Store => {
       let arg0 = get_arg::<&Pointer>(&state.env, 0, args);
       let arg1 = get_value(&state.env, 1, args);
-      state.heap.write(arg0, arg1.clone())?
+      state.heap.write(arg0, arg1.clone())?;
     }
     Free => {
       let arg0 = get_arg::<&Pointer>(&state.env, 0, args);
-      state.heap.free(arg0)?
+      state.heap.free(arg0)?;
     }
     Speculate | Commit | Guard => unimplemented!(),
   }
@@ -525,7 +538,7 @@ fn execute<'a, T: std::io::Write>(
     let curr_instrs = &curr_block.instrs;
     let curr_numified_instrs = &curr_block.numified_instrs;
     // WARNING!!! We can add the # of instructions at once because you can only jump to a new block at the end. This may need to be changed if speculation is implemented
-    state.instruction_count += curr_instrs.len() as u32;
+    state.instruction_count += curr_instrs.len();
     last_label = current_label;
     current_label = curr_block.label.as_ref();
 
@@ -548,11 +561,14 @@ fn execute<'a, T: std::io::Write>(
           // Integer literals can be promoted to Floating point
           if const_type == &bril_rs::Type::Float {
             match value {
+              // So yes, as clippy points out, you technically lose precision here on the `*i as f64` cast. On the other hand, you already give up precision when you start using floats and I haven't been able to find a case where you are giving up precision in the cast that you don't already lose by using floating points.
+              // So it's probably fine unless proven otherwise.
+              #[allow(clippy::cast_precision_loss)]
               bril_rs::Literal::Int(i) => state
                 .env
                 .set(numified_code.dest.unwrap(), Value::Float(*i as f64)),
               bril_rs::Literal::Float(f) => {
-                state.env.set(numified_code.dest.unwrap(), Value::Float(*f))
+                state.env.set(numified_code.dest.unwrap(), Value::Float(*f));
               }
               bril_rs::Literal::Bool(_) => unreachable!(),
             }
@@ -573,7 +589,7 @@ fn execute<'a, T: std::io::Write>(
         } => {
           execute_value_op(
             state,
-            op,
+            *op,
             numified_code.dest.unwrap(),
             &numified_code.args,
             labels,
@@ -592,7 +608,7 @@ fn execute<'a, T: std::io::Write>(
           result = execute_effect_op(
             state,
             func,
-            op,
+            *op,
             &numified_code.args,
             &numified_code.funcs,
             curr_block,
@@ -674,7 +690,7 @@ struct State<'a, T: std::io::Write> {
   env: Environment,
   heap: Heap,
   out: T,
-  instruction_count: u32,
+  instruction_count: usize,
 }
 
 impl<'a, T: std::io::Write> State<'a, T> {
@@ -689,7 +705,11 @@ impl<'a, T: std::io::Write> State<'a, T> {
   }
 }
 
-/// The entrance point to the interpreter. It runs over a ```prog```:[`BBProgram`] starting at the "main" function with ```input_args``` as input. Print statements output to ```out``` which implements [std::io::Write]. You also need to include whether you want the interpreter to count the number of instructions run with ```profiling```. This information is outputted to [std::io::stderr]
+/// The entrance point to the interpreter. It runs over a ```prog```:[`BBProgram`] starting at the "main" function with ```input_args``` as input. Print statements output to ```out``` which implements [`std::io::Write`]. You also need to include whether you want the interpreter to count the number of instructions run with ```profiling```. This information is outputted to [`std::io::stderr`]
+/// # Panics
+/// This should not panic with normal use except if there is a bug or if you are using an unimplemented feature
+/// # Errors
+/// Will error on malformed `BBProgram`, like if the original Bril program was not well-formed
 pub fn execute_main<T: std::io::Write, U: std::io::Write>(
   prog: &BBProgram,
   out: T,

--- a/brilirs/src/interp.rs
+++ b/brilirs/src/interp.rs
@@ -35,7 +35,6 @@ struct Environment {
 }
 
 impl Environment {
-  #[inline(always)]
   pub fn new(size: usize) -> Self {
     Self {
       current_pointer: 0,
@@ -45,7 +44,7 @@ impl Environment {
       env: vec![Value::default(); max(size, 50)],
     }
   }
-  #[inline(always)]
+
   pub fn get(&self, ident: &usize) -> &Value {
     // A bril program is well formed when, dynamically, every variable is defined before its use.
     // If this is violated, this will return Value::Uninitialized and the whole interpreter will come crashing down.
@@ -58,7 +57,6 @@ impl Environment {
     self.env.get(past_pointer + *ident).unwrap()
   }
 
-  #[inline(always)]
   pub fn set(&mut self, ident: usize, val: Value) {
     self.env[self.current_pointer + ident] = val;
   }
@@ -105,12 +103,10 @@ impl Default for Heap {
 }
 
 impl Heap {
-  #[inline(always)]
   fn is_empty(&self) -> bool {
     self.memory.is_empty()
   }
 
-  #[inline(always)]
   fn alloc(&mut self, amount: i64) -> Result<Value, InterpError> {
     if amount < 0 {
       return Err(InterpError::CannotAllocSize(amount));
@@ -123,7 +119,6 @@ impl Heap {
     Ok(Value::Pointer(Pointer { base, offset: 0 }))
   }
 
-  #[inline(always)]
   fn free(&mut self, key: &Pointer) -> Result<(), InterpError> {
     if self.memory.remove(&key.base).is_some() && key.offset == 0 {
       Ok(())
@@ -132,7 +127,6 @@ impl Heap {
     }
   }
 
-  #[inline(always)]
   fn write(&mut self, key: &Pointer, val: Value) -> Result<(), InterpError> {
     match self.memory.get_mut(&key.base) {
       Some(vec) if vec.len() > (key.offset as usize) && key.offset >= 0 => {
@@ -143,7 +137,6 @@ impl Heap {
     }
   }
 
-  #[inline(always)]
   fn read(&self, key: &Pointer) -> Result<&Value, InterpError> {
     self
       .memory
@@ -158,14 +151,12 @@ impl Heap {
 }
 
 // A getter function for when you just want the Value enum
-#[inline(always)]
 fn get_value<'a>(vars: &'a Environment, index: usize, args: &[usize]) -> &'a Value {
   vars.get(&args[index])
 }
 
 // A getter function for when you know what constructor of the Value enum you have and
 // you just want the underlying value(like a f64).
-#[inline(always)]
 fn get_arg<'a, T>(vars: &'a Environment, index: usize, args: &[usize]) -> T
 where
   T: From<&'a Value>,
@@ -218,7 +209,6 @@ impl fmt::Display for Value {
 }
 
 impl From<&bril_rs::Literal> for Value {
-  #[inline(always)]
   fn from(l: &bril_rs::Literal) -> Self {
     match l {
       bril_rs::Literal::Int(i) => Self::Int(*i),
@@ -229,7 +219,6 @@ impl From<&bril_rs::Literal> for Value {
 }
 
 impl From<bril_rs::Literal> for Value {
-  #[inline(always)]
   fn from(l: bril_rs::Literal) -> Self {
     match l {
       bril_rs::Literal::Int(i) => Self::Int(i),
@@ -240,7 +229,6 @@ impl From<bril_rs::Literal> for Value {
 }
 
 impl From<&Value> for i64 {
-  #[inline(always)]
   fn from(value: &Value) -> Self {
     if let Value::Int(i) = value {
       *i
@@ -251,7 +239,6 @@ impl From<&Value> for i64 {
 }
 
 impl From<&Value> for bool {
-  #[inline(always)]
   fn from(value: &Value) -> Self {
     if let Value::Bool(b) = value {
       *b
@@ -262,7 +249,6 @@ impl From<&Value> for bool {
 }
 
 impl From<&Value> for f64 {
-  #[inline(always)]
   fn from(value: &Value) -> Self {
     if let Value::Float(f) = value {
       *f
@@ -273,7 +259,6 @@ impl From<&Value> for f64 {
 }
 
 impl<'a> From<&'a Value> for &'a Pointer {
-  #[inline(always)]
   fn from(value: &'a Value) -> Self {
     if let Value::Pointer(p) = value {
       p
@@ -296,7 +281,6 @@ fn make_func_args<'a>(callee_func: &'a BBFunction, args: &[usize], vars: &mut En
     })
 }
 
-#[inline(always)]
 fn execute_value_op<'a, T: std::io::Write>(
   state: &'a mut State<T>,
   op: &bril_rs::ValueOps,
@@ -462,7 +446,6 @@ fn execute_value_op<'a, T: std::io::Write>(
   Ok(())
 }
 
-#[inline(always)]
 fn execute_effect_op<'a, T: std::io::Write>(
   state: &'a mut State<T>,
   func: &BBFunction,

--- a/brilirs/src/lib.rs
+++ b/brilirs/src/lib.rs
@@ -1,6 +1,10 @@
 // The group clippy::pedantic is not used as it ends up being more annoying than useful
-#![warn(clippy::all, clippy::nursery, clippy::cargo)]
+#![warn(clippy::all, clippy::pedantic, clippy::nursery, clippy::cargo)]
 #![warn(missing_docs)]
+#![allow(clippy::float_cmp)]
+#![allow(clippy::similar_names)]
+#![allow(clippy::too_many_lines)]
+#![allow(clippy::module_name_repetitions)]
 #![doc = include_str!("../README.md")]
 
 use basic_block::BBProgram;
@@ -15,14 +19,14 @@ pub mod check;
 pub mod cli;
 #[doc(hidden)]
 pub mod error;
-/// Provides ```interp::execute_main``` to execute [Program] that have been converted into [BBProgram]
+/// Provides ```interp::execute_main``` to execute [Program] that have been converted into [`BBProgram`]
 pub mod interp;
 
 #[doc(hidden)]
 pub fn run_input<T: std::io::Write, U: std::io::Write>(
   input: impl std::io::Read,
   out: T,
-  input_args: Vec<String>,
+  input_args: &[String],
   profiling: bool,
   profiling_out: U,
   check: bool,
@@ -40,7 +44,7 @@ pub fn run_input<T: std::io::Write, U: std::io::Write>(
   check::type_check(&bbprog)?;
 
   if !check {
-    interp::execute_main(&bbprog, out, &input_args, profiling, profiling_out)?;
+    interp::execute_main(&bbprog, out, input_args, profiling, profiling_out)?;
   }
 
   Ok(())

--- a/brilirs/src/main.rs
+++ b/brilirs/src/main.rs
@@ -28,7 +28,7 @@ fn main() {
   if let Err(e) = brilirs::run_input(
     input_string.as_bytes(),
     std::io::stdout(),
-    args.args,
+    &args.args,
     args.profile,
     std::io::stderr(),
     args.check,


### PR DESCRIPTION
Some small things: 
- Inlining doesn't seem to help like it did when I introduced it(I'm probably not smarter than the compiler) so I've torn it out 
- Bumped `clap` to 3.1
- Turned on `clippy::pedantic` lints and filtered out the less useful ones
- Still fiddling with the build.rs file