### PR TITLE
Simple implementation wall-clock benchmarking

### DIFF
--- a/benchmarks/.gitignore
+++ b/benchmarks/.gitignore
@@ -1,0 +1,3 @@
+*.bench.json
+bench.csv
+plot.svg

--- a/benchmarks/Makefile
+++ b/benchmarks/Makefile
@@ -4,7 +4,7 @@ CORE_BENCH := $(shell grep -L 'ptr\|float' *.bril)
 bench:
 	turnt -e bench --save $(CORE_BENCH)
 clean:
-	rm -f *.bench.json
+	rm -f *.bench.json plot.svg bench.csv
 plot: plot.svg
 
 bench.csv: $(wildcard *.bench.json)

--- a/benchmarks/Makefile
+++ b/benchmarks/Makefile
@@ -1,0 +1,14 @@
+CORE_BENCH := $(shell grep -L 'ptr\|float' *.bril)
+
+.PHONY: bench clean plot
+bench:
+	turnt -e bench --save $(CORE_BENCH)
+clean:
+	rm -f *.bench.json
+plot: plot.svg
+
+bench.csv: $(wildcard *.bench.json)
+	python3 summarize.py $^ > $@
+
+%.svg: %.vl.json bench.csv
+	npx -p vega -p vega-lite vl2svg $*.vl.json > $@

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -3,7 +3,7 @@ Bril Benchmarks
 
 This directory contains a suite of benchmarks in Bril contributed by the community. You can read [more details in the documentation][bench-docs].
 
-There is also some basic infrastructure here for benchmarking the wall-clock execution time of Bril implementations. Run the benchmarks comparing [the reference interpreter][brili], [brilirs][], and [brilift][] by typing:
+There is also some basic infrastructure here for benchmarking the wall-clock execution time of Bril implementations. Run the benchmarks comparing [the reference interpreter][brili], [brilirs][], and [brilift][] by installing [Hyperfine][] and then typing:
 
     make bench
 
@@ -22,3 +22,4 @@ You can also generate a bar chart using [Vega-Lite][]:
 [brilirs]: https://capra.cs.cornell.edu/bril/tools/brilirs.html
 [brilift]: https://capra.cs.cornell.edu/bril/tools/brilift.html
 [hm]: https://en.wikipedia.org/wiki/Harmonic_mean
+[hyperfine]: https://github.com/sharkdp/hyperfine

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,0 +1,24 @@
+Bril Benchmarks
+===============
+
+This directory contains a suite of benchmarks in Bril contributed by the community. You can read [more details in the documentation][bench-docs].
+
+There is also some basic infrastructure here for benchmarking the wall-clock execution time of Bril implementations. Run the benchmarks comparing [the reference interpreter][brili], [brilirs][], and [brilift][] by typing:
+
+    make bench
+
+Then you can aggregate the statistics with:
+
+    make bench.csv
+
+That shows you the [harmonic mean][hm] speedups over the reference interpreter as a baseline.
+You can also generate a bar chart using [Vega-Lite][]:
+
+    make plot
+
+[vega-lite]: https://vega.github.io/vega-lite/
+[bench-docs]: https://capra.cs.cornell.edu/bril/tools/bench.html
+[brili]: https://capra.cs.cornell.edu/bril/tools/interp.html
+[brilirs]: https://capra.cs.cornell.edu/bril/tools/brilirs.html
+[brilift]: https://capra.cs.cornell.edu/bril/tools/brilift.html
+[hm]: https://en.wikipedia.org/wiki/Harmonic_mean

--- a/benchmarks/plot.vl.json
+++ b/benchmarks/plot.vl.json
@@ -1,0 +1,16 @@
+{
+  "data": {"url": "bench.csv"},
+  "mark": "bar",
+  "encoding": {
+    "x": {
+      "field": "bench",
+      "type": "ordinal"
+    },
+    "y": {
+      "field": "speedup",
+      "type": "quantitative"
+    },
+    "xOffset": { "field": "mode" },
+    "color": { "field": "mode" }
+  }
+}

--- a/benchmarks/plot.vl.json
+++ b/benchmarks/plot.vl.json
@@ -1,16 +1,27 @@
 {
   "data": {"url": "bench.csv"},
   "mark": "bar",
+  "transform": [
+    {"filter": "datum.mode !== 'brili'"}
+  ],
   "encoding": {
     "x": {
+      "title": "",
       "field": "bench",
       "type": "ordinal"
     },
     "y": {
+      "title": "speedup over brili",
       "field": "speedup",
-      "type": "quantitative"
+      "type": "quantitative",
+      "axis": {
+        "labelExpr": "datum.label + '×'"
+      }
     },
     "xOffset": { "field": "mode" },
-    "color": { "field": "mode" }
+    "color": {
+      "title": "implementation",
+      "field": "mode"
+    }
   }
 }

--- a/benchmarks/summarize.py
+++ b/benchmarks/summarize.py
@@ -8,7 +8,8 @@ from collections import defaultdict
 
 MODES = {
     'brili': 'brili ',
-    'brilift-jit': 'brilift -j'
+    'brilift-jit': 'brilift -j',
+    'brilirs': 'brilirs ',
 }
 BASELINE = 'brili'
 

--- a/benchmarks/summarize.py
+++ b/benchmarks/summarize.py
@@ -3,8 +3,14 @@ import json
 import sys
 import os
 import csv
+import statistics
+from collections import defaultdict
 
-MODES = ['brili', 'brilift']
+MODES = {
+    'brili': 'brili ',
+    'brilift-jit': 'brilift -j'
+}
+BASELINE = 'brili'
 
 
 def get_results(bench_files):
@@ -14,8 +20,8 @@ def get_results(bench_files):
 
         bench, _ = os.path.basename(fn).split('.', 1)
         for res in bench_data["results"]:
-            for mode in MODES:
-                if mode in res['command']:
+            for mode, pat in MODES.items():
+                if pat in res['command']:
                     break
             else:
                 assert False, "unknown benchmark command"
@@ -24,15 +30,33 @@ def get_results(bench_files):
 
 
 def summarize(bench_files):
+    means = defaultdict(dict)
+
     writer = csv.DictWriter(sys.stdout, ['bench', 'mode', 'mean', 'stddev'])
     writer.writeheader()
     for bench, mode, res in get_results(bench_files):
+        means[bench][mode] = res['mean']
         writer.writerow({
             'bench': bench,
             'mode': mode,
             'mean': res['mean'],
             'stddev': res['stddev']
         })
+
+    speedups = {k: [] for k in MODES}
+    for bench, modes in means.items():
+        baseline = modes[BASELINE]
+        print(bench, file=sys.stderr, end=': ')
+        for mode in MODES:
+            speedup = baseline / modes[mode]
+            speedups[mode].append(speedup)
+            print('{} {:.2f}x'.format(mode, speedup), file=sys.stderr, end=' ')
+        print(file=sys.stderr)
+    for mode, speedup_list in speedups.items():
+        print('{}: {:.2f}x'.format(
+            mode,
+            statistics.harmonic_mean(speedup_list)
+        ), file=sys.stderr)
 
 
 if __name__ == '__main__':

--- a/benchmarks/summarize.py
+++ b/benchmarks/summarize.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+import json
+import sys
+import os
+import csv
+
+MODES = ['brili', 'brilift']
+
+
+def get_results(bench_files):
+    for fn in bench_files:
+        with open(fn) as f:
+            bench_data = json.load(f)
+
+        bench, _ = os.path.basename(fn).split('.', 1)
+        for res in bench_data["results"]:
+            for mode in MODES:
+                if mode in res['command']:
+                    break
+            else:
+                assert False, "unknown benchmark command"
+
+            yield bench, mode, res
+
+
+def summarize(bench_files):
+    writer = csv.DictWriter(sys.stdout, ['bench', 'mode', 'mean', 'stddev'])
+    writer.writeheader()
+    for bench, mode, res in get_results(bench_files):
+        writer.writerow({
+            'bench': bench,
+            'mode': mode,
+            'mean': res['mean'],
+            'stddev': res['stddev']
+        })
+
+
+if __name__ == '__main__':
+    summarize(sys.argv[1:])

--- a/benchmarks/summarize.py
+++ b/benchmarks/summarize.py
@@ -4,12 +4,14 @@ import sys
 import os
 import csv
 import statistics
+import re
 from collections import defaultdict
 
 MODES = {
-    'brili': 'brili ',
-    'brilift-jit': 'brilift -j',
-    'brilirs': 'brilirs ',
+    'brili': r'\bbrili\b',
+    'brilirs': r'\bbrilirs\b',
+    'brilift-jit': r'\bbrilift -j',
+    'brilift-aot': r'^\./[^/]+ '
 }
 BASELINE = 'brili'
 
@@ -22,7 +24,7 @@ def get_results(bench_files):
         bench, _ = os.path.basename(fn).split('.', 1)
         for res in bench_data["results"]:
             for mode, pat in MODES.items():
-                if pat in res['command']:
+                if re.search(pat, res['command']):
                     break
             else:
                 assert False, "unknown benchmark command"

--- a/benchmarks/turnt.toml
+++ b/benchmarks/turnt.toml
@@ -16,3 +16,12 @@ command = "bril2json < {filename} | ../brilift/run.sh {args}"
 [envs.brilift-jit]
 default = false
 command = "bril2json < {filename} | ../brilift/target/release/brilift -j -- {args}"
+
+# Execution speed benchmark.
+[envs.bench]
+default = false
+command = """
+bril2json < {filename} > {base}.json
+hyperfine --warmup 3 --export-json bench.json -L interp 'brili','../brilift/target/release/brilift -j --' '{{interp}} {args} < {base}.json'
+rm -f {base}.json"""
+output."bench.json" = "bench.json"

--- a/benchmarks/turnt.toml
+++ b/benchmarks/turnt.toml
@@ -22,6 +22,9 @@ command = "bril2json < {filename} | ../brilift/target/release/brilift -j -- {arg
 default = false
 command = """
 bril2json < {filename} > {base}.json
-hyperfine --warmup 3 --export-json bench.json -L interp 'brili','../brilift/target/release/brilift -j --' '{{interp}} {args} < {base}.json'
+hyperfine --warmup 3 --export-json bench.json -L interp 'brili',\
+'../brilift/target/release/brilift -j --',\
+'../brilirs/target/release/brilirs' \
+'{{interp}} {args} < {base}.json'
 rm -f {base}.json"""
 output."bench.json" = "bench.json"

--- a/benchmarks/turnt.toml
+++ b/benchmarks/turnt.toml
@@ -22,9 +22,13 @@ command = "bril2json < {filename} | ../brilift/target/release/brilift -j -- {arg
 default = false
 command = """
 bril2json < {filename} > {base}.json
-hyperfine --warmup 3 --export-json bench.json -L interp 'brili',\
-'../brilift/target/release/brilift -j --',\
-'../brilirs/target/release/brilirs' \
-'{{interp}} {args} < {base}.json'
+make -C ../brilift ../benchmarks/{base}
+
+hyperfine --warmup 3 --export-json bench.json \
+'brili {args} < {base}.json' \
+'../brilift/target/release/brilift -j -- {args} < {base}.json' \
+'../brilirs/target/release/brilirs {args} < {base}.json' \
+'./{base} {args}'
+
 rm -f {base}.json"""
 output."bench.json" = "bench.json"

--- a/brilift/Makefile
+++ b/brilift/Makefile
@@ -34,7 +34,7 @@ rt.o: rt.c
 	cc $(CFLAGS) -c -o $@ $^
 
 %.o: %.bril
-	bril2json < $^ | ./target/debug/brilift $(BRILFLAGS) -o $@
+	bril2json < $^ | ./target/release/brilift $(BRILFLAGS) -o $@
 
 %: %.o rt.o
 	cc $(CFLAGS) -o $@ $^

--- a/brilift/Makefile
+++ b/brilift/Makefile
@@ -1,10 +1,15 @@
-TARGET := x86_64-unknown-darwin-macho
-RUST_TARGET := x86_64-apple-darwin
+# Set TARGET to cross-compile. Brilift's AOT mode doesn't yet support macOS on
+# ARM, so on Apple Silicon devices, you'll need to do this to run compiled
+# programs through Rosetta 2:
+# TARGET := x86_64-unknown-darwin-macho
 
 # Brilift only supports core Bril for now, so we select those tests &
 # benchmarks.
 TESTS :=  ../test/interp/core/*.bril
 BENCHMARKS := $(shell grep -L 'ptr\|float' ../benchmarks/*.bril)
+
+CFLAGS := $(if $(TARGET),-target $(TARGET))
+BRILFLAGS := $(if $(TARGET),-t $(TARGET))
 
 foo:
 	echo $(BENCHMARKS)
@@ -26,10 +31,10 @@ benchmark: rt.o
 	turnt -e brilift-aot -e brilift-jit $(BENCHMARKS)
 
 rt.o: rt.c
-	cc -target $(TARGET) -c -o $@ $^
+	cc $(CFLAGS) -c -o $@ $^
 
 %.o: %.bril
-	bril2json < $^ | ./target/debug/brilift -t $(TARGET) -o $@
+	bril2json < $^ | ./target/debug/brilift $(BRILFLAGS) -o $@
 
 %: %.o rt.o
-	cc -target $(TARGET) -o $@ $^
+	cc $(CFLAGS) -o $@ $^


### PR DESCRIPTION
I wanted to set up a reasonably automated way to compare the execution time of Bril implementations on the benchmarks. This approach abuses a Turnt environment to invoke [Hyperfine][] and then aggregates the results. There is a little more usage documentation.

Tagging @Pat-Lafon because he might be interested in merging this with his existing [benchmark.sh](https://github.com/sampsyo/bril/blob/main/brilirs/benchmark.sh) and friends. Also including @charles-rs & @susan-garry because they might be interested in someday incorporating [their new bytecode interpreter](https://www.cs.cornell.edu/courses/cs6120/2022sp/blog/fast-brili/), described in https://github.com/sampsyo/cs6120/pull/337, into the benchmarking landscape.

Here are the harmonic mean speedups over brili for a recent run on havarti (an x86 server with dual 2.10 GHz Xeon Gold 6230s running Ubuntu 20.04 and Node v10.19.0), covering the core-only benchmarks:

```
brilirs: 63.81x
brilift-jit: 64.94x
brilift-aot: 186.56x
```

The setup can also draw a simple bar chart using [Vega-Lite][vl] (click to make legible):

![plot](https://user-images.githubusercontent.com/188033/173230833-3bac3a10-b32f-4545-a03f-7afb11fd413e.svg)

Basically, Brilirs is consistently a bit faster than the end-to-end execution time of Brilift in JIT mode, given the latter's extra startup cost for compilation, except for a few benchmarks that involve some nontrivial computation (e.g., `primes-between` and `pythagorean_triple`). Brilift in AOT mode doesn't get "charged" for compilation in this setup, so programs run about 3× faster. (But I wouldn't put too much stock in the exact numbers because so many benchmarks are very very small and run in basically no time.)

[hyperfine]: https://github.com/sharkdp/hyperfine
[vl]: https://vega.github.io/vega-lite/