### PR TITLE
Brilift: Float support

### DIFF
--- a/benchmarks/Makefile
+++ b/benchmarks/Makefile
@@ -1,4 +1,4 @@
-CORE_BENCH := $(shell grep -L 'ptr\|float' *.bril)
+CORE_BENCH := $(shell grep -L 'ptr' *.bril)
 
 .PHONY: bench clean plot
 bench:

--- a/brilift/Cargo.toml
+++ b/brilift/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-bril-rs = {path = "../bril-rs"}
+bril-rs = { path = "../bril-rs", features = ["float"] }
 cranelift-codegen = { version = "0.83.0", features = ["all-arch"] }
 cranelift-frontend = "0.83.0"
 cranelift-object = "0.83.0"

--- a/brilift/Makefile
+++ b/brilift/Makefile
@@ -5,8 +5,8 @@
 
 # Brilift only supports core Bril for now, so we select those tests &
 # benchmarks.
-TESTS :=  ../test/interp/core/*.bril
-BENCHMARKS := $(shell grep -L 'ptr\|float' ../benchmarks/*.bril)
+TESTS := ../test/interp/core/*.bril ../test/interp/float/*.bril
+BENCHMARKS := $(shell grep -L 'ptr' ../benchmarks/*.bril)
 
 CFLAGS := $(if $(TARGET),-target $(TARGET))
 BRILFLAGS := $(if $(TARGET),-t $(TARGET))

--- a/brilift/rt.c
+++ b/brilift/rt.c
@@ -2,6 +2,7 @@
 #include <stdint.h>
 #include <inttypes.h>
 #include <string.h>
+#include <math.h>
 
 void _bril_print_int(int64_t i) {
     printf("%" PRId64, i);
@@ -16,7 +17,17 @@ void _bril_print_bool(char i) {
 }
 
 void _bril_print_float(double f) {
-    printf("%.17lg", f);
+    if (isnan(f)) {
+        printf("NaN");
+    } else if (isinf(f)) {
+        if (f < 0) {
+            printf("-Infinity");
+        } else {
+            printf("Infinity");
+        }
+    } else {
+        printf("%.17lg", f);
+    }
 }
 
 void _bril_print_sep() {

--- a/brilift/rt.c
+++ b/brilift/rt.c
@@ -16,7 +16,7 @@ void _bril_print_bool(char i) {
 }
 
 void _bril_print_float(double f) {
-    printf("%.16lg", f);
+    printf("%.17lg", f);
 }
 
 void _bril_print_sep() {

--- a/brilift/rt.c
+++ b/brilift/rt.c
@@ -15,6 +15,10 @@ void _bril_print_bool(char i) {
     }
 }
 
+void _bril_print_float(double f) {
+    printf("%.16lg", f);
+}
+
 void _bril_print_sep() {
     printf(" ");
 }
@@ -33,4 +37,11 @@ int64_t _bril_parse_int(char **args, int64_t idx) {
 char _bril_parse_bool(char **args, int64_t idx) {
     char *arg = args[idx];
     return !strcmp(arg, "true");
+}
+
+double _bril_parse_float(char **args, int64_t idx) {
+    char *arg = args[idx];
+    double res;
+    sscanf(arg, "%lf", &res);
+    return res;
 }

--- a/brilift/src/main.rs
+++ b/brilift/src/main.rs
@@ -4,7 +4,7 @@ use argh::FromArgs;
 use bril_rs as bril;
 use core::mem;
 use cranelift_codegen::entity::EntityRef;
-use cranelift_codegen::ir::condcodes::{IntCC, FloatCC};
+use cranelift_codegen::ir::condcodes::{FloatCC, IntCC};
 use cranelift_codegen::ir::InstBuilder;
 use cranelift_codegen::settings::Configurable;
 use cranelift_codegen::{ir, isa, settings};
@@ -460,7 +460,11 @@ fn gen_print(args: &[String], builder: &mut FunctionBuilder, env: &CompileEnv) {
     builder.ins().call(env.rt_refs[RTFunc::PrintEnd], &[]);
 }
 
-fn compile_const(builder: &mut FunctionBuilder, typ: &bril::Type, lit: &bril::Literal) -> ir::Value {
+fn compile_const(
+    builder: &mut FunctionBuilder,
+    typ: &bril::Type,
+    lit: &bril::Literal,
+) -> ir::Value {
     match typ {
         bril::Type::Int => {
             let val = match lit {
@@ -581,12 +585,14 @@ fn compile_inst(inst: &bril::Instruction, builder: &mut FunctionBuilder, env: &C
             | bril::ValueOps::Fmul
             | bril::ValueOps::Fdiv => {
                 gen_binary(builder, &env.vars, args, dest, op_type, translate_op(*op));
-            },
+            }
             bril::ValueOps::Flt
             | bril::ValueOps::Fle
             | bril::ValueOps::Feq
             | bril::ValueOps::Fge
-            | bril::ValueOps::Fgt => gen_fcmp(builder, &env.vars, args, dest, translate_floatcc(*op)),
+            | bril::ValueOps::Fgt => {
+                gen_fcmp(builder, &env.vars, args, dest, translate_floatcc(*op))
+            }
         },
     }
 }

--- a/brilift/src/main.rs
+++ b/brilift/src/main.rs
@@ -186,11 +186,11 @@ fn translate_intcc(op: bril::ValueOps) -> IntCC {
 /// Translate Bril opcodes that correspond to CLIF floating point comparisons.
 fn translate_floatcc(op: bril::ValueOps) -> FloatCC {
     match op {
-        bril::ValueOps::Lt => FloatCC::LessThan,
-        bril::ValueOps::Le => FloatCC::LessThanOrEqual,
-        bril::ValueOps::Eq => FloatCC::Equal,
-        bril::ValueOps::Ge => FloatCC::GreaterThanOrEqual,
-        bril::ValueOps::Gt => FloatCC::GreaterThan,
+        bril::ValueOps::Flt => FloatCC::LessThan,
+        bril::ValueOps::Fle => FloatCC::LessThanOrEqual,
+        bril::ValueOps::Feq => FloatCC::Equal,
+        bril::ValueOps::Fge => FloatCC::GreaterThanOrEqual,
+        bril::ValueOps::Fgt => FloatCC::GreaterThan,
         _ => panic!("not a comparison opcode: {}", op),
     }
 }

--- a/brilift/src/main.rs
+++ b/brilift/src/main.rs
@@ -4,7 +4,7 @@ use argh::FromArgs;
 use bril_rs as bril;
 use core::mem;
 use cranelift_codegen::entity::EntityRef;
-use cranelift_codegen::ir::condcodes::IntCC;
+use cranelift_codegen::ir::condcodes::{IntCC, FloatCC};
 use cranelift_codegen::ir::InstBuilder;
 use cranelift_codegen::settings::Configurable;
 use cranelift_codegen::{ir, isa, settings};
@@ -22,6 +22,7 @@ use std::fs;
 enum RTFunc {
     PrintInt,
     PrintBool,
+    PrintFloat,
     PrintSep,
     PrintEnd,
 }
@@ -36,6 +37,11 @@ impl RTFunc {
             },
             Self::PrintBool => ir::Signature {
                 params: vec![ir::AbiParam::new(ir::types::B1)],
+                returns: vec![],
+                call_conv,
+            },
+            Self::PrintFloat => ir::Signature {
+                params: vec![ir::AbiParam::new(ir::types::F64)],
                 returns: vec![],
                 call_conv,
             },
@@ -56,6 +62,7 @@ impl RTFunc {
         match self {
             Self::PrintInt => "_bril_print_int",
             Self::PrintBool => "_bril_print_bool",
+            Self::PrintFloat => "_bril_print_float",
             Self::PrintSep => "_bril_print_sep",
             Self::PrintEnd => "_bril_print_end",
         }
@@ -65,6 +72,7 @@ impl RTFunc {
         match self {
             RTFunc::PrintInt => rt::print_int as *const u8,
             RTFunc::PrintBool => rt::print_bool as *const u8,
+            RTFunc::PrintFloat => rt::print_float as *const u8,
             RTFunc::PrintSep => rt::print_sep as *const u8,
             RTFunc::PrintEnd => rt::print_end as *const u8,
         }
@@ -74,9 +82,11 @@ impl RTFunc {
 /// Runtime functions used in the native `main` function, which dispatches to the proper Bril
 /// `main` function.
 #[derive(Debug, Enum)]
+#[allow(clippy::enum_variant_names)]
 enum RTSetupFunc {
     ParseInt,
     ParseBool,
+    ParseFloat,
 }
 
 impl RTSetupFunc {
@@ -102,6 +112,14 @@ impl RTSetupFunc {
                 returns: vec![ir::AbiParam::new(ir::types::B1)],
                 call_conv,
             },
+            Self::ParseFloat => ir::Signature {
+                params: vec![
+                    ir::AbiParam::new(pointer_type),
+                    ir::AbiParam::new(ir::types::I64),
+                ],
+                returns: vec![ir::AbiParam::new(ir::types::F64)],
+                call_conv,
+            },
         }
     }
 
@@ -109,6 +127,7 @@ impl RTSetupFunc {
         match self {
             Self::ParseInt => "_bril_parse_int",
             Self::ParseBool => "_bril_parse_bool",
+            Self::ParseFloat => "_bril_parse_float",
         }
     }
 }
@@ -118,6 +137,7 @@ fn translate_type(typ: &bril::Type) -> ir::Type {
     match typ {
         bril::Type::Int => ir::types::I64,
         bril::Type::Bool => ir::types::B1,
+        bril::Type::Float => ir::types::F64,
     }
 }
 
@@ -143,6 +163,10 @@ fn translate_op(op: bril::ValueOps) -> ir::Opcode {
         bril::ValueOps::Div => ir::Opcode::Sdiv,
         bril::ValueOps::And => ir::Opcode::Band,
         bril::ValueOps::Or => ir::Opcode::Bor,
+        bril::ValueOps::Fadd => ir::Opcode::Fadd,
+        bril::ValueOps::Fsub => ir::Opcode::Fsub,
+        bril::ValueOps::Fmul => ir::Opcode::Fmul,
+        bril::ValueOps::Fdiv => ir::Opcode::Fdiv,
         _ => panic!("not a translatable opcode: {}", op),
     }
 }
@@ -155,6 +179,18 @@ fn translate_intcc(op: bril::ValueOps) -> IntCC {
         bril::ValueOps::Eq => IntCC::Equal,
         bril::ValueOps::Ge => IntCC::SignedGreaterThanOrEqual,
         bril::ValueOps::Gt => IntCC::SignedGreaterThan,
+        _ => panic!("not a comparison opcode: {}", op),
+    }
+}
+
+/// Translate Bril opcodes that correspond to CLIF floating point comparisons.
+fn translate_floatcc(op: bril::ValueOps) -> FloatCC {
+    match op {
+        bril::ValueOps::Lt => FloatCC::LessThan,
+        bril::ValueOps::Le => FloatCC::LessThanOrEqual,
+        bril::ValueOps::Eq => FloatCC::Equal,
+        bril::ValueOps::Ge => FloatCC::GreaterThanOrEqual,
+        bril::ValueOps::Gt => FloatCC::GreaterThan,
         _ => panic!("not a comparison opcode: {}", op),
     }
 }
@@ -260,6 +296,7 @@ fn val_ptrs(vals: &[bril::Literal]) -> Vec<*const u8> {
         .map(|lit| match lit {
             bril::Literal::Int(i) => i as *const i64 as *const u8,
             bril::Literal::Bool(b) => b as *const bool as *const u8,
+            bril::Literal::Float(f) => f as *const f64 as *const u8,
         })
         .collect()
 }
@@ -351,11 +388,25 @@ fn gen_icmp(
     vars: &HashMap<String, Variable>,
     args: &[String],
     dest: &String,
-    cc: IntCC,
+    cc: ir::condcodes::IntCC,
 ) {
     let lhs = builder.use_var(vars[&args[0]]);
     let rhs = builder.use_var(vars[&args[1]]);
     let res = builder.ins().icmp(cc, lhs, rhs);
+    builder.def_var(vars[dest], res);
+}
+
+/// Generate a CLIF fcmp instruction.
+fn gen_fcmp(
+    builder: &mut FunctionBuilder,
+    vars: &HashMap<String, Variable>,
+    args: &[String],
+    dest: &String,
+    cc: ir::condcodes::FloatCC,
+) {
+    let lhs = builder.use_var(vars[&args[0]]);
+    let rhs = builder.use_var(vars[&args[1]]);
+    let res = builder.ins().fcmp(cc, lhs, rhs);
     builder.def_var(vars[dest], res);
 }
 
@@ -401,6 +452,7 @@ fn gen_print(args: &[String], builder: &mut FunctionBuilder, env: &CompileEnv) {
         let print_func = match env.var_types[arg] {
             bril::Type::Int => RTFunc::PrintInt,
             bril::Type::Bool => RTFunc::PrintBool,
+            bril::Type::Float => RTFunc::PrintFloat,
         };
         let print_ref = env.rt_refs[print_func];
         builder.ins().call(print_ref, &[arg_val]);
@@ -420,6 +472,7 @@ fn compile_inst(inst: &bril::Instruction, builder: &mut FunctionBuilder, env: &C
             let val = match value {
                 bril::Literal::Int(i) => builder.ins().iconst(ir::types::I64, *i),
                 bril::Literal::Bool(b) => builder.ins().bconst(ir::types::B1, *b),
+                bril::Literal::Float(f) => builder.ins().f64const(*f),
             };
             builder.def_var(env.vars[dest], val);
         }
@@ -498,6 +551,19 @@ fn compile_inst(inst: &bril::Instruction, builder: &mut FunctionBuilder, env: &C
                 let arg = builder.use_var(env.vars[&args[0]]);
                 builder.def_var(env.vars[dest], arg);
             }
+
+            // Floating point extension.
+            bril::ValueOps::Fadd
+            | bril::ValueOps::Fsub
+            | bril::ValueOps::Fmul
+            | bril::ValueOps::Fdiv => {
+                gen_binary(builder, &env.vars, args, dest, op_type, translate_op(*op));
+            },
+            bril::ValueOps::Flt
+            | bril::ValueOps::Fle
+            | bril::ValueOps::Feq
+            | bril::ValueOps::Fge
+            | bril::ValueOps::Fgt => gen_fcmp(builder, &env.vars, args, dest, translate_floatcc(*op)),
         },
     }
 }
@@ -704,6 +770,7 @@ impl<M: Module> Translator<M> {
                 let parse_ref = rt_setup_refs[match arg.arg_type {
                     bril::Type::Int => RTSetupFunc::ParseInt,
                     bril::Type::Bool => RTSetupFunc::ParseBool,
+                    bril::Type::Float => RTSetupFunc::ParseFloat,
                 }];
                 let idx_arg = builder.ins().iconst(ir::types::I64, (i + 1) as i64); // skip argv[0]
                 let inst = builder.ins().call(parse_ref, &[argv_arg, idx_arg]);
@@ -815,7 +882,6 @@ impl<M: Module> Translator<M> {
         wrapper_id
     }
 
-    // TODO The two arguments here (and in fact including the wrapper emission here) is ugly and bad...
     fn compile_prog(&mut self, prog: &bril::Program, dump: bool) {
         // Declare all functions.
         for func in &prog.functions {
@@ -918,6 +984,7 @@ fn main() {
             .map(|(arg, val_str)| match arg.arg_type {
                 bril::Type::Int => bril::Literal::Int(val_str.parse().unwrap()),
                 bril::Type::Bool => bril::Literal::Bool(val_str == "true"),
+                bril::Type::Float => bril::Literal::Bool(val_str.parse().unwrap()),
             })
             .collect();
 

--- a/brilift/src/rt.rs
+++ b/brilift/src/rt.rs
@@ -10,7 +10,15 @@ pub extern "C" fn print_bool(b: bool) {
 
 #[no_mangle]
 pub extern "C" fn print_float(f: f64) {
-    print!("{}", f);
+    if f.is_infinite() {
+        if f < 0.0 {
+            print!("-Infinity");
+        } else {
+            print!("Infinity");
+        }
+    } else {
+        print!("{}", f);
+    }
 }
 
 #[no_mangle]

--- a/brilift/src/rt.rs
+++ b/brilift/src/rt.rs
@@ -9,6 +9,11 @@ pub extern "C" fn print_bool(b: bool) {
 }
 
 #[no_mangle]
+pub extern "C" fn print_float(f: f64) {
+    print!("{}", f);
+}
+
+#[no_mangle]
 pub extern "C" fn print_sep() {
     print!(" ");
 }


### PR DESCRIPTION
Not much to see here; this just adds support for the ever-popular [floating point language extension](https://capra.cs.cornell.edu/bril/lang/float.html) in the Brilift compiler.

As always, there is a dangling annoyance here that different tools print floats differently. Currently, `printf` is currently only roughly within the ballpark of how Node and Rust print floats, so there are some niggling mismatches. A more tolerant way to match this stuff would be helpful, but I don't have any great ideas currently. Maybe some kind of fuzziness in Turnt, someday.