### PR TITLE
brilirs deps + buffering

### DIFF
--- a/bril-rs/bril2json/Cargo.toml
+++ b/bril-rs/bril2json/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["compiler", "bril", "parser", "data-structures", "language"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-clap         = { version = "3.1", features = ["derive"] }
+clap         = { version = "3.2", features = ["derive"] }
 lalrpop-util = { version = "0.19", features = ["lexer"] }
 regex = "1.5"
 

--- a/bril-rs/bril2json/src/cli.rs
+++ b/bril-rs/bril2json/src/cli.rs
@@ -4,6 +4,6 @@ use clap::Parser;
 #[clap(about, version, author)] // keeps the cli synced with Cargo.toml
 pub struct Cli {
     /// Flag for whether position information should be included
-    #[clap(short)]
+    #[clap(short, action)]
     pub position: bool,
 }

--- a/bril-rs/brild/Cargo.toml
+++ b/bril-rs/brild/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["compiler", "bril", "parser", "data-structures", "language"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-clap         = { version = "3.1", features = ["derive"] }
+clap         = { version = "3.2", features = ["derive"] }
 
 [dependencies.bril2json]
 version      = "0.1.0"

--- a/bril-rs/brild/src/cli.rs
+++ b/bril-rs/brild/src/cli.rs
@@ -5,9 +5,9 @@ use std::path::PathBuf;
 #[clap(about, version, author)] // keeps the cli synced with Cargo.toml
 pub struct Cli {
     /// The bril file to statically link. stdin is assumed if file is not provided.
-    #[clap(short, long)]
+    #[clap(short, long, action)]
     pub file: Option<String>,
     /// A list of library paths to look for Bril files.
-    #[clap(short, long, multiple_values = true)]
+    #[clap(short, long, action, multiple_values = true)]
     pub libs: Vec<PathBuf>,
 }

--- a/brilirs/Cargo.toml
+++ b/brilirs/Cargo.toml
@@ -13,12 +13,12 @@ keywords = ["compiler", "bril", "interpreter", "data-structures", "language"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [build-dependencies]
-clap         = { version = "3.1", features = ["derive"] }
-clap_complete= "3.1"
+clap         = { version = "3.2", features = ["derive"] }
+clap_complete= "3.2"
 
 [dependencies]
 thiserror    = "1.0"
-clap         = { version = "3.1", features = ["derive"] }
+clap         = { version = "3.2", features = ["derive"] }
 fxhash       = "0.2"
 mimalloc     = "0.1"
 

--- a/brilirs/src/cli.rs
+++ b/brilirs/src/cli.rs
@@ -5,22 +5,23 @@ use clap::Parser;
 #[clap(allow_hyphen_values(true))]
 pub struct Cli {
   /// Flag to output the total number of dynamic instructions
-  #[clap(short, long)]
+  #[clap(short, long, action)]
   pub profile: bool,
 
   /// The bril file to run. stdin is assumed if file is not provided
-  #[clap(short, long)]
+  #[clap(short, long, action)]
   pub file: Option<String>,
 
   /// Flag to only typecheck/validate the bril program
-  #[clap(short, long)]
+  #[clap(short, long, action)]
   pub check: bool,
 
   /// Flag for when the bril program is in text form
-  #[clap(short, long)]
+  #[clap(short, long, action)]
   pub text: bool,
 
   /// Arguments for the main function
+  #[clap(action)]
   pub args: Vec<String>,
 
   /// This is the original source file that the file input was generated from.
@@ -28,6 +29,6 @@ pub struct Cli {
   /// interpreter is in JSON form with source positions and you what brilirs to
   /// include sections of the source file in its error messages.
   /// If --text/-t is provided, that will be assumed to be the source file if none are provided.
-  #[clap(short, long)]
+  #[clap(short, long, action)]
   pub source: Option<String>,
 }

--- a/brilirs/src/main.rs
+++ b/brilirs/src/main.rs
@@ -27,7 +27,7 @@ fn main() {
 
   if let Err(e) = brilirs::run_input(
     input_string.as_bytes(),
-    std::io::stdout(),
+    std::io::BufWriter::new(std::io::stdout()),
     &args.args,
     args.profile,
     std::io::stderr(),


### PR DESCRIPTION
This pr handles the ever marching forward of dependency versions and switches to using `BufWriter` when writing to `stdout` which, as https://doc.rust-lang.org/std/io/struct.BufWriter.html describes, is much more efficient for many small calls to write.

Looking at this now, I realize that there is maybe one case where the `BufWriter` does not get flushed: when the Bril program raises an `InterpError` and then there is an error during the dropping of `BufWriter` where its contents are not flushed. I think this is both unlikely in practice and an allowable edge case.