### PR TITLE
Brilift: Conformant `float` printing

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -36,8 +36,8 @@ jobs:
           - "cd bril-rs && make features"
           - "cd brilirs && make test TURNTARGS=-v"
           - "cd brilirs && make benchmark TURNTARGS=-v"
-          - "cd brilift && cargo build --release && make rt.o && make test TURNTARGS=-vp"
-          - "cd brilift && cargo build --release && make rt.o && make benchmark TURNTARGS=-vp"
+          - "cd brilift && cargo build --release && make rt.o && make test TURNTARGS=-v"
+          - "cd brilift && cargo build --release && make rt.o && make benchmark TURNTARGS=-v"
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -36,8 +36,8 @@ jobs:
           - "cd bril-rs && make features"
           - "cd brilirs && make test TURNTARGS=-v"
           - "cd brilirs && make benchmark TURNTARGS=-v"
-          - "cd brilift && cargo build --release && make test TURNTARGS=-v"
-          - "cd brilift && cargo build --release && make benchmark TURNTARGS=-v"
+          - "cd brilift && cargo build --release && make rt.o && make test TURNTARGS=-v"
+          - "cd brilift && cargo build --release && make rt.o && make benchmark TURNTARGS=-v"
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -31,7 +31,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        test-code: ["cd bril-rs && make test TURNTARGS=-v", "cd bril-rs && make features", "cd brilirs && make test TURNTARGS=-v", "cd brilirs && make benchmark TURNTARGS=-v"]
+        test-code:
+          - "cd bril-rs && make test TURNTARGS=-v"
+          - "cd bril-rs && make features"
+          - "cd brilirs && make test TURNTARGS=-v"
+          - "cd brilirs && make benchmark TURNTARGS=-v"
+          - "cd brilift && cargo build --release && make test TURNTARGS=-v"
+          - "cd brilift && cargo build --release && make benchmark TURNTARGS=-v"
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -36,8 +36,8 @@ jobs:
           - "cd bril-rs && make features"
           - "cd brilirs && make test TURNTARGS=-v"
           - "cd brilirs && make benchmark TURNTARGS=-v"
-          - "cd brilift && cargo build --release && make rt.o && make test TURNTARGS=-v"
-          - "cd brilift && cargo build --release && make rt.o && make benchmark TURNTARGS=-v"
+          - "cd brilift && cargo build --release && make rt.o && make test TURNTARGS=-vp"
+          - "cd brilift && cargo build --release && make rt.o && make benchmark TURNTARGS=-vp"
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1

--- a/brilift/Makefile
+++ b/brilift/Makefile
@@ -1,7 +1,7 @@
 # Set TARGET to cross-compile. Brilift's AOT mode doesn't yet support macOS on
 # ARM, so on Apple Silicon devices, you'll need to do this to run compiled
 # programs through Rosetta 2:
-TARGET := x86_64-unknown-darwin-macho
+# TARGET := x86_64-unknown-darwin-macho
 
 # Brilift only supports core Bril for now, so we select those tests &
 # benchmarks.

--- a/brilift/Makefile
+++ b/brilift/Makefile
@@ -1,7 +1,7 @@
 # Set TARGET to cross-compile. Brilift's AOT mode doesn't yet support macOS on
 # ARM, so on Apple Silicon devices, you'll need to do this to run compiled
 # programs through Rosetta 2:
-# TARGET := x86_64-unknown-darwin-macho
+TARGET := x86_64-unknown-darwin-macho
 
 # Brilift only supports core Bril for now, so we select those tests &
 # benchmarks.

--- a/brilift/Makefile
+++ b/brilift/Makefile
@@ -24,11 +24,11 @@ install:
 
 .PHONY: test
 test: rt.o
-	turnt -e brilift-aot -e brilift-jit $(TESTS)
+	turnt -e brilift-aot -e brilift-jit $(TURNTARGS) $(TESTS)
 
 .PHONY: benchmark
 benchmark: rt.o
-	turnt -e brilift-aot -e brilift-jit $(BENCHMARKS)
+	turnt -e brilift-aot -e brilift-jit $(TURNTARGS) $(BENCHMARKS)
 
 rt.o: rt.c
 	cc $(CFLAGS) -c -o $@ $^

--- a/brilift/rt.c
+++ b/brilift/rt.c
@@ -26,7 +26,7 @@ void _bril_print_float(double f) {
             printf("Infinity");
         }
     } else {
-        printf("%.17lg", f);
+        printf("%.17lf", f);
     }
 }
 

--- a/brilift/run.sh
+++ b/brilift/run.sh
@@ -1,7 +1,10 @@
 #!/bin/sh
 set -e
 
-TARGET=x86_64-unknown-darwin-macho
+# Set this if you need to use a target other than the native platform---for
+# example, to run under Rosetta on macOS with Apple Silicon.
+# TARGET=x86_64-unknown-darwin-macho
+
 HERE=`dirname $0`
 
 RUST_BACKTRACE=1 cargo run --manifest-path $HERE/Cargo.toml --quiet -- -t $TARGET -o tmp_run.o

--- a/brilift/run.sh
+++ b/brilift/run.sh
@@ -7,7 +7,12 @@ set -e
 
 HERE=`dirname $0`
 
-RUST_BACKTRACE=1 cargo run --manifest-path $HERE/Cargo.toml --quiet -- -t $TARGET -o tmp_run.o
-cc -target $TARGET -o tmp_run tmp_run.o $HERE/rt.o
+if [ -n "$TARGET" ]; then
+    CFLAGS="-target $TARGET"
+    BFLAGS="-t $TARGET"
+fi
+
+RUST_BACKTRACE=1 cargo run --manifest-path $HERE/Cargo.toml --quiet -- $BFLAGS -o tmp_run.o
+cc $CFLAGS -o tmp_run tmp_run.o $HERE/rt.o
 ./tmp_run $@
 rm tmp_run.o tmp_run

--- a/brilift/src/rt.rs
+++ b/brilift/src/rt.rs
@@ -17,7 +17,7 @@ pub extern "C" fn print_float(f: f64) {
             print!("Infinity");
         }
     } else {
-        print!("{}", f);
+        print!("{:.17}", f);
     }
 }
 


### PR DESCRIPTION
Just makes Brilift conform to the new spec in #218 for printing all floats with 17 decimal digits of precision. Now all the float tests pass!

Hoping to tack CI stuff on to this PR…