### PR TITLE
Reorganize TypeScript tools (fixes #48)

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -25,10 +25,10 @@ jobs:
             python-version: '3.10'
 
       - name: TypeScript check
-        run: cd bril-ts ; deno check brili.ts brilck.ts ts2bril.ts
+        run: deno check brili.ts brilck.ts ts2bril.ts
 
-      - name: Install TypeScript tools
-        run: cd bril-ts ; deno install brili.ts ; deno install brilck.ts ; deno install --allow-env --allow-read ts2bril.ts
+      - name: Install all TypeScript tools
+        run: deno install brili.ts ; deno install brilck.ts ; deno install --allow-env --allow-read ts2bril.ts
 
       - name: Install Flit
         run: pip install flit
@@ -67,8 +67,8 @@ jobs:
         with:
             python-version: '3.10'
 
-      - name: Install TypeScript tools
-        run: cd bril-ts ; deno install brilck.ts
+      - name: Install brilck
+        run: deno install brilck.ts
 
       - name: Install Flit
         run: pip install flit

--- a/README.md
+++ b/README.md
@@ -20,15 +20,14 @@ Install the Tools
 ### Reference Interpreter
 
 You will want the IR interpreter, which uses [Deno][].
-Go to the `bril-ts` directory and do this:
+Just type this:
 
     $ deno install brili.ts
 
 As Deno tells you, you will then need to add `$HOME/.deno/bin` to [your `$PATH`][path].
 You will then have `brili`, which takes a Bril program as JSON on stdin and executes it.
 
-[node]: https://nodejs.org/en/
-[yarn]: https://yarnpkg.com/en/
+[deno]: https://deno.land
 [path]: https://unix.stackexchange.com/a/26059/61192
 
 ### Text Format

--- a/bril-ts/types.ts
+++ b/bril-ts/types.ts
@@ -99,7 +99,7 @@ export const OP_SIGS: {[key: string]: Signature | PolySignature} = {
   'fgt': {args: ['float', 'float'], dest: 'bool'},
   'fle': {args: ['float', 'float'], dest: 'bool'},
   'fge': {args: ['float', 'float'], dest: 'bool'},
-  
+
   // Memory.
   'alloc': {tvar: {tv: 'T'}, sig: {args: ['int'], dest: {ptr: {tv: 'T'}}}},
   'free': {tvar: {tv: 'T'}, sig: {args: [{ptr: {tv: 'T'}}]}},

--- a/brilck.ts
+++ b/brilck.ts
@@ -1,6 +1,6 @@
-import * as bril from './bril.ts';
-import {Signature, PolySignature, FuncType, OP_SIGS, TVar, BaseSignature, PolyType} from './types.ts';
-import {readStdin, unreachable} from './util.ts';
+import * as bril from './bril-ts/bril.ts';
+import {Signature, PolySignature, FuncType, OP_SIGS, TVar, BaseSignature, PolyType} from './bril-ts/types.ts';
+import {readStdin, unreachable} from './bril-ts/util.ts';
 
 /**
  * The JavaScript types of Bril constant values.

--- a/brili.ts
+++ b/brili.ts
@@ -1,5 +1,5 @@
-import * as bril from './bril.ts';
-import {readStdin, unreachable} from './util.ts';
+import * as bril from './bril-ts/bril.ts';
+import {readStdin, unreachable} from './bril-ts/util.ts';
 
 /**
  * An interpreter error to print to the console.

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -20,6 +20,7 @@
     - [Type Inference](tools/infer.md)
     - [Type Checker](tools/brilck.md)
     - [Benchmarks](tools/bench.md)
+    - [TypeScript Library](tools/ts.md)
     - [OCaml Library](tools/ocaml.md)
     - [Rust Library](tools/rust.md)
     - [Benchmark Runner](tools/brench.md)

--- a/docs/tools/brilck.md
+++ b/docs/tools/brilck.md
@@ -8,7 +8,7 @@ Install
 -------
 
 The `brilck` tool uses [Deno][].
-Go to the `bril-ts` directory and type:
+Type this:
 
     $ deno install brilck.ts
 

--- a/docs/tools/interp.md
+++ b/docs/tools/interp.md
@@ -11,7 +11,7 @@ Install
 -------
 
 To use the interpreter, you will need [Deno][].
-Go to the `bril-ts` directory and do this:
+Just run:
 
     $ deno install brili.ts
 

--- a/docs/tools/ocaml.md
+++ b/docs/tools/ocaml.md
@@ -17,7 +17,7 @@ opam pin add -k path bril path/to/brill/bril-ocaml
 opam install bril
 ```
 
-Thats it! Now, you can then include it in your [Dune][] files as `bril`, like any other ocaml library!
+Thats it! Now, you can then include it in your [Dune][] files as `bril`, like any other OCaml library!
 
 Use
 ---

--- a/docs/tools/ts.md
+++ b/docs/tools/ts.md
@@ -1,0 +1,17 @@
+TypeScript Library
+==================
+
+`bril-ts` is a [TypeScript][] library for interacting with Bril programs.
+It is the basis for [the reference interpreter][interp] and [the included type checker][brilck], but it is also useful on its own.
+
+The library includes:
+
+* `bril.ts`: Type definitions for the Bril language.
+  Parsing a JSON file produces a value of type `Program` from this module.
+* `builder.ts`: A [builder][] class that makes it more convenient to generate Bril programs from front-end compilers.
+* `types.ts`: A description of the type signatures for Bril operations, including the core language and all currently known extensions.
+
+[TypeScript]: https://www.typescriptlang.org/
+[interp]: ./interp.md
+[brilck]: ./brilck.md
+[builder]: https://en.wikipedia.org/wiki/Builder_pattern

--- a/docs/tools/ts2bril.md
+++ b/docs/tools/ts2bril.md
@@ -11,7 +11,7 @@ Install
 -------
 
 The TypeScript compiler uses [Deno][].
-Go to the `bril-ts` directory and type:
+Type this:
 
     $ deno install --allow-env --allow-read ts2bril.ts
 

--- a/ts2bril.ts
+++ b/ts2bril.ts
@@ -1,6 +1,6 @@
 import * as ts from 'https://esm.sh/typescript@3.4.3';
-import * as bril from './bril.ts';
-import {Builder} from './builder.ts';
+import * as bril from './bril-ts/bril.ts';
+import {Builder} from './bril-ts/builder.ts';
 
 const opTokens = new Map<ts.SyntaxKind, [bril.ValueOpCode, bril.Type]>([
   [ts.SyntaxKind.PlusToken,               ["add", "int"]],


### PR DESCRIPTION
It has always been annoying that three totally unrelated tools (the interpreter, the type checker, and the TypeScript-to-Bril compiler) have been coupled together in a single package. Since switching from Node to Deno in #224, it is now very easy to split these off from the core TypeScript library that they all depend upon. As a bonus, this makes that TS library more independent and therefore more usable by other clients—so I've added documentation for it in its own right.