### PR TITLE
Only try to rsync if you are sampsyo

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: mdbook
         run: mdbook build
       - name: rsync
-        if: ${{github.event_name=='push' && github.ref=='refs/heads/main'}}
+        if: ${{github.event_name=='push' && github.ref=='refs/heads/main' && github.repository_owner == 'sampsyo'}}
         env:
           DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
           DEPLOY_PORT: ${{ secrets.DEPLOY_PORT }}


### PR DESCRIPTION
Whenever I pull in documentation changes to my fork of this repository, I always get an email saying that the workflow failed(because I obviously don't have the super secret deploy keys). Deployment should only happen if the doc changes are being pushed to the main branch of this repository and I've added what I expect to be the correct change to the workflow to do that.

I've tested it in my own repository and if doesn't try to deploy anything which I take as a positive sign.

Before, a failing workflow: https://github.com/Pat-Lafon/bril/runs/7364333363?check_suite_focus=true
After, a test change to the docs with a passing workflow: https://github.com/Pat-Lafon/bril/runs/7364482838?check_suite_focus=true