### PR TITLE
pgo for brilirs

### DIFF
--- a/brilirs/Makefile
+++ b/brilirs/Makefile
@@ -14,7 +14,7 @@ BENCHMARKS := ../benchmarks/core/*.bril \
 
 .PHONY: install
 install:
-	cargo install --path .
+	RUSTFLAGS="-C target-cpu=native" cargo install --path .
 
 .PHONY: test
 test:
@@ -27,6 +27,15 @@ benchmark:
 .PHONY: release
 release:
 	RUSTFLAGS="-C target-cpu=native" cargo build --release
+
+#https://doc.rust-lang.org/rustc/profile-guided-optimization.html
+.PHONY: pgo
+pgo:
+	RUSTFLAGS="-C target-cpu=native -Cprofile-use=$(shell pwd)/merged.profdata" cargo build --release
+
+.PHONY: pgo-install
+pgo-install:
+	RUSTFLAGS="-Cprofile-use=$(shell pwd)/merged.profdata" cargo install --path .
 
 .PHONY: compare
 compare: release

--- a/brilirs/README.md
+++ b/brilirs/README.md
@@ -28,6 +28,10 @@ interp::execute_main(&bbprog, std::io::stdout(), &args, false, std::io::stderr()
 
 You can also use a `bril_rs::AbstractProgram` called `abstract_program` by converting it into a `bril_rs::Program` using `abstract_program.try_into()?`.
 
+## PGO
+
+You can get a modest performance benefit(~5-7%) by using LLVM's profile guided optimization. See `pgo.sh` and `make pgo`/`make pgo-install` for more details.
+
 ## Contributing
 
 Issues and PRs are welcome. For pull requests, make sure to run the test harness with `make test` and `make benchmark`. There is also `.github/workflows/rust.yaml` which will format your code and check that it is conforming with clippy.

--- a/brilirs/pgo.sh
+++ b/brilirs/pgo.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# https://doc.rust-lang.org/rustc/profile-guided-optimization.html
+
+set -e
+
+# You need the path to where ever cargo has the llvm-profdata command
+# rustup component add llvm-tools-preview
+export PATH="$PATH:~/.rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/aarch64-apple-darwin/bin/"
+# export PATH="$PATH:~/.rustup/toolchains/stable-x86_64-apple-darwin/lib/rustlib/x86_64-apple-darwin/bin"
+
+# STEP 0: Make sure there is no left-over profiling data from previous runs
+rm -rf /tmp/pgo-data || true
+rm merged.profdata || true
+
+# STEP 1: Build the instrumented binaries
+RUSTFLAGS="-Cprofile-generate=/tmp/pgo-data" \
+  cargo build --release
+
+# STEP 2: Run the instrumented binaries with some typical data
+./long_benchmark.sh
+
+# STEP 3: Merge the `.profraw` files into a `.profdata` file
+touch merged.profdata
+llvm-profdata merge -o merged.profdata /tmp/pgo-data
+
+# STEP 4: Use the `.profdata` file for guiding optimizations
+make pgo


### PR DESCRIPTION
Profile-Guided Optimization kind of seems like a modest amount of free performance(~5%). Cargo/Rust make using LLVM's support for this rather easy so I've included a shell script + make commands to compile `brilirs` with this optimization.