### PR TITLE
Actual BrildErrors in Brild

### DIFF
--- a/bril-rs/brild/Cargo.toml
+++ b/bril-rs/brild/Cargo.toml
@@ -14,6 +14,7 @@ keywords = ["compiler", "bril", "parser", "data-structures", "language"]
 
 [dependencies]
 clap         = { version = "3.2", features = ["derive"] }
+thiserror    = "1.0"
 
 [dependencies.bril2json]
 version      = "0.1.0"

--- a/bril-rs/brild/src/error.rs
+++ b/bril-rs/brild/src/error.rs
@@ -1,0 +1,13 @@
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum BrildError {
+    #[error("Could not find a complete path for `{0}` from the list of provided libraries")]
+    NoPathExists(std::path::PathBuf),
+    #[error("Imported file is missing or has an unknown a file extension: `{0}`")]
+    MissingOrUnknownFileExtension(std::path::PathBuf),
+    #[error("Function `{0}` declared more than once")]
+    DuplicateFunction(String),
+    #[error(transparent)]
+    IoError(#[from] std::io::Error),
+}

--- a/bril-rs/brild/src/main.rs
+++ b/bril-rs/brild/src/main.rs
@@ -5,9 +5,9 @@ use std::fs::canonicalize;
 use std::path::PathBuf;
 
 use bril_rs::{load_abstract_program, output_abstract_program, AbstractProgram};
-use brild::{cli::Cli, do_import, handle_program};
+use brild::{cli::Cli, do_import, error::BrildError, handle_program};
 
-fn main() -> std::io::Result<()> {
+fn main() -> Result<(), BrildError> {
     let mut map = HashMap::new();
     let args = Cli::parse();
 


### PR DESCRIPTION
Adds some structured errors to Brild via `thiserror`. There are still a couple `expect`/`panic` but I believe these would be triggered because of a bug and not because of user input.