### PR TITLE
Richer Source Positions

### DIFF
--- a/docs/lang/syntax.md
+++ b/docs/lang/syntax.md
@@ -124,11 +124,13 @@ It also has the optional `args`, `funcs`, and `labels` fields.
 Source Positions
 ----------------
 
-Any syntax object may optionally have a `pos` field to reflect a source position:
+Any syntax object may optionally have position fields to reflect a source position:
 
-    { ..., "pos": {"row": <int>, "col": <int>} }
+    { ..., "pos": {"row": <int>, "col": <int>},
+           "end_pos": {"row": <int>, "col": <int>}?,
+           "src": "<string>"? }
 
-The `pos` object has two keys: `row` (the line number) and `col` (the column number within the line).
+The `pos` and `pos_end` objects have two keys: `row` (the line number) and `col` (the column number within the line). The `src` object can optionally provide the absolute path to a file which is referenced to by the source position.
 Front-end compilers that generate Bril code may add this information to help with debugging.
 The [text format parser](../tools/text.md), for example, can optionally add source positions.
 However, tools can't require positions to exist, to consistently exist or not on all syntax objects in a program, or to follow any particular rules.

--- a/docs/lang/syntax.md
+++ b/docs/lang/syntax.md
@@ -127,10 +127,11 @@ Source Positions
 Any syntax object may optionally have position fields to reflect a source position:
 
     { ..., "pos": {"row": <int>, "col": <int>},
-           "end_pos": {"row": <int>, "col": <int>}?,
+           "pos_end": {"row": <int>, "col": <int>}?,
            "src": "<string>"? }
 
 The `pos` and `pos_end` objects have two keys: `row` (the line number) and `col` (the column number within the line). The `src` object can optionally provide the absolute path to a file which is referenced to by the source position.
+If `pos_end` is provided, it must be equal to or greater than `pos`.
 Front-end compilers that generate Bril code may add this information to help with debugging.
 The [text format parser](../tools/text.md), for example, can optionally add source positions.
 However, tools can't require positions to exist, to consistently exist or not on all syntax objects in a program, or to follow any particular rules.


### PR DESCRIPTION
Now that there are a couple of front-end compilers, specifically looking at #227 and #197, I want to tie things together into a nice bow by extending #161 with (optional) richer source position information as discussed in part in #191.

To support something span-like, this pr adds an optional `pos_end` field to describe the end line/column of the position.

To provide source code for the error message, this pr adds an optional `src` field which is an absolute path to the original file that this position points to. Note that the `src` field does not need to be the same across the entire Bril program.

Each is currently described as their own field to be compatible with the original specification, but I would probably like to combine them into one object if that's fine. Something like 

```JSON
{
  ...
  "pos": {
    "pos_start" : {"row": <int>, "col": <int>},
    "pos_end" : {"row": <int>, "col": <int>}?,
    "src" : "<string>"?,
  }
}
```