### PR TITLE
bril2json -p -p and Rust/Clap updates

### DIFF
--- a/bril-rs/bril2json/Cargo.toml
+++ b/bril-rs/bril2json/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["compiler", "bril", "parser", "data-structures", "language"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-clap         = { version = "3.2", features = ["derive"] }
+clap         = { version = "4.0", features = ["derive"] }
 lalrpop-util = { version = "0.19", features = ["lexer"] }
 regex = "1.5"
 

--- a/bril-rs/bril2json/src/bril_grammar.lalrpop
+++ b/bril-rs/bril2json/src/bril_grammar.lalrpop
@@ -75,12 +75,12 @@ Alias : String = {
 }
 
 AbstractFunction : AbstractFunction = {
-    <loc:@L> <f: Func> <a: (Argument_List)?> <t:OutputType?> "{" <c :(<AbstractCode>)*> "}" => {let a = a.unwrap_or_default(); AbstractFunction {
+    <loc:@L> <f: Func> <a: (Argument_List)?> <t:OutputType?> <loc2:@R> "{" <c :(<AbstractCode>)*> "}" => {let a = a.unwrap_or_default(); AbstractFunction {
         name : f,
         args : a,
         return_type : t,
         instrs: c,
-        pos : lines.get_position(loc),
+        pos : lines.get_position(loc, loc2),
     }}
 }
 
@@ -100,19 +100,19 @@ AbstractArgument : AbstractArgument = {
 }
 
 AbstractCode : AbstractCode = {
-    <loc:@L> <l: Label> ":" => AbstractCode::Label{ label : l, pos : lines.get_position(loc)},
+    <loc:@L> <l: Label> ":" <loc2:@R> => AbstractCode::Label{ label : l, pos : lines.get_position(loc, loc2)},
     <i: AbstractInstruction> => AbstractCode::Instruction(i),
 }
 
 AbstractInstruction : AbstractInstruction = {
-    <loc:@L> <i:Ident> <t:(":" <AbstractType>)?> "=" <c: ConstOps> <l: Literal> ";" => AbstractInstruction::Constant {
+    <loc:@L> <i:Ident> <t:(":" <AbstractType>)?> "=" <c: ConstOps> <l: Literal> ";" <loc2:@R> => AbstractInstruction::Constant {
         op : c,
         dest : i,
         const_type : t,
         value : l,
-        pos : lines.get_position(loc),
+        pos : lines.get_position(loc, loc2),
     },
-    <loc:@L> <i:Ident> <t:(":" <AbstractType>)?> "=" <v:Ident> <f :(<Args>)*> ";" => {
+    <loc:@L> <i:Ident> <t:(":" <AbstractType>)?> "=" <v:Ident> <f :(<Args>)*> ";" <loc2:@R> => {
         let mut a_vec = Vec::new();
         let mut f_vec = Vec::new();
         let mut l_vec = Vec::new();
@@ -130,10 +130,10 @@ AbstractInstruction : AbstractInstruction = {
             args: a_vec,
             funcs: f_vec,
             labels: l_vec,
-            pos : lines.get_position(loc),
+            pos : lines.get_position(loc, loc2),
         }
     },
-    <loc:@L> <e:Ident> <f :(<Args>)*> ";" => {
+    <loc:@L> <e:Ident> <f :(<Args>)*> ";" <loc2:@R> => {
         let mut a_vec = Vec::new();
         let mut f_vec = Vec::new();
         let mut l_vec = Vec::new();
@@ -149,7 +149,7 @@ AbstractInstruction : AbstractInstruction = {
             args: a_vec,
             funcs: f_vec,
             labels: l_vec,
-            pos : lines.get_position(loc),
+            pos : lines.get_position(loc, loc2),
         }
     }
 

--- a/bril-rs/bril2json/src/cli.rs
+++ b/bril-rs/bril2json/src/cli.rs
@@ -1,4 +1,4 @@
-use clap::Parser;
+use clap::{ArgAction::Count, Parser};
 
 #[derive(Parser)]
 #[command(about, version, author)] // keeps the cli synced with Cargo.toml
@@ -7,6 +7,6 @@ pub struct Cli {
     #[arg(short, long, action)]
     pub file: Option<String>,
     /// Flag for whether position information should be included
-    #[arg(short, action)]
-    pub position: bool,
+    #[arg(short, action = Count)]
+    pub position: u8,
 }

--- a/bril-rs/bril2json/src/cli.rs
+++ b/bril-rs/bril2json/src/cli.rs
@@ -3,6 +3,9 @@ use clap::Parser;
 #[derive(Parser)]
 #[clap(about, version, author)] // keeps the cli synced with Cargo.toml
 pub struct Cli {
+    /// The bril file to statically link. stdin is assumed if file is not provided.
+    #[clap(short, long, action)]
+    pub file: Option<String>,
     /// Flag for whether position information should be included
     #[clap(short, action)]
     pub position: bool,

--- a/bril-rs/bril2json/src/cli.rs
+++ b/bril-rs/bril2json/src/cli.rs
@@ -1,12 +1,12 @@
 use clap::Parser;
 
 #[derive(Parser)]
-#[clap(about, version, author)] // keeps the cli synced with Cargo.toml
+#[command(about, version, author)] // keeps the cli synced with Cargo.toml
 pub struct Cli {
     /// The bril file to statically link. stdin is assumed if file is not provided.
-    #[clap(short, long, action)]
+    #[arg(short, long, action)]
     pub file: Option<String>,
     /// Flag for whether position information should be included
-    #[clap(short, action)]
+    #[arg(short, action)]
     pub position: bool,
 }

--- a/bril-rs/bril2json/src/lib.rs
+++ b/bril-rs/bril2json/src/lib.rs
@@ -8,19 +8,23 @@
 pub mod bril_grammar;
 #[doc(hidden)]
 pub mod cli;
-use bril_rs::{AbstractProgram, Position};
+use std::fs::File;
+
+use bril_rs::{AbstractProgram, ColRow, Position};
 
 #[doc(hidden)]
 #[derive(Clone)]
 pub struct Lines {
     use_pos: bool,
     new_lines: Vec<usize>,
+    src_name: Option<String>,
 }
 
 impl Lines {
-    fn new(input: &str, use_pos: bool) -> Self {
+    fn new(input: &str, use_pos: bool, src_name: Option<String>) -> Self {
         Self {
             use_pos,
+            src_name,
             new_lines: input
                 .as_bytes()
                 .iter()
@@ -30,7 +34,19 @@ impl Lines {
         }
     }
 
-    fn get_position(&self, index: usize) -> Option<Position> {
+    fn get_position(&self, starting_index: usize, ending_index: usize) -> Option<Position> {
+        if self.use_pos {
+            Some(Position {
+                pos: self.get_row_col(starting_index).unwrap(),
+                pos_end: self.get_row_col(ending_index),
+                src: self.src_name.clone(),
+            })
+        } else {
+            None
+        }
+    }
+
+    fn get_row_col(&self, index: usize) -> Option<ColRow> {
         if self.use_pos {
             Some(
                 self.new_lines
@@ -38,13 +54,13 @@ impl Lines {
                     .enumerate()
                     .map(|(i, j)| (i + 1, j))
                     .fold(
-                        Position {
+                        ColRow {
                             col: index as u64,
                             row: 1,
                         },
                         |current, (line_num, idx)| {
                             if *idx < index {
-                                Position {
+                                ColRow {
                                     row: (line_num + 1) as u64,
                                     col: (index - idx) as u64,
                                 }
@@ -66,17 +82,25 @@ impl Lines {
 pub fn parse_abstract_program_from_read<R: std::io::Read>(
     mut input: R,
     use_pos: bool,
+    file_name: Option<String>,
 ) -> AbstractProgram {
     let mut buffer = String::new();
     input.read_to_string(&mut buffer).unwrap();
     let parser = bril_grammar::AbstractProgramParser::new();
     parser
-        .parse(&Lines::new(&buffer, use_pos), &buffer)
+        .parse(&Lines::new(&buffer, use_pos, file_name), &buffer)
         .unwrap()
 }
 
 #[must_use]
-/// A wrapper around [`parse_abstract_program_from_read`] which assumes [`std::io::Stdin`]
-pub fn parse_abstract_program(use_pos: bool) -> AbstractProgram {
-    parse_abstract_program_from_read(std::io::stdin(), use_pos)
+/// A wrapper around [`parse_abstract_program_from_read`] which assumes [`std::io::Stdin`] if `file_name` is [`None`]
+/// # Panics
+/// Will panic if the input is not well-formed Bril text or if `file_name` does not exist
+pub fn parse_abstract_program(use_pos: bool, file_name: Option<String>) -> AbstractProgram {
+    let input: Box<dyn std::io::Read> = match file_name.clone() {
+        Some(f) => Box::new(File::open(f).unwrap()),
+        None => Box::new(std::io::stdin()),
+    };
+
+    parse_abstract_program_from_read(input, use_pos, file_name)
 }

--- a/bril-rs/bril2json/src/lib.rs
+++ b/bril-rs/bril2json/src/lib.rs
@@ -87,8 +87,11 @@ pub fn parse_abstract_program_from_read<R: std::io::Read>(
     let mut buffer = String::new();
     input.read_to_string(&mut buffer).unwrap();
     let parser = bril_grammar::AbstractProgramParser::new();
+
+    let src_name = file_name.map(|f| std::fs::canonicalize(f).unwrap().display().to_string());
+
     parser
-        .parse(&Lines::new(&buffer, use_pos, file_name), &buffer)
+        .parse(&Lines::new(&buffer, use_pos, src_name), &buffer)
         .unwrap()
 }
 

--- a/bril-rs/bril2json/src/main.rs
+++ b/bril-rs/bril2json/src/main.rs
@@ -5,5 +5,9 @@ use clap::Parser;
 
 fn main() {
     let args = Cli::parse();
-    output_abstract_program(&parse_abstract_program(args.position, args.file))
+    output_abstract_program(&parse_abstract_program(
+        args.position >= 1,
+        args.position >= 2,
+        args.file,
+    ))
 }

--- a/bril-rs/bril2json/src/main.rs
+++ b/bril-rs/bril2json/src/main.rs
@@ -5,5 +5,5 @@ use clap::Parser;
 
 fn main() {
     let args = Cli::parse();
-    output_abstract_program(&parse_abstract_program(args.position))
+    output_abstract_program(&parse_abstract_program(args.position, args.file))
 }

--- a/bril-rs/brild/Cargo.toml
+++ b/bril-rs/brild/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["compiler", "bril", "parser", "data-structures", "language"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-clap         = { version = "3.2", features = ["derive"] }
+clap         = { version = "4.0", features = ["derive"] }
 thiserror    = "1.0"
 
 [dependencies.bril2json]

--- a/bril-rs/brild/src/cli.rs
+++ b/bril-rs/brild/src/cli.rs
@@ -2,12 +2,12 @@ use clap::Parser;
 use std::path::PathBuf;
 
 #[derive(Parser)]
-#[clap(about, version, author)] // keeps the cli synced with Cargo.toml
+#[command(about, version, author)] // keeps the cli synced with Cargo.toml
 pub struct Cli {
     /// The bril file to statically link. stdin is assumed if file is not provided.
-    #[clap(short, long, action)]
+    #[arg(short, long, action)]
     pub file: Option<String>,
     /// A list of library paths to look for Bril files.
-    #[clap(short, long, action, multiple_values = true)]
+    #[arg(short, long, action, num_args=1..)]
     pub libs: Vec<PathBuf>,
 }

--- a/bril-rs/brild/src/lib.rs
+++ b/bril-rs/brild/src/lib.rs
@@ -204,20 +204,23 @@ pub fn do_import<S: BuildHasher>(
     path_map.insert(canonical_path.clone(), None);
 
     // Find the correct parser for this path based on the extension
-    let f: Box<dyn Fn(_) -> AbstractProgram> = match canonical_path
-        .extension()
-        .and_then(std::ffi::OsStr::to_str)
-    {
-        Some("bril") => Box::new(|s| {
-            parse_abstract_program_from_read(s, true, Some(canonical_path.display().to_string()))
-        }),
-        Some("json") => Box::new(load_abstract_program_from_read),
-        Some(_) | None => {
-            return Err(BrildError::MissingOrUnknownFileExtension(
-                canonical_path.clone(),
-            ))
-        }
-    };
+    let f: Box<dyn Fn(_) -> AbstractProgram> =
+        match canonical_path.extension().and_then(std::ffi::OsStr::to_str) {
+            Some("bril") => Box::new(|s| {
+                parse_abstract_program_from_read(
+                    s,
+                    true,
+                    true,
+                    Some(canonical_path.display().to_string()),
+                )
+            }),
+            Some("json") => Box::new(load_abstract_program_from_read),
+            Some(_) | None => {
+                return Err(BrildError::MissingOrUnknownFileExtension(
+                    canonical_path.clone(),
+                ))
+            }
+        };
 
     // Get the AbstractProgram representation of the file
     let program = f(File::open(&canonical_path)?);

--- a/bril-rs/rs2bril/Cargo.toml
+++ b/bril-rs/rs2bril/Cargo.toml
@@ -16,7 +16,7 @@ keywords = ["compiler", "bril", "parser", "data-structures", "language"]
 [dependencies]
 syn = {version = "1.0", features = ["full", "extra-traits"]}
 proc-macro2 = {version = "1.0", features = ["span-locations"]}
-clap         = { version = "3.2", features = ["derive"] }
+clap         = { version = "4.0", features = ["derive"] }
 
 [dependencies.bril-rs]
 version = "0.1.0"

--- a/bril-rs/rs2bril/src/cli.rs
+++ b/bril-rs/rs2bril/src/cli.rs
@@ -3,6 +3,9 @@ use clap::Parser;
 #[derive(Parser)]
 #[clap(about, version, author)] // keeps the cli synced with Cargo.toml
 pub struct Cli {
+    /// The bril file to statically link. stdin is assumed if file is not provided.
+    #[clap(short, long, action)]
+    pub file: Option<String>,
     /// Flag for whether position information should be included
     #[clap(short, action)]
     pub position: bool,

--- a/bril-rs/rs2bril/src/cli.rs
+++ b/bril-rs/rs2bril/src/cli.rs
@@ -1,12 +1,12 @@
 use clap::Parser;
 
 #[derive(Parser)]
-#[clap(about, version, author)] // keeps the cli synced with Cargo.toml
+#[command(about, version, author)] // keeps the cli synced with Cargo.toml
 pub struct Cli {
     /// The bril file to statically link. stdin is assumed if file is not provided.
-    #[clap(short, long, action)]
+    #[arg(short, long, action)]
     pub file: Option<String>,
     /// Flag for whether position information should be included
-    #[clap(short, action)]
+    #[arg(short, action)]
     pub position: bool,
 }

--- a/bril-rs/rs2bril/src/main.rs
+++ b/bril-rs/rs2bril/src/main.rs
@@ -10,8 +10,17 @@ use clap::Parser;
 fn main() {
     let args = Cli::parse();
     let mut src = String::new();
-    std::io::stdin().read_to_string(&mut src).unwrap();
+    let source_name = if let Some(f) = args.file {
+        let path = std::fs::canonicalize(f).unwrap();
+        let mut file = std::fs::File::open(path.clone()).unwrap();
+        file.read_to_string(&mut src).unwrap();
+        Some(path.display().to_string())
+    } else {
+        std::io::stdin().read_to_string(&mut src).unwrap();
+        None
+    };
+
     let syntax = syn::parse_file(&src).unwrap();
 
-    output_program(&from_file_to_program(syntax, args.position));
+    output_program(&from_file_to_program(syntax, args.position, source_name));
 }

--- a/bril-rs/src/abstract_program.rs
+++ b/bril-rs/src/abstract_program.rs
@@ -48,7 +48,7 @@ pub struct AbstractFunction {
     pub name: String,
     /// The position of this function in the original source code
     #[cfg(feature = "position")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(flatten, skip_serializing_if = "Option::is_none")]
     pub pos: Option<Position>,
     /// The possible return type of this function
     #[serde(rename = "type")]
@@ -110,7 +110,7 @@ pub enum AbstractCode {
         label: String,
         /// Where the label is located in source code
         #[cfg(feature = "position")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(flatten, skip_serializing_if = "Option::is_none")]
         pos: Option<Position>,
     },
     /// <https://capra.cs.cornell.edu/bril/lang/syntax.html#instruction>
@@ -142,7 +142,7 @@ pub enum AbstractInstruction {
         op: ConstOps,
         /// The source position of the instruction if provided
         #[cfg(feature = "position")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(flatten, skip_serializing_if = "Option::is_none")]
         pos: Option<Position>,
         /// Type of variable
         #[serde(rename = "type")]
@@ -167,7 +167,7 @@ pub enum AbstractInstruction {
         op: String,
         /// The source position of the instruction if provided
         #[cfg(feature = "position")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(flatten, skip_serializing_if = "Option::is_none")]
         pos: Option<Position>,
         /// Type of variable
         #[serde(rename = "type")]
@@ -188,7 +188,7 @@ pub enum AbstractInstruction {
         op: String,
         /// The source position of the instruction if provided
         #[cfg(feature = "position")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(flatten, skip_serializing_if = "Option::is_none")]
         pos: Option<Position>,
     },
 }

--- a/bril-rs/src/lib.rs
+++ b/bril-rs/src/lib.rs
@@ -4,6 +4,8 @@
 #![allow(clippy::too_many_lines)]
 // https://github.com/rust-lang/rust-clippy/issues/6902
 #![allow(clippy::use_self)]
+// Buggy in that it wants Eq to be derived on Literal which has an f64 field
+#![allow(clippy::derive_partial_eq_without_eq)]
 
 /// Provides the unstructured representation of Bril programs
 pub mod abstract_program;

--- a/bril-rs/src/program.rs
+++ b/bril-rs/src/program.rs
@@ -90,7 +90,7 @@ pub struct Function {
     pub name: String,
     /// The position of this function in the original source code
     #[cfg(feature = "position")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(flatten, skip_serializing_if = "Option::is_none")]
     pub pos: Option<Position>,
     /// The possible return type of this function
     #[serde(rename = "type")]
@@ -152,7 +152,7 @@ pub enum Code {
         label: String,
         /// Where the label is located in source code
         #[cfg(feature = "position")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(flatten, skip_serializing_if = "Option::is_none")]
         pos: Option<Position>,
     },
     /// <https://capra.cs.cornell.edu/bril/lang/syntax.html#instruction>
@@ -184,7 +184,7 @@ pub enum Instruction {
         op: ConstOps,
         #[cfg(feature = "position")]
         /// The source position of the instruction if provided
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(flatten, skip_serializing_if = "Option::is_none")]
         pos: Option<Position>,
         /// Type of variable
         #[serde(rename = "type")]
@@ -209,7 +209,7 @@ pub enum Instruction {
         op: ValueOps,
         /// The source position of the instruction if provided
         #[cfg(feature = "position")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(flatten, skip_serializing_if = "Option::is_none")]
         pos: Option<Position>,
         /// Type of variable
         #[serde(rename = "type")]
@@ -230,7 +230,7 @@ pub enum Instruction {
         op: EffectOps,
         /// The source position of the instruction if provided
         #[cfg(feature = "position")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(flatten, skip_serializing_if = "Option::is_none")]
         pos: Option<Position>,
     },
 }
@@ -239,11 +239,11 @@ pub enum Instruction {
 impl Instruction {
     /// A helper function to extract the position value if it exists from an instruction
     #[must_use]
-    pub const fn get_pos(&self) -> Option<Position> {
+    pub fn get_pos(&self) -> Option<Position> {
         match self {
             Instruction::Constant { pos, .. }
             | Instruction::Value { pos, .. }
-            | Instruction::Effect { pos, .. } => *pos,
+            | Instruction::Effect { pos, .. } => pos.clone(),
         }
     }
 }
@@ -570,8 +570,21 @@ impl Literal {
 }
 
 /// <https://capra.cs.cornell.edu/bril/lang/syntax.html#source-positions>
-#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct Position {
+    /// Starting position
+    pub pos: ColRow,
+    /// Optional ending position
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pos_end: Option<ColRow>,
+    /// Optional absolute path to source file
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub src: Option<String>,
+}
+
+/// <https://capra.cs.cornell.edu/bril/lang/syntax.html#source-positions>
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ColRow {
     /// Column
     pub col: u64,
     /// Row

--- a/brilck.ts
+++ b/brilck.ts
@@ -281,14 +281,14 @@ const INSTR_CHECKS: {[key: string]: CheckFunc} = {
     }
     return;
   },
-  
+
   phi: (env, instr) => {
     let args = instr.args ?? [];
     if (!('type' in instr)) {
       err(`phi needs a result type`, instr.pos);
       return;
     }
-    
+
     // Construct a signature with uniform argument types.
     let argTypes: bril.Type[] = [];
     for (let i = 0; i < args.length; ++i) {
@@ -353,25 +353,27 @@ function checkFunc(funcs: FuncEnv, func: bril.Function) {
   }
 
   // Gather up all the types of the local variables and all the label names.
-  for (let instr of func.instrs) {
-    if ('dest' in instr) {
-      addType(vars, instr.dest, instr.type, instr.pos);
-    } else if ('label' in instr) {
-      if (labels.has(instr.label)) {
-        err(`multiply defined label .${instr.label}`, instr.pos);
-      } else {
-        labels.add(instr.label);
+  if (func.instrs){
+    for (let instr of func.instrs) {
+      if ('dest' in instr) {
+        addType(vars, instr.dest, instr.type, instr.pos);
+      } else if ('label' in instr) {
+        if (labels.has(instr.label)) {
+          err(`multiply defined label .${instr.label}`, instr.pos);
+        } else {
+          labels.add(instr.label);
+        }
       }
     }
-  }
 
-  // Check each instruction.
-  for (let instr of func.instrs) {
-    if ('op' in instr) {
-      if (instr.op === 'const') {
-        checkConst(instr);
-      } else {
-        checkOp({vars, labels, funcs, ret: func.type}, instr);
+    // Check each instruction.
+    for (let instr of func.instrs) {
+      if ('op' in instr) {
+        if (instr.op === 'const') {
+          checkConst(instr);
+        } else {
+          checkOp({vars, labels, funcs, ret: func.type}, instr);
+        }
       }
     }
   }

--- a/brilirs/Cargo.toml
+++ b/brilirs/Cargo.toml
@@ -13,12 +13,12 @@ keywords = ["compiler", "bril", "interpreter", "data-structures", "language"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [build-dependencies]
-clap         = { version = "3.2", features = ["derive"] }
-clap_complete= "3.2"
+clap         = { version = "4.0", features = ["derive"] }
+clap_complete= "4.0"
 
 [dependencies]
 thiserror    = "1.0"
-clap         = { version = "3.2", features = ["derive"] }
+clap         = { version = "4.0", features = ["derive"] }
 fxhash       = "0.2"
 mimalloc     = "0.1"
 itoa         = "1.0"

--- a/brilirs/build.rs
+++ b/brilirs/build.rs
@@ -1,6 +1,6 @@
 // https://kbknapp.dev/shell-completions/
 
-use clap::IntoApp;
+use clap::CommandFactory;
 use clap_complete::{
   shells::{Bash, Elvish, Fish, PowerShell, Zsh},
   Generator,

--- a/brilirs/src/basic_block.rs
+++ b/brilirs/src/basic_block.rs
@@ -142,7 +142,7 @@ impl NumifiedInstruction {
             func_map
               .get(f)
               .copied()
-              .ok_or_else(|| InterpError::FuncNotFound(f.to_string()).add_pos(*pos))
+              .ok_or_else(|| InterpError::FuncNotFound(f.to_string()).add_pos(pos.clone()))
           })
           .collect::<Result<Vec<usize>, PositionalInterpError>>()?,
       },
@@ -160,7 +160,7 @@ impl NumifiedInstruction {
             func_map
               .get(f)
               .copied()
-              .ok_or_else(|| InterpError::FuncNotFound(f.to_string()).add_pos(*pos))
+              .ok_or_else(|| InterpError::FuncNotFound(f.to_string()).add_pos(pos.clone()))
           })
           .collect::<Result<Vec<usize>, PositionalInterpError>>()?,
       },

--- a/brilirs/src/basic_block.rs
+++ b/brilirs/src/basic_block.rs
@@ -97,14 +97,15 @@ fn get_num_from_map(
   // A map from variables to numbers
   num_var_map: &mut FxHashMap<String, usize>,
 ) -> usize {
-  match num_var_map.get(variable_name) {
-    Some(i) => *i,
-    None => {
-      let x = *num_of_vars;
-      num_var_map.insert(variable_name.to_string(), x);
-      *num_of_vars += 1;
-      x
-    }
+  // https://github.com/rust-lang/rust-clippy/issues/8346
+  #[allow(clippy::option_if_let_else)]
+  if let Some(i) = num_var_map.get(variable_name) {
+    *i
+  } else {
+    let x = *num_of_vars;
+    num_var_map.insert(variable_name.to_string(), x);
+    *num_of_vars += 1;
+    x
   }
 }
 

--- a/brilirs/src/check.rs
+++ b/brilirs/src/check.rs
@@ -43,12 +43,13 @@ fn update_env<'a>(
   dest: &'a str,
   typ: &'a Type,
 ) -> Result<(), InterpError> {
-  match env.get(dest) {
-    Some(current_typ) => check_asmt_type(current_typ, typ),
-    None => {
-      env.insert(dest, typ);
-      Ok(())
-    }
+  // https://github.com/rust-lang/rust-clippy/issues/8346
+  #[allow(clippy::option_if_let_else)]
+  if let Some(current_typ) = env.get(dest) {
+    check_asmt_type(current_typ, typ)
+  } else {
+    env.insert(dest, typ);
+    Ok(())
   }
 }
 

--- a/brilirs/src/cli.rs
+++ b/brilirs/src/cli.rs
@@ -23,12 +23,4 @@ pub struct Cli {
   /// Arguments for the main function
   #[clap(action)]
   pub args: Vec<String>,
-
-  /// This is the original source file that the file input was generated from.
-  /// You would want to provide this if the bril file you are providing to the
-  /// interpreter is in JSON form with source positions and you what brilirs to
-  /// include sections of the source file in its error messages.
-  /// If --text/-t is provided, that will be assumed to be the source file if none are provided.
-  #[clap(short, long, action)]
-  pub source: Option<String>,
 }

--- a/brilirs/src/cli.rs
+++ b/brilirs/src/cli.rs
@@ -1,26 +1,26 @@
 use clap::Parser;
 
 #[derive(Parser)]
-#[clap(about, version, author)] // keeps the cli synced with Cargo.toml
-#[clap(allow_hyphen_values(true))]
+#[command(about, version, author)] // keeps the cli synced with Cargo.toml
+#[command(allow_hyphen_values(true))]
 pub struct Cli {
   /// Flag to output the total number of dynamic instructions
-  #[clap(short, long, action)]
+  #[arg(short, long, action)]
   pub profile: bool,
 
   /// The bril file to run. stdin is assumed if file is not provided
-  #[clap(short, long, action)]
+  #[arg(short, long, action)]
   pub file: Option<String>,
 
   /// Flag to only typecheck/validate the bril program
-  #[clap(short, long, action)]
+  #[arg(short, long, action)]
   pub check: bool,
 
   /// Flag for when the bril program is in text form
-  #[clap(short, long, action)]
+  #[arg(short, long, action)]
   pub text: bool,
 
   /// Arguments for the main function
-  #[clap(action)]
+  #[arg(action)]
   pub args: Vec<String>,
 }

--- a/brilirs/src/error.rs
+++ b/brilirs/src/error.rs
@@ -79,10 +79,58 @@ pub struct PositionalInterpError {
 impl Display for PositionalInterpError {
   fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
     match self {
-      PositionalInterpError { e, pos: Some(pos) } => {
+      Self {
+        e,
+        pos:
+          Some(Position {
+            pos,
+            pos_end: Some(end),
+            src: Some(s),
+          }),
+      } => {
+        write!(
+          f,
+          "{s}:{}:{} to {s}:{}:{} \n\t {e}",
+          pos.row, pos.col, end.row, end.col
+        )
+      }
+      Self {
+        e,
+        pos:
+          Some(Position {
+            pos,
+            pos_end: None,
+            src: Some(s),
+          }),
+      } => {
+        write!(f, "{s}:{}:{} \n\t {e}", pos.row, pos.col)
+      }
+      Self {
+        e,
+        pos:
+          Some(Position {
+            pos,
+            pos_end: Some(end),
+            src: None,
+          }),
+      } => {
+        write!(
+          f,
+          "Line {}, Column {} to Line {}, Column {}: {e}",
+          pos.row, pos.col, end.row, end.col
+        )
+      }
+      Self {
+        e,
+        pos: Some(Position {
+          pos,
+          pos_end: None,
+          src: None,
+        }),
+      } => {
         write!(f, "Line {}, Column {}: {e}", pos.row, pos.col)
       }
-      PositionalInterpError { e, pos: None } => write!(f, "{e}"),
+      Self { e, pos: None } => write!(f, "{e}"),
     }
   }
 }

--- a/brilirs/src/interp.rs
+++ b/brilirs/src/interp.rs
@@ -44,16 +44,16 @@ impl Environment {
     }
   }
 
-  pub fn get(&self, ident: &usize) -> &Value {
+  pub fn get(&self, ident: usize) -> &Value {
     // A bril program is well formed when, dynamically, every variable is defined before its use.
     // If this is violated, this will return Value::Uninitialized and the whole interpreter will come crashing down.
-    self.env.get(self.current_pointer + *ident).unwrap()
+    self.env.get(self.current_pointer + ident).unwrap()
   }
 
   // Used for getting arguments that should be passed to the current frame from the previous one
-  pub fn get_from_last_frame(&self, ident: &usize) -> &Value {
+  pub fn get_from_last_frame(&self, ident: usize) -> &Value {
     let past_pointer = self.stack_pointers.last().unwrap().0;
-    self.env.get(past_pointer + *ident).unwrap()
+    self.env.get(past_pointer + ident).unwrap()
   }
 
   pub fn set(&mut self, ident: usize, val: Value) {
@@ -161,7 +161,7 @@ impl Heap {
 // you just want the underlying value(like a f64).
 // Or can just be used to get a owned version of the Value
 fn get_arg<'a, T: From<&'a Value>>(vars: &'a Environment, index: usize, args: &[usize]) -> T {
-  T::from(vars.get(&args[index]))
+  T::from(vars.get(args[index]))
 }
 
 #[derive(Debug, Default, Clone, Copy)]
@@ -290,7 +290,7 @@ fn make_func_args<'a>(callee_func: &'a BBFunction, args: &[usize], vars: &mut En
     .iter()
     .zip(callee_func.args_as_nums.iter())
     .for_each(|(arg_name, expected_arg)| {
-      let arg = vars.get_from_last_frame(arg_name);
+      let arg = vars.get_from_last_frame(*arg_name);
       vars.set(*expected_arg, *arg);
     });
 }
@@ -493,7 +493,7 @@ fn execute_effect_op<'a, T: std::io::Write>(
       // In the typical case, users only print out one value at a time
       // So we can usually avoid extra allocations by providing that string directly
       if args.len() == 1 {
-        optimized_val_output(&mut state.out, state.env.get(args.first().unwrap()))?;
+        optimized_val_output(&mut state.out, state.env.get(*args.first().unwrap()))?;
         // Add new line
         state.out.write_all(&[b'\n'])?;
       } else {
@@ -502,7 +502,7 @@ fn execute_effect_op<'a, T: std::io::Write>(
           "{}",
           args
             .iter()
-            .map(|a| state.env.get(a).to_string())
+            .map(|a| state.env.get(*a).to_string())
             .collect::<Vec<String>>()
             .join(" ")
         )?;

--- a/brilirs/src/lib.rs
+++ b/brilirs/src/lib.rs
@@ -37,7 +37,7 @@ pub fn run_input<T: std::io::Write, U: std::io::Write>(
   //      - bril_rs takes file.json as input
   //      - bril2json takes file.bril as input
   let prog: Program = if text {
-    bril2json::parse_abstract_program_from_read(input, true, src_name).try_into()?
+    bril2json::parse_abstract_program_from_read(input, true, true, src_name).try_into()?
   } else {
     bril_rs::load_abstract_program_from_read(input).try_into()?
   };

--- a/brilirs/src/lib.rs
+++ b/brilirs/src/lib.rs
@@ -4,6 +4,7 @@
 #![allow(clippy::similar_names)]
 #![allow(clippy::too_many_lines)]
 #![allow(clippy::module_name_repetitions)]
+#![allow(clippy::too_many_arguments)]
 #![doc = include_str!("../README.md")]
 
 use basic_block::BBProgram;
@@ -30,12 +31,13 @@ pub fn run_input<T: std::io::Write, U: std::io::Write>(
   profiling_out: U,
   check: bool,
   text: bool,
+  src_name: Option<String>,
 ) -> Result<(), PositionalInterpError> {
   // It's a little confusing because of the naming conventions.
   //      - bril_rs takes file.json as input
   //      - bril2json takes file.bril as input
   let prog: Program = if text {
-    bril2json::parse_abstract_program_from_read(input, true).try_into()?
+    bril2json::parse_abstract_program_from_read(input, true, src_name).try_into()?
   } else {
     bril_rs::load_abstract_program_from_read(input).try_into()?
   };

--- a/docs/tools/rust.md
+++ b/docs/tools/rust.md
@@ -24,7 +24,7 @@ Tools
 
 This library supports fully compatible Rust implementations of `bril2txt` and `bril2json`. This library also implements the [import][] extension with a static linker called `brild`.
 
-This library is used in a Rust compiler called `rs2bril` which supports generating [core], [float], and [mem] Bril from a subset of valid Rust.
+This library is used in a Rust compiler called `rs2bril` which supports generating [core], [float], and [memory] Bril from a subset of valid Rust.
 
 For ease of use, these tools can be installed and added to your path by running the following in `bril-rs/`:
 

--- a/test/parse/positions.json
+++ b/test/parse/positions.json
@@ -9,10 +9,6 @@
             "col": 3,
             "row": 3
           },
-          "pos_end": {
-            "col": 21,
-            "row": 3
-          },
           "type": "int",
           "value": 1
         },
@@ -21,10 +17,6 @@
           "op": "const",
           "pos": {
             "col": 3,
-            "row": 4
-          },
-          "pos_end": {
-            "col": 21,
             "row": 4
           },
           "type": "int",
@@ -38,20 +30,12 @@
           "pos": {
             "col": 3,
             "row": 5
-          },
-          "pos_end": {
-            "col": 14,
-            "row": 5
           }
         },
         {
           "label": "label",
           "pos": {
             "col": 1,
-            "row": 6
-          },
-          "pos_end": {
-            "col": 8,
             "row": 6
           }
         },
@@ -66,10 +50,6 @@
             "col": 3,
             "row": 7
           },
-          "pos_end": {
-            "col": 23,
-            "row": 7
-          },
           "type": "int"
         },
         {
@@ -80,20 +60,12 @@
           "pos": {
             "col": 3,
             "row": 8
-          },
-          "pos_end": {
-            "col": 12,
-            "row": 8
           }
         }
       ],
       "name": "main",
       "pos": {
         "col": 1,
-        "row": 2
-      },
-      "pos_end": {
-        "col": 7,
         "row": 2
       }
     }

--- a/test/parse/positions.json
+++ b/test/parse/positions.json
@@ -9,6 +9,10 @@
             "col": 3,
             "row": 3
           },
+          "pos_end": {
+            "col": 21,
+            "row": 3
+          },
           "type": "int",
           "value": 1
         },
@@ -17,6 +21,10 @@
           "op": "const",
           "pos": {
             "col": 3,
+            "row": 4
+          },
+          "pos_end": {
+            "col": 21,
             "row": 4
           },
           "type": "int",
@@ -30,12 +38,20 @@
           "pos": {
             "col": 3,
             "row": 5
+          },
+          "pos_end": {
+            "col": 14,
+            "row": 5
           }
         },
         {
           "label": "label",
           "pos": {
             "col": 1,
+            "row": 6
+          },
+          "pos_end": {
+            "col": 8,
             "row": 6
           }
         },
@@ -50,6 +66,10 @@
             "col": 3,
             "row": 7
           },
+          "pos_end": {
+            "col": 23,
+            "row": 7
+          },
           "type": "int"
         },
         {
@@ -60,12 +80,20 @@
           "pos": {
             "col": 3,
             "row": 8
+          },
+          "pos_end": {
+            "col": 12,
+            "row": 8
           }
         }
       ],
       "name": "main",
       "pos": {
         "col": 1,
+        "row": 2
+      },
+      "pos_end": {
+        "col": 7,
         "row": 2
       }
     }


### PR DESCRIPTION
- All the rust tools now use Clap v4.0
- Rust 1.64 Clippy lint updates
- Link fix in docs
- Minor bug in brilck where it didn't check if there were actually instructions in the function(func.instrs could be `undefined`) which triggered on `test/check/badcall.bril` for `@nothing`. Not sure why this wasn't caught before.
- bril-rs adds support for #232
- (rust) bril2json now takes multiple `-p` flags where just one `-p` is still compatible with python versions and `-p -p` additionally adds the end source positions.
- rs2bril now supports end source positions via `proc_macro2::Span`(best effort) and also adds the `--file/-f` flag.
- brilirs now has rough support for end source positions.

I've manually tested the additional support for richer source positions but like the rest of the error-handling support is not rigorously tested.