### PR TITLE
Address Rust 1.66 clippy lints

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -84,6 +84,9 @@ jobs:
 
   rust-ci:
     runs-on: ubuntu-latest
+    env:
+      RUSTDOCFLAGS: -D warnings
+      RUSTFLAGS: -D warnings
     strategy:
       matrix:
         path: ["brilirs/Cargo.toml", "bril-rs/Cargo.toml", "bril-rs/bril2json/Cargo.toml", "bril-rs/brild/Cargo.toml", "brilift/Cargo.toml", "bril-rs/rs2bril/Cargo.toml"]
@@ -109,7 +112,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: --manifest-path ${{ matrix.path }} -- -D warnings
+          args: --manifest-path ${{ matrix.path }}
 
       - uses: actions-rs/cargo@v1
         with:

--- a/bril-rs/bril2json/src/bril_grammar.lalrpop
+++ b/bril-rs/bril2json/src/bril_grammar.lalrpop
@@ -20,6 +20,7 @@
 #![allow(clippy::must_use_candidate)]
 #![allow(clippy::cognitive_complexity)]
 #![allow(clippy::ptr_arg)]
+#![allow(clippy::uninlined_format_args)]
 
 use std::str::FromStr;
 use std::path::PathBuf;

--- a/bril-rs/src/abstract_program.rs
+++ b/bril-rs/src/abstract_program.rs
@@ -120,12 +120,12 @@ pub enum AbstractCode {
 impl Display for AbstractCode {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
-            AbstractCode::Label {
+            Self::Label {
                 label,
                 #[cfg(feature = "position")]
                     pos: _,
             } => write!(f, ".{label}:"),
-            AbstractCode::Instruction(instr) => write!(f, "  {instr}"),
+            Self::Instruction(instr) => write!(f, "  {instr}"),
         }
     }
 }
@@ -196,7 +196,7 @@ pub enum AbstractInstruction {
 impl Display for AbstractInstruction {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
-            AbstractInstruction::Constant {
+            Self::Constant {
                 op,
                 dest,
                 const_type,
@@ -207,7 +207,7 @@ impl Display for AbstractInstruction {
                 Some(const_type) => write!(f, "{dest}: {const_type} = {op} {value};"),
                 None => write!(f, "{dest} = {op} {value};"),
             },
-            AbstractInstruction::Value {
+            Self::Value {
                 op,
                 dest,
                 op_type,
@@ -232,7 +232,7 @@ impl Display for AbstractInstruction {
                 }
                 write!(f, ";")
             }
-            AbstractInstruction::Effect {
+            Self::Effect {
                 op,
                 args,
                 funcs,
@@ -329,8 +329,8 @@ impl Serialize for AbstractType {
         S: Serializer,
     {
         match self {
-            AbstractType::Primitive(s) => serializer.serialize_str(s),
-            AbstractType::Parameterized(t, at) => {
+            Self::Primitive(s) => serializer.serialize_str(s),
+            Self::Parameterized(t, at) => {
                 let mut map = serializer.serialize_map(Some(1))?;
                 map.serialize_entry(t, at)?;
                 map.end()
@@ -342,9 +342,8 @@ impl Serialize for AbstractType {
 impl Display for AbstractType {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
-            AbstractType::Primitive(t) => write!(f, "{t}"),
-
-            AbstractType::Parameterized(t, at) => write!(f, "{t}<{at}>"),
+            Self::Primitive(t) => write!(f, "{t}"),
+            Self::Parameterized(t, at) => write!(f, "{t}<{at}>"),
         }
     }
 }

--- a/bril-rs/src/abstract_program.rs
+++ b/bril-rs/src/abstract_program.rs
@@ -259,9 +259,9 @@ impl Display for AbstractInstruction {
 /// <https://capra.cs.cornell.edu/bril/lang/syntax.html#type>
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum AbstractType {
-    /// For example "bool" => Primitive("bool")
+    /// For example `bool` => `Primitive("bool")`
     Primitive(String),
-    /// For example "ptr<bool>" => Parameterized("ptr", Box::new(Primitive("bool")))
+    /// For example `ptr<bool>` => `Parameterized("ptr", Box::new(Primitive("bool")))`
     Parameterized(String, Box<Self>),
 }
 

--- a/bril-rs/src/conversion.rs
+++ b/bril-rs/src/conversion.rs
@@ -72,14 +72,14 @@ impl Display for PositionalConversionError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             #[cfg(feature = "position")]
-            PositionalConversionError { e, pos: Some(pos) } => {
+            Self { e, pos: Some(pos) } => {
                 write!(f, "Line {}, Column {}: {e}", pos.pos.row, pos.pos.col)
             }
             #[cfg(not(feature = "position"))]
-            PositionalConversionError { e: _, pos: Some(_) } => {
+            Self { e: _, pos: Some(_) } => {
                 unreachable!()
             }
-            PositionalConversionError { e, pos: None } => write!(f, "{e}"),
+            Self { e, pos: None } => write!(f, "{e}"),
         }
     }
 }

--- a/bril-rs/src/lib.rs
+++ b/bril-rs/src/lib.rs
@@ -2,8 +2,6 @@
 #![warn(missing_docs)]
 #![doc = include_str!("../README.md")]
 #![allow(clippy::too_many_lines)]
-// https://github.com/rust-lang/rust-clippy/issues/6902
-#![allow(clippy::use_self)]
 // Buggy in that it wants Eq to be derived on Literal which has an f64 field
 #![allow(clippy::derive_partial_eq_without_eq)]
 

--- a/bril-rs/src/program.rs
+++ b/bril-rs/src/program.rs
@@ -162,12 +162,12 @@ pub enum Code {
 impl Display for Code {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
-            Code::Label {
+            Self::Label {
                 label,
                 #[cfg(feature = "position")]
                     pos: _,
             } => write!(f, ".{label}:"),
-            Code::Instruction(instr) => write!(f, "  {instr}"),
+            Self::Instruction(instr) => write!(f, "  {instr}"),
         }
     }
 }
@@ -251,7 +251,7 @@ impl Instruction {
 impl Display for Instruction {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
-            Instruction::Constant {
+            Self::Constant {
                 op,
                 dest,
                 const_type,
@@ -261,7 +261,7 @@ impl Display for Instruction {
             } => {
                 write!(f, "{dest}: {const_type} = {op} {value};")
             }
-            Instruction::Value {
+            Self::Value {
                 op,
                 dest,
                 op_type,
@@ -283,7 +283,7 @@ impl Display for Instruction {
                 }
                 write!(f, ";")
             }
-            Instruction::Effect {
+            Self::Effect {
                 op,
                 args,
                 funcs,
@@ -548,10 +548,10 @@ pub enum Literal {
 impl Display for Literal {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
-            Literal::Int(i) => write!(f, "{i}"),
-            Literal::Bool(b) => write!(f, "{b}"),
+            Self::Int(i) => write!(f, "{i}"),
+            Self::Bool(b) => write!(f, "{b}"),
             #[cfg(feature = "float")]
-            Literal::Float(x) => write!(f, "{x}"),
+            Self::Float(x) => write!(f, "{x}"),
         }
     }
 }
@@ -561,10 +561,10 @@ impl Literal {
     #[must_use]
     pub const fn get_type(&self) -> Type {
         match self {
-            Literal::Int(_) => Type::Int,
-            Literal::Bool(_) => Type::Bool,
+            Self::Int(_) => Type::Int,
+            Self::Bool(_) => Type::Bool,
             #[cfg(feature = "float")]
-            Literal::Float(_) => Type::Float,
+            Self::Float(_) => Type::Float,
         }
     }
 }

--- a/brilck.ts
+++ b/brilck.ts
@@ -318,10 +318,6 @@ function checkOp(env: Env, instr: bril.Operation) {
 }
 
 function checkConst(instr: bril.Constant) {
-  if (!('type' in instr)) {
-    err(`const missing type`, instr.pos);
-    return;
-  }
   if (typeof instr.type !== 'string') {
     err(`const of non-primitive type ${typeFmt(instr.type)}`, instr.pos);
     return;

--- a/brilck.ts
+++ b/brilck.ts
@@ -319,7 +319,7 @@ function checkOp(env: Env, instr: bril.Operation) {
 
 function checkConst(instr: bril.Constant) {
   if (!('type' in instr)) {
-    err(`const missing type`, instr!.pos);
+    err(`const missing type`, instr.pos);
     return;
   }
   if (typeof instr.type !== 'string') {

--- a/brilck.ts
+++ b/brilck.ts
@@ -318,6 +318,11 @@ function checkOp(env: Env, instr: bril.Operation) {
 }
 
 function checkConst(instr: bril.Constant) {
+  if (!(instr as any)) {
+    err(`const missing type`, instr!.pos);
+    return;
+  }
+
   if (typeof instr.type !== 'string') {
     err(`const of non-primitive type ${typeFmt(instr.type)}`, instr.pos);
     return;

--- a/brilirs/src/interp.rs
+++ b/brilirs/src/interp.rs
@@ -481,7 +481,7 @@ fn execute_effect_op<'a, T: std::io::Write>(
     }
     Branch => {
       let bool_arg0 = get_arg::<bool>(&state.env, 0, args);
-      let exit_idx = if bool_arg0 { 0 } else { 1 };
+      let exit_idx = usize::from(!bool_arg0);
       *next_block_idx = Some(curr_block.exit[exit_idx]);
     }
     Return => {


### PR DESCRIPTION
As described in title. I'm particularly happy about the fixing of a false positive in the `use_self` lint.

In doing this, I ran into an error on the typescript side: [error: TS2339 [ERROR]: Property 'pos' does not exist on type 'never'.](https://github.com/sampsyo/bril/commit/8b1c4754e16a7cf0966f5e6f1974b436763b26ea) My understanding is that typescript is saying that this branch is impossible end up in. I'm not sure how to handle this, so after trying a few permutations, I decided to trust the typescript typechecker and just removed the branch. 