### PR TITLE
Tweaks

### DIFF
--- a/bril-rs/bril2json/Cargo.toml
+++ b/bril-rs/bril2json/Cargo.toml
@@ -16,7 +16,7 @@ keywords = ["compiler", "bril", "parser", "data-structures", "language"]
 [dependencies]
 clap         = { version = "4.0", features = ["derive"] }
 lalrpop-util = { version = "0.19", features = ["lexer"] }
-regex = "1.5"
+regex = "1.7"
 
 # Add a build-time dependency on the lalrpop library:
 [build-dependencies]

--- a/bril-rs/bril2json/Cargo.toml
+++ b/bril-rs/bril2json/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["compiler", "bril", "parser", "data-structures", "language"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-clap         = { version = "4.0", features = ["derive"] }
+clap         = { version = "4.1", features = ["derive"] }
 lalrpop-util = { version = "0.19", features = ["lexer"] }
 regex = "1.7"
 

--- a/bril-rs/brild/Cargo.toml
+++ b/bril-rs/brild/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["compiler", "bril", "parser", "data-structures", "language"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-clap         = { version = "4.0", features = ["derive"] }
+clap         = { version = "4.1", features = ["derive"] }
 thiserror    = "1.0"
 
 [dependencies.bril2json]

--- a/bril-rs/rs2bril/Cargo.toml
+++ b/bril-rs/rs2bril/Cargo.toml
@@ -16,7 +16,7 @@ keywords = ["compiler", "bril", "parser", "data-structures", "language"]
 [dependencies]
 syn = {version = "1.0", features = ["full", "extra-traits"]}
 proc-macro2 = {version = "1.0", features = ["span-locations"]}
-clap         = { version = "4.0", features = ["derive"] }
+clap         = { version = "4.1", features = ["derive"] }
 
 [dependencies.bril-rs]
 version = "0.1.0"

--- a/bril-rs/src/abstract_program.rs
+++ b/bril-rs/src/abstract_program.rs
@@ -101,6 +101,7 @@ impl Display for AbstractArgument {
 
 /// <https://capra.cs.cornell.edu/bril/lang/syntax.html#function>
 /// Code is a Label or an Instruction
+#[cfg_attr(not(feature = "float"), derive(Eq))]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 #[serde(untagged)]
 pub enum AbstractCode {
@@ -131,6 +132,7 @@ impl Display for AbstractCode {
 }
 
 /// <https://capra.cs.cornell.edu/bril/lang/syntax.html#instruction>
+#[cfg_attr(not(feature = "float"), derive(Eq))]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 #[serde(untagged)]
 pub enum AbstractInstruction {

--- a/bril-rs/src/lib.rs
+++ b/bril-rs/src/lib.rs
@@ -2,8 +2,6 @@
 #![warn(missing_docs)]
 #![doc = include_str!("../README.md")]
 #![allow(clippy::too_many_lines)]
-// Buggy in that it wants Eq to be derived on Literal which has an f64 field
-#![allow(clippy::derive_partial_eq_without_eq)]
 
 /// Provides the unstructured representation of Bril programs
 pub mod abstract_program;

--- a/bril-rs/src/program.rs
+++ b/bril-rs/src/program.rs
@@ -3,7 +3,8 @@ use std::fmt::{self, Display, Formatter};
 use serde::{Deserialize, Serialize};
 
 /// Equivalent to a file of bril code
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[cfg_attr(not(feature = "float"), derive(Eq))]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct Program {
     /// A list of functions declared in the program
     pub functions: Vec<Function>,
@@ -28,7 +29,7 @@ impl Display for Program {
 
 /// <https://capra.cs.cornell.edu/bril/lang/import.html#syntax>
 #[cfg(feature = "import")]
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct Import {
     /// A list of functions to be imported
     #[serde(skip_serializing_if = "Vec::is_empty")]
@@ -57,7 +58,7 @@ impl Display for Import {
 
 /// <https://capra.cs.cornell.edu/bril/lang/import.html#syntax>
 #[cfg(feature = "import")]
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct ImportedFunction {
     #[serde(skip_serializing_if = "Option::is_none")]
     /// A function can be optionally aliased with a different name for use in the rest of the program
@@ -78,7 +79,8 @@ impl Display for ImportedFunction {
 }
 
 /// <https://capra.cs.cornell.edu/bril/lang/syntax.html#function>
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[cfg_attr(not(feature = "float"), derive(Eq))]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct Function {
     /// Any arguments the function accepts
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -126,7 +128,7 @@ impl Display for Function {
 /// An argument of a function
 /// <https://capra.cs.cornell.edu/bril/lang/syntax.html#function>
 /// Example: a : int
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct Argument {
     /// a
     pub name: String,

--- a/bril-rs/src/program.rs
+++ b/bril-rs/src/program.rs
@@ -143,6 +143,7 @@ impl Display for Argument {
 
 /// <https://capra.cs.cornell.edu/bril/lang/syntax.html#function>
 /// Code is a Label or an Instruction
+#[cfg_attr(not(feature = "float"), derive(Eq))]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 #[serde(untagged)]
 pub enum Code {
@@ -173,6 +174,7 @@ impl Display for Code {
 }
 
 /// <https://capra.cs.cornell.edu/bril/lang/syntax.html#instruction>
+#[cfg_attr(not(feature = "float"), derive(Eq))]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 #[serde(untagged)]
 pub enum Instruction {
@@ -533,6 +535,7 @@ impl Display for Type {
 }
 
 /// A JSON number/value
+#[cfg_attr(not(feature = "float"), derive(Eq))]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 #[serde(untagged)]
 pub enum Literal {

--- a/brilirs/Cargo.toml
+++ b/brilirs/Cargo.toml
@@ -37,3 +37,6 @@ path         = "../bril-rs/bril2json"
 # codegen-units = 1
 lto = true
 panic = "abort"
+
+[features]
+completions = []

--- a/brilirs/Cargo.toml
+++ b/brilirs/Cargo.toml
@@ -13,12 +13,12 @@ keywords = ["compiler", "bril", "interpreter", "data-structures", "language"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [build-dependencies]
-clap         = { version = "4.0", features = ["derive"] }
-clap_complete= "4.0"
+clap         = { version = "4.1", features = ["derive"] }
+clap_complete= "4.1"
 
 [dependencies]
 thiserror    = "1.0"
-clap         = { version = "4.0", features = ["derive"] }
+clap         = { version = "4.1", features = ["derive"] }
 fxhash       = "0.2"
 mimalloc     = "0.1"
 itoa         = "1.0"

--- a/brilirs/build.rs
+++ b/brilirs/build.rs
@@ -1,16 +1,25 @@
 // https://kbknapp.dev/shell-completions/
 
-use clap::CommandFactory;
-use clap_complete::{
-  shells::{Bash, Elvish, Fish, PowerShell, Zsh},
-  Generator,
-};
 use std::io::Error;
-use std::{env, path::PathBuf};
 
+#[cfg(feature = "completions")]
 include!("src/cli.rs");
 
 fn main() -> Result<(), Error> {
+  #[cfg(feature = "completions")]
+  create_cli_completions()?;
+
+  Ok(())
+}
+
+#[cfg(feature = "completions")]
+fn create_cli_completions() -> Result<(), Error> {
+  use clap::CommandFactory;
+  use clap_complete::{
+    shells::{Bash, Elvish, Fish, PowerShell, Zsh},
+    Generator,
+  };
+  use std::{env, path::PathBuf};
   // Waiting on https://github.com/rust-lang/cargo/issues/5457 / https://github.com/rust-lang/cargo/issues/6790 to clean this up
   let out_dir = match env::var_os("OUT_DIR") {
     None => {


### PR DESCRIPTION
Just some small tweaks
- Up crate versions for clap and regex
- Feature gate brilirs shell completions. I think these are really cool, but they are a bit finicky(especially being located in the build script) so I've hidden this behind a feature flag for those who want it.
- Derive `PartialEq` and `Eq` when possible on the rest of `bril-rs` structs