### PR TITLE
Update some GitHub Action versions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -18,7 +18,7 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-            python-version: '3.10'
+            python-version: '3.11'
             cache: pip
             cache-dependency-path: bril-txt/pyproject.toml
 
@@ -59,7 +59,7 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-            python-version: '3.10'
+            python-version: '3.11'
             cache: pip
             cache-dependency-path: bril-txt/pyproject.toml
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,6 +20,7 @@ jobs:
         with:
             python-version: '3.10'
             cache: pip
+            cache-dependency-path: bril-txt/pyproject.toml
 
       - name: TypeScript check
         run: deno check brili.ts brilck.ts ts2bril.ts
@@ -60,6 +61,7 @@ jobs:
         with:
             python-version: '3.10'
             cache: pip
+            cache-dependency-path: bril-txt/pyproject.toml
 
       - name: Install brilck
         run: deno install brilck.ts

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,19 +10,16 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: denoland/setup-deno@v1
         with:
           deno-version: v1.x
 
-      - uses: actions/cache@v2
-        with:
-            path: ~/.cache/pip
-            key: ${{ runner.os }}-pip
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
             python-version: '3.10'
+            cache: pip
 
       - name: TypeScript check
         run: deno check brili.ts brilck.ts ts2bril.ts
@@ -37,7 +34,7 @@ jobs:
 
       - name: Install Turnt
         # run: pip install turnt  # Use instead if pip turnt version >= 1.7
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: cucapra/turnt
           path: './turnt'
@@ -53,19 +50,16 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: denoland/setup-deno@v1
         with:
           deno-version: v1.x
 
-      - uses: actions/cache@v2
-        with:
-            path: ~/.cache/pip
-            key: ${{ runner.os }}-pip
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
             python-version: '3.10'
+            cache: pip
 
       - name: Install brilck
         run: deno install brilck.ts
@@ -83,7 +77,7 @@ jobs:
   style:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: TrueBrain/actions-flake8@master
         with:
           path: bril-txt

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -10,7 +10,7 @@ jobs:
   docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup mdBook
         uses: peaceiris/actions-mdbook@v1
         with:

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -58,6 +58,7 @@ jobs:
         with:
             python-version: '3.10'
             cache: pip
+            cache-dependency-path: bril-txt/pyproject.toml
 
       - name: Install Flit
         run: pip install flit

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -39,7 +39,7 @@ jobs:
           - "cd brilift && cargo build --release && make rt.o && make test TURNTARGS=-v"
           - "cd brilift && cargo build --release && make rt.o && make benchmark TURNTARGS=-v"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
@@ -54,13 +54,10 @@ jobs:
           # One can use the tool cache if compiling this takes to long. Using prebuilt binaries is a security concern... but I guess so is compiling/running code from the internet.
           #use-tool-cache: true
 
-      - uses: actions/cache@v2
-        with:
-            path: ~/.cache/pip
-            key: ${{ runner.os }}-pip
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
             python-version: '3.10'
+            cache: pip
 
       - name: Install Flit
         run: pip install flit
@@ -69,7 +66,7 @@ jobs:
 
       - name: Install Turnt
         # run: pip install turnt  # Use instead if pip turnt version >= 1.7
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: cucapra/turnt
           path: './turnt'
@@ -91,7 +88,7 @@ jobs:
       matrix:
         path: ["brilirs/Cargo.toml", "bril-rs/Cargo.toml", "bril-rs/bril2json/Cargo.toml", "bril-rs/brild/Cargo.toml", "brilift/Cargo.toml", "bril-rs/rs2bril/Cargo.toml"]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -56,7 +56,7 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-            python-version: '3.10'
+            python-version: '3.11'
             cache: pip
             cache-dependency-path: bril-txt/pyproject.toml
 


### PR DESCRIPTION
Some old stuff is deprecated (mostly because the old actions were on Node 12).