### PR TITLE
small clippy lint for Rust 1.68

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -43,7 +43,9 @@ jobs:
       - uses: dtolnay/rust-toolchain@v1
         with:
           toolchain: stable
-          components: cargo-hack
+
+      - name: Install cargo-hack for feature-flag checking
+        run: cargo install cargo-hack
 
       - uses: actions/setup-python@v4
         with:

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -40,19 +40,10 @@ jobs:
           - "cd brilift && cargo build --release && make rt.o && make benchmark TURNTARGS=-v"
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@v1
         with:
-          profile: minimal
           toolchain: stable
-          override: true
-
-      # This is for checking the powerset of bril-rs features compiles
-      - uses: actions-rs/install@v0.1
-        with:
-          crate: cargo-hack
-          version: latest
-          # One can use the tool cache if compiling this takes to long. Using prebuilt binaries is a security concern... but I guess so is compiling/running code from the internet.
-          #use-tool-cache: true
+          components: cargo-hack
 
       - uses: actions/setup-python@v4
         with:
@@ -90,29 +81,19 @@ jobs:
         path: ["brilirs/Cargo.toml", "bril-rs/Cargo.toml", "bril-rs/bril2json/Cargo.toml", "bril-rs/brild/Cargo.toml", "brilift/Cargo.toml", "bril-rs/rs2bril/Cargo.toml"]
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@v1
         with:
-          profile: minimal
           toolchain: stable
-          override: true
           components: rustfmt, clippy
 
-      - uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --manifest-path ${{ matrix.path }} --all-targets
+      - name: cargo check
+        run: cargo check --manifest-path ${{ matrix.path }} --all-targets
 
-      - uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --manifest-path ${{ matrix.path }} --all -- --check
+      - name: cargo fmt
+        run: cargo fmt --manifest-path ${{ matrix.path }} --all -- --check
 
-      - uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --manifest-path ${{ matrix.path }}
+      - name: cargo clippy
+        run: cargo clippy --manifest-path ${{ matrix.path }}
 
-      - uses: actions-rs/cargo@v1
-        with:
-          command: doc
-          args: --manifest-path ${{ matrix.path }}
+      - name: cargo doc
+        run: cargo doc --manifest-path ${{ matrix.path }}

--- a/bril-rs/brild/src/lib.rs
+++ b/bril-rs/brild/src/lib.rs
@@ -27,7 +27,6 @@ fn mangle_name(path: &Path, func_name: &String) -> String {
     parts.next();
 
     let mut p: Vec<_> = parts
-        .into_iter()
         .map(|c| {
             c.as_os_str().to_str().expect(
                 "Panics if the path does not contain valid unicode which I'm not worried about",


### PR DESCRIPTION
Only a small change for the new Rust release.

I'll note that there is an additional future-incompat warning that we hit because of the current version of lalrpop. https://github.com/rust-lang/rust/pull/103418/ https://github.com/lalrpop/lalrpop/issues/701 

In one sense, it's kind of a non-issue because it doesn't hold up the ci and I think this can only become a hard error over an edition change. On the other hand, it's a little disconcerting if lalrpop isn't getting much attention from the maintainers these days.

I would expect that a (new?) maintainer will arise who can cut a new lalrpop release which will resolve this issue. Otherwise this could motivate a switch in parsers.