### PR TITLE
cfg_dot.py: add quotes around labels when needed

### DIFF
--- a/examples/cfg_dot.py
+++ b/examples/cfg_dot.py
@@ -7,7 +7,6 @@ import json
 import sys
 from cfg import block_map, successors, add_terminators
 
-
 def cfg_dot(bril, verbose):
     """Generate a GraphViz "dot" file showing the control flow graph for
     a Bril program.
@@ -27,7 +26,7 @@ def cfg_dot(bril, verbose):
             if verbose:
                 import briltxt
                 print(r'  {} [shape=box, xlabel="{}", label="{}\l"];'.format(
-                    name,
+                    quote_if_needed(name),
                     name,
                     r'\l'.join(briltxt.instr_to_string(i) for i in block),
                 ))
@@ -38,10 +37,14 @@ def cfg_dot(bril, verbose):
         for i, (name, block) in enumerate(blocks.items()):
             succ = successors(block[-1])
             for label in succ:
-                print('  {} -> {};'.format(name, label))
+                print('  {} -> {};'.format(quote_if_needed(name), quote_if_needed(label)))
 
         print('}')
 
+def quote_if_needed(s):
+    if s.isalnum():
+        return s
+    return '"' + s + '"'
 
 if __name__ == '__main__':
     cfg_dot(json.load(sys.stdin), '-v' in sys.argv[1:])


### PR DESCRIPTION
I was looking at the CFG graph for the `ts2bril` output (`ts2bril test/ts/factorial.ts | python3 examples/cfg_dot.py -v`) and was surprised by the [strange output](https://dreampuf.github.io/GraphvizOnline/#digraph%20fac%20%7B%0A%20%20b1%20%5Bshape%3Dbox%2C%20xlabel%3D%22b1%22%2C%20label%3D%22v1%3A%20int%20%3D%20id%20x%5Clv2%3A%20int%20%3D%20const%201%5Clv3%3A%20bool%20%3D%20le%20v1%20v2%5Clbr%20v3%20.then.0%20.else.0%5Cl%22%5D%3B%0A%20%20then.0%20%5Bshape%3Dbox%2C%20xlabel%3D%22then.0%22%2C%20label%3D%22v4%3A%20int%20%3D%20const%201%5Clret%20v4%5Cl%22%5D%3B%0A%20%20b2%20%5Bshape%3Dbox%2C%20xlabel%3D%22b2%22%2C%20label%3D%22jmp%20.endif.0%5Cl%22%5D%3B%0A%20%20else.0%20%5Bshape%3Dbox%2C%20xlabel%3D%22else.0%22%2C%20label%3D%22jmp%20.endif.0%5Cl%22%5D%3B%0A%20%20endif.0%20%5Bshape%3Dbox%2C%20xlabel%3D%22endif.0%22%2C%20label%3D%22v5%3A%20int%20%3D%20id%20x%5Clv6%3A%20int%20%3D%20id%20x%5Clv7%3A%20int%20%3D%20const%201%5Clv8%3A%20int%20%3D%20sub%20v6%20v7%5Clv9%3A%20int%20%3D%20call%20%40fac%20v8%5Clv10%3A%20int%20%3D%20mul%20v5%20v9%5Clresult%3A%20int%20%3D%20id%20v10%5Clv11%3A%20int%20%3D%20id%20result%5Clret%20v11%5Cl%22%5D%3B%0A%20%20b1%20-%3E%20then.0%3B%0A%20%20b1%20-%3E%20else.0%3B%0A%20%20b2%20-%3E%20endif.0%3B%0A%20%20else.0%20-%3E%20endif.0%3B%0A%7D):

![graphviz](https://user-images.githubusercontent.com/794591/233431259-f97d735b-f491-4567-9365-45cb48c9d883.png)

Turns out in DOT language labels containing `.` characters need to be quoted for the [proper output](https://dreampuf.github.io/GraphvizOnline/#digraph%20fac%20%7B%0A%20%20b1%20%5Bshape%3Dbox%2C%20xlabel%3D%22b1%22%2C%20label%3D%22v1%3A%20int%20%3D%20id%20x%5Clv2%3A%20int%20%3D%20const%201%5Clv3%3A%20bool%20%3D%20le%20v1%20v2%5Clbr%20v3%20.then.0%20.else.0%5Cl%22%5D%3B%0A%20%20%22then.0%22%20%5Bshape%3Dbox%2C%20xlabel%3D%22then.0%22%2C%20label%3D%22v4%3A%20int%20%3D%20const%201%5Clret%20v4%5Cl%22%5D%3B%0A%20%20b2%20%5Bshape%3Dbox%2C%20xlabel%3D%22b2%22%2C%20label%3D%22jmp%20.endif.0%5Cl%22%5D%3B%0A%20%20%22else.0%22%20%5Bshape%3Dbox%2C%20xlabel%3D%22else.0%22%2C%20label%3D%22jmp%20.endif.0%5Cl%22%5D%3B%0A%20%20%22endif.0%22%20%5Bshape%3Dbox%2C%20xlabel%3D%22endif.0%22%2C%20label%3D%22v5%3A%20int%20%3D%20id%20x%5Clv6%3A%20int%20%3D%20id%20x%5Clv7%3A%20int%20%3D%20const%201%5Clv8%3A%20int%20%3D%20sub%20v6%20v7%5Clv9%3A%20int%20%3D%20call%20%40fac%20v8%5Clv10%3A%20int%20%3D%20mul%20v5%20v9%5Clresult%3A%20int%20%3D%20id%20v10%5Clv11%3A%20int%20%3D%20id%20result%5Clret%20v11%5Cl%22%5D%3B%0A%20%20b1%20-%3E%20%22then.0%22%3B%0A%20%20b1%20-%3E%20%22else.0%22%3B%0A%20%20b2%20-%3E%20%22endif.0%22%3B%0A%20%20%22else.0%22%20-%3E%20%22endif.0%22%3B%0A%7D):

![graphviz-2](https://user-images.githubusercontent.com/794591/233431571-5752b62b-69e9-43e5-b25a-cfea1d247d8f.png)
