### PR TITLE
[ts2bril] Recognize top level code below function definitions as main function

### DIFF
--- a/bril-ts/builder.ts
+++ b/bril-ts/builder.ts
@@ -134,4 +134,8 @@ export class Builder {
     this.nextFresh += 1;
     return out;
   }
+
+  setCurrentFunction(func: bril.Function) {
+    this.curFunction = func;
+  }
 }

--- a/test/ts/main.out
+++ b/test/ts/main.out
@@ -1,0 +1,11 @@
+@main {
+  v: int = call @getThree;
+  v: int = id v;
+  v1: int = id v;
+  print v1;
+  v2: int = const 0;
+}
+@getThree: int {
+  v0: int = const 3;
+  ret v0;
+}

--- a/test/ts/main.ts
+++ b/test/ts/main.ts
@@ -1,0 +1,6 @@
+function getThree(): bigint {
+    return 3n;
+}
+
+var v = getThree();
+console.log(v);

--- a/ts2bril.ts
+++ b/ts2bril.ts
@@ -48,7 +48,7 @@ function brilType(node: ts.Node, checker: ts.TypeChecker): bril.Type {
  */
 function emitBril(prog: ts.Node, checker: ts.TypeChecker): bril.Program {
   let builder = new Builder();
-  builder.buildFunction("main", []);  // Main has no return type.
+  let mainFn = builder.buildFunction("main", []);  // Main has no return type.
 
   function emitExpr(expr: ts.Expression): bril.ValueInstruction {
     switch (expr.kind) {
@@ -278,6 +278,7 @@ function emitBril(prog: ts.Node, checker: ts.TypeChecker): bril.Program {
         if (funcDef.body) {
           emit(funcDef.body);
         }
+        builder.setCurrentFunction(mainFn);
         break;
 
       case ts.SyntaxKind.ReturnStatement: {


### PR DESCRIPTION
Previously top-level instructions were incorrectly added to function above, resulting in an empty main function.

```ts
function getThree(): bigint {
    return 3n;
}

var v = getThree();
console.log(v);
```

```
@main {
}
@getThree: int {
  v0: int = const 3;
  ret v0;
  v: int = call @getThree;
  v: int = id v;
  v1: int = id v;
  print v1;
  v2: int = const 0;
}
```