### PR TITLE
Bump Rust dependencies

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -95,7 +95,7 @@ jobs:
         run: cargo fmt --manifest-path ${{ matrix.path }} --all -- --check
 
       - name: cargo clippy
-        run: cargo clippy --manifest-path ${{ matrix.path }}
+        run: cargo clippy --manifest-path ${{ matrix.path }} --all-targets
 
       - name: cargo doc
-        run: cargo doc --manifest-path ${{ matrix.path }}
+        run: cargo doc --manifest-path ${{ matrix.path }} --all

--- a/bril-rs/bril2json/Cargo.toml
+++ b/bril-rs/bril2json/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["compiler", "bril", "parser", "data-structures", "language"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-clap         = { version = "4.1", features = ["derive"] }
+clap         = { version = "4.2", features = ["derive"] }
 lalrpop-util = { version = "0.19", features = ["lexer"] }
 regex = "1.7"
 

--- a/bril-rs/brild/Cargo.toml
+++ b/bril-rs/brild/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["compiler", "bril", "parser", "data-structures", "language"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-clap         = { version = "4.1", features = ["derive"] }
+clap         = { version = "4.2", features = ["derive"] }
 thiserror    = "1.0"
 
 [dependencies.bril2json]

--- a/bril-rs/rs2bril/Cargo.toml
+++ b/bril-rs/rs2bril/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["compiler", "bril", "parser", "data-structures", "language"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-syn = {version = "1.0", features = ["full", "extra-traits"]}
+syn = {version = "2.0", features = ["full", "extra-traits"]}
 proc-macro2 = {version = "1.0", features = ["span-locations"]}
 clap         = { version = "4.1", features = ["derive"] }
 

--- a/bril-rs/rs2bril/Cargo.toml
+++ b/bril-rs/rs2bril/Cargo.toml
@@ -16,7 +16,7 @@ keywords = ["compiler", "bril", "parser", "data-structures", "language"]
 [dependencies]
 syn = {version = "2.0", features = ["full", "extra-traits"]}
 proc-macro2 = {version = "1.0", features = ["span-locations"]}
-clap         = { version = "4.1", features = ["derive"] }
+clap         = { version = "4.2", features = ["derive"] }
 
 [dependencies.bril-rs]
 version = "0.1.0"

--- a/bril-rs/rs2bril/README.md
+++ b/bril-rs/rs2bril/README.md
@@ -6,14 +6,14 @@ View the interface with `cargo doc --open` or install with `make install` using 
 
 ## Limitations
 
-- Currently types are not inferred for variable declarations so all let bindings must be explicitly annotated: `let x:i64 = 5;`
-- The `println!` macro is special cased to be converted into a `print` call in Bril. It takes a valid `println!` call, ignores the first argument which it assumes to be a format string, and assumes all of the following comma separated arguments are variables: `println!("this is ignored{}", these, must, be, variables);`
+- Currently, types are not inferred for variable declarations so all let bindings must be explicitly annotated: `let x:i64 = 5;`
+- The `println!` macro is special cased to be converted into a `print` call in Bril. It takes a valid `println!` call, ignores the first argument which it assumes to be a format string, and assumes all of the following comma-separated arguments are variables: `println!("this is ignored{}", these, must, be, variables);`
 - There currently isn't a way to pass arguments to the main function that is also valid Rust. You can either declare arguments in the main function such that it is no longer valid Rust but will generate the correct Bril code, or declared them as const values in the first line and edit the Bril IR later: `fn main(a:i64) {}` or `fn main() {let a:i64 = 0;}`
 - Automatic static memory management <https://www.cs.cornell.edu/courses/cs6120/2020fa/blog/asmm/> has not been implemented so arrays must be explicitly dropped where `drop` is specialized to translate to a call to free: `drop([0]);`
 - For loops, `continue`, `break`, and ranges have not been implemented(but could be).
-- Memory is implemented using Rust arrays. These are statically sized values unlike how calls to Bril `alloc` can be dynamically sized. One solution is to just allocate a large enough array and then treat the dynamic size like the length.(A subset of vectors could also be specialized in the future).
-- In normal Rust, `if` can also be used as an expression which evaluates a value to be put in a variable. This is not implemented and it is assumed that there will only be if statements.
-- The Bril code that is produces is super inefficient and it is left to other tools to optimize it. Array initialization is unrolled is not an optimal solution.
+- Memory is implemented using Rust arrays. These are statically sized values unlike how calls to Bril `alloc` can be dynamically sized. One solution is to just allocate a large enough array and then treat the dynamic size like the length. (A subset of vectors could also be specialized in the future).
+- In normal Rust, `if` can also be used as an expression that evaluates a value to be put in a variable. This is not implemented and it is assumed that there will only be if statements.
+- The Bril code that it produces is super inefficient and it is left to other tools to optimize it. Array initialization is unrolled is not an optimal solution.
 - `!=` and automatic promotions of integer literals to floats are not implemented.
 - to support indexing into arrays, you can cast to usize in the Rust code. This will be ignored when generating Bril. `arr[i as usize];`
 - The parts of Rust which make it valid like lifetimes, references, mutability, and function visibility are ignored and compiled away in Bril.

--- a/bril-rs/rs2bril/src/lib.rs
+++ b/bril-rs/rs2bril/src/lib.rs
@@ -3,8 +3,6 @@
 #![doc = include_str!("../README.md")]
 #![allow(clippy::too_many_lines)]
 #![allow(clippy::cognitive_complexity)]
-// Clap seemingly pulls in two different versions of `bitflags: 1.3.2, 2.0.2`
-#![allow(clippy::multiple_crate_versions)]
 
 #[doc(hidden)]
 pub mod cli;

--- a/bril-rs/rs2bril/src/lib.rs
+++ b/bril-rs/rs2bril/src/lib.rs
@@ -3,6 +3,8 @@
 #![doc = include_str!("../README.md")]
 #![allow(clippy::too_many_lines)]
 #![allow(clippy::cognitive_complexity)]
+// Clap seemingly pulls in two different versions of `bitflags: 1.3.2, 2.0.2`
+#![allow(clippy::multiple_crate_versions)]
 
 #[doc(hidden)]
 pub mod cli;
@@ -12,13 +14,12 @@ use bril_rs::{
     Type, ValueOps,
 };
 
-use syn::punctuated::Punctuated;
 use syn::{
-    BinOp, Block, Expr, ExprArray, ExprAssign, ExprAssignOp, ExprBinary, ExprBlock, ExprCall,
-    ExprCast, ExprIf, ExprIndex, ExprLet, ExprLit, ExprLoop, ExprMacro, ExprParen, ExprPath,
-    ExprReference, ExprRepeat, ExprReturn, ExprUnary, ExprWhile, File, FnArg, Ident, Item, ItemFn,
-    Lit, Local, Macro, Pat, PatIdent, PatType, Path, PathSegment, ReturnType, Signature, Stmt,
-    Type as SType, TypeArray, TypePath, TypeReference, TypeSlice, UnOp,
+    BinOp, Block, Expr, ExprArray, ExprAssign, ExprBinary, ExprBlock, ExprCall, ExprCast, ExprIf,
+    ExprIndex, ExprLet, ExprLit, ExprLoop, ExprMacro, ExprParen, ExprPath, ExprReference,
+    ExprRepeat, ExprReturn, ExprUnary, ExprWhile, File, FnArg, Item, ItemFn, Lit, Local, Macro,
+    Pat, PatIdent, PatType, Path, ReturnType, Signature, Stmt, StmtMacro, Type as SType, TypeArray,
+    TypePath, TypeReference, TypeSlice, UnOp,
 };
 
 use proc_macro2::Span;
@@ -79,6 +80,7 @@ impl State {
     }
 }
 
+// A helper to get the span of any given Rust expression
 fn from_expr_to_span(expr: &Expr) -> Span {
     match expr {
         Expr::Array(ExprArray {
@@ -92,17 +94,11 @@ fn from_expr_to_span(expr: &Expr) -> Span {
             expr: _,
             semi_token: _,
             len: _,
-        }) => bracket_token.span,
+        }) => bracket_token.span.join(),
         Expr::Assign(ExprAssign {
             attrs: _,
             left,
             eq_token: _,
-            right,
-        })
-        | Expr::AssignOp(ExprAssignOp {
-            attrs: _,
-            left,
-            op: _,
             right,
         })
         | Expr::Binary(ExprBinary {
@@ -117,13 +113,15 @@ fn from_expr_to_span(expr: &Expr) -> Span {
             attrs: _,
             label: _,
             block,
-        }) => block.brace_token.span,
+        }) => block.brace_token.span.join(),
         Expr::Call(ExprCall {
             attrs: _,
             func,
             paren_token,
             args: _,
-        }) => from_expr_to_span(func).join(paren_token.span).unwrap(),
+        }) => from_expr_to_span(func)
+            .join(paren_token.span.join())
+            .unwrap(),
         Expr::Cast(ExprCast {
             attrs: _,
             expr,
@@ -133,7 +131,6 @@ fn from_expr_to_span(expr: &Expr) -> Span {
         | Expr::Reference(ExprReference {
             attrs: _,
             and_token: _,
-            raw: _,
             mutability: _,
             expr,
         }) => from_expr_to_span(expr),
@@ -150,13 +147,18 @@ fn from_expr_to_span(expr: &Expr) -> Span {
             cond: _,
             then_branch,
             else_branch: None,
-        }) => if_token.span.join(then_branch.brace_token.span).unwrap(),
+        }) => if_token
+            .span
+            .join(then_branch.brace_token.span.join())
+            .unwrap(),
         Expr::Index(ExprIndex {
             attrs: _,
             expr,
             bracket_token,
             index: _,
-        }) => from_expr_to_span(expr).join(bracket_token.span).unwrap(),
+        }) => from_expr_to_span(expr)
+            .join(bracket_token.span.join())
+            .unwrap(),
         Expr::Let(ExprLet {
             attrs: _,
             let_token,
@@ -170,7 +172,7 @@ fn from_expr_to_span(expr: &Expr) -> Span {
             label: _,
             loop_token,
             body,
-        }) => loop_token.span.join(body.brace_token.span).unwrap(),
+        }) => loop_token.span.join(body.brace_token.span.join()).unwrap(),
         Expr::Macro(ExprMacro {
             attrs: _,
             mac:
@@ -183,16 +185,16 @@ fn from_expr_to_span(expr: &Expr) -> Span {
         }) => bang_token
             .span
             .join(match delimiter {
-                syn::MacroDelimiter::Paren(p) => p.span,
-                syn::MacroDelimiter::Brace(b) => b.span,
-                syn::MacroDelimiter::Bracket(b) => b.span,
+                syn::MacroDelimiter::Paren(p) => p.span.join(),
+                syn::MacroDelimiter::Brace(b) => b.span.join(),
+                syn::MacroDelimiter::Bracket(b) => b.span.join(),
             })
             .unwrap(),
         Expr::Paren(ExprParen {
             attrs: _,
             paren_token,
             expr: _,
-        }) => paren_token.span,
+        }) => paren_token.span.join(),
         Expr::Path(ExprPath {
             attrs: _,
             qself: _,
@@ -221,6 +223,7 @@ fn from_expr_to_span(expr: &Expr) -> Span {
             UnOp::Deref(d) => d.span,
             UnOp::Not(n) => n.span,
             UnOp::Neg(n) => n.span,
+            _ => unimplemented!("Non-exhaustive"),
         }
         .join(from_expr_to_span(expr))
         .unwrap(),
@@ -230,11 +233,12 @@ fn from_expr_to_span(expr: &Expr) -> Span {
             while_token,
             cond: _,
             body,
-        }) => while_token.span.join(body.brace_token.span).unwrap(),
+        }) => while_token.span.join(body.brace_token.span.join()).unwrap(),
         _ => todo!(),
     }
 }
 
+// A helper for converting Syn Span to Bril Position
 fn from_span_to_position(
     starting_span: Span,
     ending_span: Option<Span>,
@@ -278,6 +282,7 @@ fn from_pat_to_string(pat: Pat) -> String {
     }
 }
 
+// A helper for converting Syn Type to Bril Type
 fn from_type_to_type(ty: SType) -> Type {
     match ty {
         SType::Array(TypeArray { elem, .. }) | SType::Slice(TypeSlice { elem, .. }) => {
@@ -296,6 +301,7 @@ fn from_type_to_type(ty: SType) -> Type {
     }
 }
 
+// A helper for converting Syn function arguments to Bril Argument
 fn from_fnarg_to_argument(f: FnArg, state: &mut State) -> Argument {
     match f {
         FnArg::Receiver(_) => panic!("can't handle self in function arguments"),
@@ -376,7 +382,7 @@ fn from_signature_to_function(
         pos: if state.is_pos {
             Some(from_span_to_position(
                 fn_token.span,
-                Some(paren_token.span),
+                Some(paren_token.span.join()),
                 state.src.clone(),
             ))
         } else {
@@ -528,53 +534,6 @@ fn from_expr_to_bril(expr: Expr, state: &mut State) -> (Option<String>, Vec<Code
                 _ => panic!("can't handle left hand assignment: {left:?}"),
             }
         }
-        Expr::AssignOp(ExprAssignOp {
-            attrs,
-            left,
-            op,
-            right,
-        }) if attrs.is_empty() => {
-            let (assign_arg, mut assign_code) = from_expr_to_bril(*left, state);
-            let mut segments = Punctuated::new();
-            segments.push(PathSegment::from(Ident::new(
-                assign_arg.clone().unwrap().as_str(),
-                Span::call_site(), // This probably makes no sense actually. But I'm not sure where to get the span yet
-            )));
-            let (arg, mut code) = from_expr_to_bril(
-                Expr::Binary(ExprBinary {
-                    attrs: Vec::new(),
-                    left: Box::new(Expr::Path(ExprPath {
-                        attrs: Vec::new(),
-                        qself: None,
-                        path: Path {
-                            leading_colon: None,
-                            segments,
-                        },
-                    })),
-                    op: match op {
-                        BinOp::AddEq(x) => BinOp::Add(syn::Token![+](x.spans[0])),
-                        BinOp::SubEq(x) => BinOp::Sub(syn::Token![-](x.spans[0])),
-                        BinOp::MulEq(x) => BinOp::Mul(syn::Token![*](x.spans[0])),
-                        BinOp::DivEq(x) => BinOp::Div(syn::Token![/](x.spans[0])),
-                        _ => panic!("can't handle Assignment Op {op:?}"),
-                    },
-                    right,
-                }),
-                state,
-            );
-            let op_type = state.get_type_for_ident(arg.as_ref().unwrap());
-            assign_code.append(&mut code);
-            assign_code.push(Code::Instruction(Instruction::Value {
-                args: vec![arg.unwrap()],
-                dest: assign_arg.unwrap(),
-                funcs: Vec::new(),
-                labels: Vec::new(),
-                op: ValueOps::Id,
-                pos,
-                op_type,
-            }));
-            (None, assign_code)
-        }
         Expr::Binary(ExprBinary {
             attrs,
             left,
@@ -584,6 +543,8 @@ fn from_expr_to_bril(expr: Expr, state: &mut State) -> (Option<String>, Vec<Code
             let (arg1, mut code1) = from_expr_to_bril(*left, state);
             let (arg2, mut code2) = from_expr_to_bril(*right, state);
             code1.append(&mut code2);
+
+            let mut place_expression = None;
 
             let (value_op, op_type) = match (op, state.get_type_for_ident(arg1.as_ref().unwrap())) {
                 (BinOp::Add(_), Type::Int) => (ValueOps::Add, Type::Int),
@@ -606,10 +567,46 @@ fn from_expr_to_bril(expr: Expr, state: &mut State) -> (Option<String>, Vec<Code
                 (BinOp::Ge(_), Type::Float) => (ValueOps::Fge, Type::Bool),
                 (BinOp::Gt(_), Type::Int) => (ValueOps::Gt, Type::Bool),
                 (BinOp::Gt(_), Type::Float) => (ValueOps::Fgt, Type::Bool),
+
+                // For the assignment operations, the left hand side is being mutated and is restricted to being a rust "place expression"
+                // So we need to set a specific destination
+                // https://doc.rust-lang.org/reference/expressions.html#place-expressions-and-value-expressions
+                (BinOp::AddAssign(_), Type::Int) => {
+                    place_expression = arg1.clone();
+                    (ValueOps::Add, Type::Int)
+                }
+                (BinOp::AddAssign(_), Type::Float) => {
+                    place_expression = arg1.clone();
+                    (ValueOps::Fadd, Type::Float)
+                }
+                (BinOp::SubAssign(_), Type::Int) => {
+                    place_expression = arg1.clone();
+                    (ValueOps::Sub, Type::Int)
+                }
+                (BinOp::SubAssign(_), Type::Float) => {
+                    place_expression = arg1.clone();
+                    (ValueOps::Fsub, Type::Float)
+                }
+                (BinOp::MulAssign(_), Type::Int) => {
+                    place_expression = arg1.clone();
+                    (ValueOps::Mul, Type::Int)
+                }
+                (BinOp::MulAssign(_), Type::Float) => {
+                    place_expression = arg1.clone();
+                    (ValueOps::Fmul, Type::Float)
+                }
+                (BinOp::DivAssign(_), Type::Int) => {
+                    place_expression = arg1.clone();
+                    (ValueOps::Div, Type::Int)
+                }
+                (BinOp::DivAssign(_), Type::Float) => {
+                    place_expression = arg1.clone();
+                    (ValueOps::Fdiv, Type::Float)
+                }
                 (_, _) => unimplemented!("{op:?}"),
             };
 
-            let dest = state.fresh_var(op_type.clone());
+            let dest = place_expression.unwrap_or_else(|| state.fresh_var(op_type.clone()));
 
             code1.push(Code::Instruction(Instruction::Value {
                 args: vec![arg1.unwrap(), arg2.unwrap()],
@@ -893,7 +890,6 @@ fn from_expr_to_bril(expr: Expr, state: &mut State) -> (Option<String>, Vec<Code
         Expr::Reference(ExprReference {
             attrs,
             and_token: _,
-            raw: _,
             mutability: _,
             expr,
         }) if attrs.is_empty() => from_expr_to_bril(*expr, state),
@@ -979,6 +975,7 @@ fn from_expr_to_bril(expr: Expr, state: &mut State) -> (Option<String>, Vec<Code
                         ty,
                     )
                 }
+                _ => unimplemented!("Non-exhaustive"),
             };
 
             let dest = state.fresh_var(op_type.clone());
@@ -1064,7 +1061,7 @@ fn from_stmt_to_vec_code(s: Stmt, state: &mut State) -> Vec<Code> {
                     let op_type = from_type_to_type(*ty);
                     let dest = from_pat_to_string(*pat);
                     state.add_type_for_ident(dest.clone(), op_type.clone());
-                    let (_, expr) = init.unwrap();
+                    let expr = init.unwrap().expr;
                     let (arg, mut code) = from_expr_to_bril(*expr, state);
                     code.push(Code::Instruction(Instruction::Value {
                         args: vec![arg.unwrap()],
@@ -1092,8 +1089,18 @@ fn from_stmt_to_vec_code(s: Stmt, state: &mut State) -> Vec<Code> {
                 p => panic!("can't handle pattern in let: {p:?}"),
             }
         }
-        Stmt::Expr(e) | Stmt::Semi(e, _) => {
+        Stmt::Expr(e, _) => {
             let (_, code) = from_expr_to_bril(e, state);
+            code
+        }
+        Stmt::Macro(StmtMacro {
+            attrs,
+            mac,
+            semi_token: _,
+        }) => {
+            // Currently the only supported macro is println?
+            // So we just dispatch StmtMacro as an ExprMacro
+            let (_, code) = from_expr_to_bril(Expr::Macro(ExprMacro { attrs, mac }), state);
             code
         }
     }

--- a/bril-rs/src/conversion.rs
+++ b/bril-rs/src/conversion.rs
@@ -189,7 +189,7 @@ impl TryFrom<AbstractInstruction> for Instruction {
                     .map_err(|e: ConversionError| e.add_pos(pos.clone()))?,
                 value,
                 #[cfg(feature = "position")]
-                pos: pos,
+                pos,
             },
             AbstractInstruction::Value {
                 args,

--- a/bril-rs/src/program.rs
+++ b/bril-rs/src/program.rs
@@ -75,7 +75,7 @@ impl Display for ImportedFunction {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.name)?;
         if let Some(a) = self.alias.as_ref() {
-            write!(f, " as {}", a)?;
+            write!(f, " as {a}")?;
         }
         Ok(())
     }
@@ -248,9 +248,9 @@ impl Instruction {
     #[must_use]
     pub fn get_pos(&self) -> Option<Position> {
         match self {
-            Instruction::Constant { pos, .. }
-            | Instruction::Value { pos, .. }
-            | Instruction::Effect { pos, .. } => pos.clone(),
+            Self::Constant { pos, .. } | Self::Value { pos, .. } | Self::Effect { pos, .. } => {
+                pos.clone()
+            }
         }
     }
 }

--- a/brilirs/Cargo.toml
+++ b/brilirs/Cargo.toml
@@ -13,12 +13,12 @@ keywords = ["compiler", "bril", "interpreter", "data-structures", "language"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [build-dependencies]
-clap         = { version = "4.1", features = ["derive"] }
-clap_complete= "4.1"
+clap         = { version = "4.2", features = ["derive"] }
+clap_complete= { version = "4.2", optional = true }
 
 [dependencies]
 thiserror    = "1.0"
-clap         = { version = "4.1", features = ["derive"] }
+clap         = { version = "4.2", features = ["derive"] }
 fxhash       = "0.2"
 mimalloc     = "0.1"
 itoa         = "1.0"
@@ -39,4 +39,4 @@ lto = true
 panic = "abort"
 
 [features]
-completions = []
+completions = ["clap_complete"]


### PR DESCRIPTION
No interesting changes from the new Rust release (1.69).

I am taking this opportunity to update dependencies. The main upgrade to motivate this pr is moving to Syn 2.0. Also of note is that lalrpop made a point release to fix some of the previous issues. I look forward to their new maintainers + Niko publishing a 1.0 release.

I have also tweaked the workflow with respect to the ci flags.