### PR TITLE
[ts2bril] Support for pointers and memory operations

### DIFF
--- a/bril-ts/mem.d.ts
+++ b/bril-ts/mem.d.ts
@@ -1,0 +1,9 @@
+/**
+ * https://capra.cs.cornell.edu/bril/lang/memory.html
+ */
+export interface Pointer<T> {}
+export function alloc<T>(size: bigint): Pointer<T>
+export function store<T>(pointer: Pointer<T>, value: T)
+export function load<T>(pointer: Pointer<T>): T
+export function free<T>(pointer: Pointer<T>): void;
+export function ptradd<T>(pointer: Pointer<T>, offset: bigint): Pointer<T>

--- a/test/ts/memory-call.out
+++ b/test/ts/memory-call.out
@@ -1,0 +1,23 @@
+@main {
+  v4: int = const 1;
+  v5: ptr<int> = alloc v4;
+  p1: ptr<int> = id v5;
+  v6: ptr<int> = id p1;
+  p2: ptr<int> = call @update v6;
+  p2: ptr<int> = id p2;
+  v7: ptr<int> = id p2;
+  v8: int = load v7;
+  print v8;
+  v9: int = const 0;
+  v10: ptr<int> = id p1;
+  free v10;
+  v11: int = const 0;
+}
+@update(p: ptr<int>): ptr<int> {
+  v0: ptr<int> = id p;
+  v1: int = const 42;
+  store v0 v1;
+  v2: int = const 0;
+  v3: ptr<int> = id p;
+  ret v3;
+}

--- a/test/ts/memory-call.ts
+++ b/test/ts/memory-call.ts
@@ -1,0 +1,12 @@
+import * as mem from "../../bril-ts/mem";
+
+function update(p: mem.Pointer<bigint>): mem.Pointer<bigint> {
+    mem.store(p, 42n);
+    return p;
+}
+
+let p1 = mem.alloc<bigint>(1n);
+let p2 = update(p1);
+console.log(mem.load(p2));
+
+mem.free(p1);

--- a/test/ts/memory-loop.out
+++ b/test/ts/memory-loop.out
@@ -1,0 +1,56 @@
+@main {
+  v0: int = const 100;
+  size: int = id v0;
+  v1: int = id size;
+  v2: ptr<int> = alloc v1;
+  arr: ptr<int> = id v2;
+  v4: int = const 0;
+  i: int = id v4;
+.for.cond.3:
+  v5: int = id i;
+  v6: int = id size;
+  v7: bool = lt v5 v6;
+  br v7 .for.body.3 .for.end.3;
+.for.body.3:
+  v8: ptr<int> = id arr;
+  v9: int = id i;
+  v10: ptr<int> = ptradd v8 v9;
+  v11: int = id i;
+  store v10 v11;
+  v12: int = const 0;
+  v13: int = id i;
+  v14: int = const 1;
+  v15: int = add v13 v14;
+  i: int = id v15;
+  jmp .for.cond.3;
+.for.end.3:
+  v16: int = const 0;
+  sum: int = id v16;
+  v18: int = const 0;
+  i: int = id v18;
+.for.cond.17:
+  v19: int = id i;
+  v20: int = id size;
+  v21: bool = lt v19 v20;
+  br v21 .for.body.17 .for.end.17;
+.for.body.17:
+  v22: int = id sum;
+  v23: ptr<int> = id arr;
+  v24: int = id i;
+  v25: ptr<int> = ptradd v23 v24;
+  v26: int = load v25;
+  v27: int = add v22 v26;
+  sum: int = id v27;
+  v28: int = id i;
+  v29: int = const 1;
+  v30: int = add v28 v29;
+  i: int = id v30;
+  jmp .for.cond.17;
+.for.end.17:
+  v31: int = id sum;
+  print v31;
+  v32: int = const 0;
+  v33: ptr<int> = id arr;
+  free v33;
+  v34: int = const 0;
+}

--- a/test/ts/memory-loop.ts
+++ b/test/ts/memory-loop.ts
@@ -1,0 +1,16 @@
+import * as mem from "../../bril-ts/mem";
+
+let size = 100n;
+let arr = mem.alloc<bigint>(size);
+
+for (let i = 0n; i < size; i = i + 1n) {
+    mem.store(mem.ptradd(arr, i), i); // arr[i] = i
+}
+
+let sum = 0n;
+for (let i = 0n; i < size; i = i + 1n) {
+    sum = sum + mem.load(mem.ptradd(arr, i)); // sum += arr[i]
+}
+console.log(sum);
+
+mem.free(arr);

--- a/test/ts/memory-matrix.out
+++ b/test/ts/memory-matrix.out
@@ -1,0 +1,147 @@
+@main {
+  v29: int = const 3;
+  size: int = id v29;
+  v30: int = id size;
+  v31: int = const 1;
+  m: ptr<ptr<int>> = call @allocateMatrix v30 v31;
+  m: ptr<ptr<int>> = id m;
+  v32: ptr<ptr<int>> = id m;
+  v33: int = id size;
+  call @printMatrix v32 v33;
+  v34: int = const 0;
+  v35: ptr<ptr<int>> = id m;
+  v36: int = id size;
+  call @freeMatrix v35 v36;
+  v37: int = const 0;
+}
+@allocateMatrix(size: int, startValue: int): ptr<ptr<int>> {
+  v0: int = id startValue;
+  value: int = id v0;
+  v1: int = id size;
+  v2: ptr<ptr<int>> = alloc v1;
+  matrix: ptr<ptr<int>> = id v2;
+  v4: int = const 0;
+  i: int = id v4;
+.for.cond.3:
+  v5: int = id i;
+  v6: int = id size;
+  v7: bool = lt v5 v6;
+  br v7 .for.body.3 .for.end.3;
+.for.body.3:
+  v8: int = id size;
+  v9: ptr<int> = alloc v8;
+  row: ptr<int> = id v9;
+  v11: int = const 0;
+  j: int = id v11;
+.for.cond.10:
+  v12: int = id j;
+  v13: int = id size;
+  v14: bool = lt v12 v13;
+  br v14 .for.body.10 .for.end.10;
+.for.body.10:
+  v15: ptr<int> = id row;
+  v16: int = id j;
+  v17: ptr<int> = ptradd v15 v16;
+  v18: int = id value;
+  store v17 v18;
+  v19: int = const 0;
+  v20: int = id value;
+  v21: int = const 1;
+  v22: int = add v20 v21;
+  value: int = id v22;
+  v23: int = id j;
+  v24: int = const 1;
+  v25: int = add v23 v24;
+  j: int = id v25;
+  jmp .for.cond.10;
+.for.end.10:
+  v26: ptr<ptr<int>> = id matrix;
+  v27: int = id i;
+  v28: ptr<ptr<int>> = ptradd v26 v27;
+  v29: ptr<int> = id row;
+  store v28 v29;
+  v30: int = const 0;
+  v31: int = id i;
+  v32: int = const 1;
+  v33: int = add v31 v32;
+  i: int = id v33;
+  jmp .for.cond.3;
+.for.end.3:
+  v34: ptr<ptr<int>> = id matrix;
+  ret v34;
+}
+@freeMatrix(matrix: ptr<ptr<int>>, size: int) {
+  v1: int = const 0;
+  i: int = id v1;
+.for.cond.0:
+  v2: int = id i;
+  v3: int = id size;
+  v4: bool = lt v2 v3;
+  br v4 .for.body.0 .for.end.0;
+.for.body.0:
+  v5: ptr<ptr<int>> = id matrix;
+  v6: int = id i;
+  v7: ptr<ptr<int>> = ptradd v5 v6;
+  v8: ptr<int> = load v7;
+  row: ptr<int> = id v8;
+  v9: ptr<int> = id row;
+  free v9;
+  v10: int = const 0;
+  v11: int = id i;
+  v12: int = const 1;
+  v13: int = add v11 v12;
+  i: int = id v13;
+  jmp .for.cond.0;
+.for.end.0:
+  v14: ptr<ptr<int>> = id matrix;
+  free v14;
+  v15: int = const 0;
+}
+@printMatrix(matrix: ptr<ptr<int>>, size: int) {
+  v1: int = const 0;
+  i: int = id v1;
+.for.cond.0:
+  v2: int = id i;
+  v3: int = id size;
+  v4: bool = lt v2 v3;
+  br v4 .for.body.0 .for.end.0;
+.for.body.0:
+  v5: ptr<ptr<int>> = id matrix;
+  v6: int = id i;
+  v7: ptr<ptr<int>> = ptradd v5 v6;
+  v8: ptr<int> = load v7;
+  row: ptr<int> = id v8;
+  v10: int = const 0;
+  j: int = id v10;
+.for.cond.9:
+  v11: int = id j;
+  v12: int = id size;
+  v13: bool = lt v11 v12;
+  br v13 .for.body.9 .for.end.9;
+.for.body.9:
+  v14: ptr<int> = id row;
+  v15: int = id j;
+  v16: ptr<int> = ptradd v14 v15;
+  v17: int = load v16;
+  value: int = id v17;
+  v18: int = id value;
+  print v18;
+  v19: int = const 0;
+  v20: int = id j;
+  v21: int = const 1;
+  v22: int = add v20 v21;
+  j: int = id v22;
+  jmp .for.cond.9;
+.for.end.9:
+  v23: bool = const true;
+  separator: bool = id v23;
+  v24: bool = id separator;
+  print v24;
+  v25: int = const 0;
+  v26: int = id i;
+  v27: int = const 1;
+  v28: int = add v26 v27;
+  i: int = id v28;
+  jmp .for.cond.0;
+.for.end.0:
+}

--- a/test/ts/memory-matrix.ts
+++ b/test/ts/memory-matrix.ts
@@ -1,0 +1,40 @@
+import * as mem from "../../bril-ts/mem";
+
+function allocateMatrix(size: bigint, startValue: bigint): mem.Pointer<mem.Pointer<bigint>> {
+    let value = startValue;
+    let matrix = mem.alloc<mem.Pointer<bigint>>(size);
+    for (let i = 0n; i < size; i = i + 1n) {
+        let row = mem.alloc<bigint>(size);
+        for (let j = 0n; j < size; j = j + 1n) {
+            mem.store(mem.ptradd(row, j), value); // row[j] = value
+            value = value + 1n;
+        }
+        mem.store(mem.ptradd(matrix, i), row); // matrix[i] = row
+    }
+    return matrix;
+}
+
+function freeMatrix(matrix: mem.Pointer<mem.Pointer<bigint>>, size: bigint) {
+    for (let i = 0n; i < size; i = i + 1n) {
+        let row = mem.load(mem.ptradd(matrix, i)); // row = matrix[i]
+        mem.free(row)
+    }
+    mem.free(matrix);
+}
+
+function printMatrix(matrix: mem.Pointer<mem.Pointer<bigint>>, size: bigint) {
+    for (let i = 0n; i < size; i = i + 1n) {
+        let row = mem.load(mem.ptradd(matrix, i)); // row = matrix[i]
+        for (let j = 0n; j < size; j = j + 1n) {
+            let value = mem.load(mem.ptradd(row, j)); // value = row[j]
+            console.log(value);
+        }
+        let separator = true;
+        console.log(separator)
+    }
+}
+
+let size = 3n;
+let m = allocateMatrix(size, 1n);
+printMatrix(m, size)
+freeMatrix(m, size);

--- a/ts2bril.ts
+++ b/ts2bril.ts
@@ -28,6 +28,10 @@ const opTokensFloat = new Map<ts.SyntaxKind, [bril.ValueOpCode, bril.Type]>([
   [ts.SyntaxKind.EqualsEqualsEqualsToken, ["feq",  "bool"]],
 ]);
 
+function isTypeReference(ty: ts.Type): ty is ts.TypeReference {
+  return 'typeArguments' in ty;
+}
+
 function tsTypeToBril(tsType: ts.Type, checker: ts.TypeChecker): bril.Type {
   if (tsType.flags & (ts.TypeFlags.Number | ts.TypeFlags.NumberLiteral)) {
     return "float";
@@ -37,7 +41,7 @@ function tsTypeToBril(tsType: ts.Type, checker: ts.TypeChecker): bril.Type {
   } else if (tsType.flags &
              (ts.TypeFlags.BigInt | ts.TypeFlags.BigIntLiteral)) {
     return "int";
-  } else if (tsType.symbol && tsType.symbol.name === "Pointer") {
+  } else if (isTypeReference(tsType) && tsType.symbol && tsType.symbol.name === "Pointer") {
     const params = checker.getTypeArguments(tsType);
     return { ptr: tsTypeToBril(params[0], checker) };
   } else {


### PR DESCRIPTION
This PR introduces support for built-in functions to manage heap memory. Functions are modelled after the [memory extension operations](https://capra.cs.cornell.edu/bril/lang/memory.html).

Example code that is now supported by `ts2bril`:

```ts
import * as mem from "../../bril-ts/mem";

let size = 100n;
let arr = mem.alloc<bigint>(size);

for (let i = 0n; i < size; i = i + 1n) {
    mem.store(mem.ptradd(arr, i), i); // arr[i] = i
}

let sum = 0n;
for (let i = 0n; i < size; i = i + 1n) {
    sum = sum + mem.load(mem.ptradd(arr, i)); // sum += arr[i]
}
console.log(sum);

mem.free(arr);
```

I had to update the TypeScript compiler version because the old version was missing `checker.getTypeArguments`.