### PR TITLE
Implement char extension in Rust tools

### DIFF
--- a/bril-rs/Cargo.toml
+++ b/bril-rs/Cargo.toml
@@ -17,7 +17,6 @@ keywords = ["compiler", "bril", "parser", "data-structures", "language"]
 thiserror = "1.0"
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
-encode_unicode = { version = "1.0.0", optional = true}
 
 [features]
 float = []
@@ -26,7 +25,7 @@ ssa = []
 speculate = []
 position = []
 import = []
-char = ["dep:encode_unicode"]
+char = []
 
 [[example]]
 name = "bril2txt"

--- a/bril-rs/Cargo.toml
+++ b/bril-rs/Cargo.toml
@@ -17,6 +17,7 @@ keywords = ["compiler", "bril", "parser", "data-structures", "language"]
 thiserror = "1.0"
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
+encode_unicode = { version = "1.0.0", optional = true}
 
 [features]
 float = []
@@ -25,6 +26,7 @@ ssa = []
 speculate = []
 position = []
 import = []
+char = ["dep:encode_unicode"]
 
 [[example]]
 name = "bril2txt"
@@ -33,10 +35,10 @@ path = "examples/bril2txt.rs"
 # However this currently does not work as expected and is being hashed out in https://github.com/rust-lang/rfcs/pull/3020 and https://github.com/rust-lang/rfcs/pull/2887
 # Until a solution is reached, I'm using `required-features` so that these features must be passed by flag. This is less ergonomic at the moment, however the user will get a nicer error that they need a feature flag instead of an Result::unwrap() error.
 # Note: See dev-dependencies for a hack to not need the user to pass that feature flag.
-required-features = ["memory", "float", "ssa", "speculate", "position", "import"]
+required-features = ["memory", "float", "ssa", "speculate", "position", "import", "char"]
 
 [dev-dependencies]
 # trick to enable all features in test
 # This is actually really hacky because it is used in all tests/examples/benchmarks but since we currently only have one example this works for enabling the following feature flags for our users.
 # If the above rfcs every get resolved, then dev-dependencies will no longer be needed.
-bril-rs = { path = ".", features = ["memory", "float", "ssa", "speculate", "position", "import"] }
+bril-rs = { path = ".", features = ["memory", "float", "ssa", "speculate", "position", "import", "char"] }

--- a/bril-rs/bril2json/Cargo.toml
+++ b/bril-rs/bril2json/Cargo.toml
@@ -15,7 +15,6 @@ keywords = ["compiler", "bril", "parser", "data-structures", "language"]
 
 [dependencies]
 clap         = { version = "4.3", features = ["derive"] }
-encode_unicode = "1.0.0"
 lalrpop-util = { version = "0.20", features = ["lexer"] }
 regex = "1.8"
 

--- a/bril-rs/bril2json/Cargo.toml
+++ b/bril-rs/bril2json/Cargo.toml
@@ -15,6 +15,7 @@ keywords = ["compiler", "bril", "parser", "data-structures", "language"]
 
 [dependencies]
 clap         = { version = "4.3", features = ["derive"] }
+encode_unicode = "1.0.0"
 lalrpop-util = { version = "0.20", features = ["lexer"] }
 regex = "1.8"
 
@@ -25,4 +26,4 @@ lalrpop = "0.20"
 [dependencies.bril-rs]
 version = "0.1.0"
 path = "../../bril-rs"
-features = ["ssa", "memory", "float", "speculate", "position", "import"]
+features = ["ssa", "memory", "float", "speculate", "position", "import", "char"]

--- a/bril-rs/bril2json/src/bril_grammar.lalrpop
+++ b/bril-rs/bril2json/src/bril_grammar.lalrpop
@@ -20,7 +20,7 @@
 
 use std::str::FromStr;
 use std::path::PathBuf;
-use crate::{Lines, ParsingArgs};
+use crate::{Lines, ParsingArgs, escape_control_chars};
 use bril_rs::{AbstractProgram, AbstractFunction, AbstractArgument, AbstractCode, AbstractInstruction, ConstOps, AbstractType, Literal, Import, ImportedFunction};
 
 grammar(lines : &Lines);
@@ -33,6 +33,7 @@ match {
     r"(\+|-)?[0-9]+" => INT_TOKEN, // int
     r"(\+|-)?(((([0-9]+\.?[0-9]*)|(\.[0-9]+))(E|e)(\+|-)?[0-9]+)|(([0-9]+\.[0-9]*)|(\.[0-9]+)))" => FLOAT_TOKEN, // https://stackoverflow.com/questions/12643009/regular-expression-for-floating-point-numbers
     r"(_|%|[[:alpha:]])(_|%|\.|[[:alnum:]])*" => IDENT_TOKEN,
+    r"('.')|('\\[0abtnvfr]')" => CHAR_TOKEN,
     r#""[^"]*""# => STRING_TOKEN,
     _
 }
@@ -189,6 +190,7 @@ Literal: Literal = {
     <n: Num> => Literal::Int(n),
     <b: Bool> => Literal::Bool(b),
     <f: Float> => Literal::Float(f),
+    <c: Char> => Literal::Char(c),
 }
 
 Num: i64 = <s:INT_TOKEN> => i64::from_str(s).unwrap();
@@ -198,6 +200,8 @@ Bool: bool = {
 }
 
 Float: f64 = <f:FLOAT_TOKEN> => f64::from_str(f).unwrap();
+
+Char: u16 = <c:CHAR_TOKEN> => {let c = c.trim_matches('\''); escape_control_chars(&c).unwrap_or_else(|| encode_unicode::Utf16Char::from_str_start(c).unwrap().0.to_tuple().0)};
 
 // https://lalrpop.github.io/lalrpop/tutorial/006_macros.html
 Comma<T>: Vec<T> = { // (1)

--- a/bril-rs/bril2json/src/bril_grammar.lalrpop
+++ b/bril-rs/bril2json/src/bril_grammar.lalrpop
@@ -201,7 +201,7 @@ Bool: bool = {
 
 Float: f64 = <f:FLOAT_TOKEN> => f64::from_str(f).unwrap();
 
-Char: u16 = <c:CHAR_TOKEN> => {let c = c.trim_matches('\''); escape_control_chars(c).unwrap_or_else(|| encode_unicode::Utf16Char::from_str_start(c).unwrap().0.to_tuple().0)};
+Char: char = <c:CHAR_TOKEN> => {let c = c.trim_matches('\''); escape_control_chars(c).unwrap()};
 
 // https://lalrpop.github.io/lalrpop/tutorial/006_macros.html
 Comma<T>: Vec<T> = { // (1)

--- a/bril-rs/bril2json/src/bril_grammar.lalrpop
+++ b/bril-rs/bril2json/src/bril_grammar.lalrpop
@@ -201,7 +201,7 @@ Bool: bool = {
 
 Float: f64 = <f:FLOAT_TOKEN> => f64::from_str(f).unwrap();
 
-Char: u16 = <c:CHAR_TOKEN> => {let c = c.trim_matches('\''); escape_control_chars(&c).unwrap_or_else(|| encode_unicode::Utf16Char::from_str_start(c).unwrap().0.to_tuple().0)};
+Char: u16 = <c:CHAR_TOKEN> => {let c = c.trim_matches('\''); escape_control_chars(c).unwrap_or_else(|| encode_unicode::Utf16Char::from_str_start(c).unwrap().0.to_tuple().0)};
 
 // https://lalrpop.github.io/lalrpop/tutorial/006_macros.html
 Comma<T>: Vec<T> = { // (1)

--- a/bril-rs/bril2json/src/lib.rs
+++ b/bril-rs/bril2json/src/lib.rs
@@ -12,6 +12,20 @@ use std::fs::File;
 
 use bril_rs::{AbstractProgram, ColRow, Position};
 
+fn escape_control_chars(s: &str) -> Option<u16> {
+    match s {
+        "\\0" => Some(0),
+        "\\a" => Some(7),
+        "\\b" => Some(8),
+        "\\t" => Some(9),
+        "\\n" => Some(10),
+        "\\v" => Some(11),
+        "\\f" => Some(12),
+        "\\r" => Some(13),
+        _ => None,
+    }
+}
+
 #[doc(hidden)]
 #[derive(Clone)]
 pub struct Lines {

--- a/bril-rs/bril2json/src/lib.rs
+++ b/bril-rs/bril2json/src/lib.rs
@@ -12,16 +12,19 @@ use std::fs::File;
 
 use bril_rs::{AbstractProgram, ColRow, Position};
 
-fn escape_control_chars(s: &str) -> Option<u16> {
+/// A helper function for processing the accepted Bril characters from their text representation
+#[must_use]
+pub fn escape_control_chars(s: &str) -> Option<char> {
     match s {
-        "\\0" => Some(0),
-        "\\a" => Some(7),
-        "\\b" => Some(8),
-        "\\t" => Some(9),
-        "\\n" => Some(10),
-        "\\v" => Some(11),
-        "\\f" => Some(12),
-        "\\r" => Some(13),
+        "\\0" => Some('\u{0000}'),
+        "\\a" => Some('\u{0007}'),
+        "\\b" => Some('\u{0008}'),
+        "\\t" => Some('\u{0009}'),
+        "\\n" => Some('\u{000A}'),
+        "\\v" => Some('\u{000B}'),
+        "\\f" => Some('\u{000C}'),
+        "\\r" => Some('\u{000D}'),
+        s if s.len() == 1 => s.chars().next(),
         _ => None,
     }
 }

--- a/bril-rs/bril2json/src/lib.rs
+++ b/bril-rs/bril2json/src/lib.rs
@@ -24,7 +24,7 @@ pub fn escape_control_chars(s: &str) -> Option<char> {
         "\\v" => Some('\u{000B}'),
         "\\f" => Some('\u{000C}'),
         "\\r" => Some('\u{000D}'),
-        s if s.len() == 1 => s.chars().next(),
+        s if s.chars().count() == 1 => s.chars().next(),
         _ => None,
     }
 }

--- a/bril-rs/brild/src/lib.rs
+++ b/bril-rs/brild/src/lib.rs
@@ -2,6 +2,8 @@
 #![warn(missing_docs)]
 #![doc = include_str!("../README.md")]
 #![allow(clippy::module_name_repetitions)]
+// todo until multiple versions of some really far down dependency are fixed
+#![allow(clippy::multiple_crate_versions)]
 
 #[doc(hidden)]
 pub mod cli;

--- a/bril-rs/brillvm/Makefile
+++ b/bril-rs/brillvm/Makefile
@@ -2,13 +2,13 @@ TESTS := ../../test/interp/core/*.bril \
          ../../test/interp/float/*.bril \
 		 ../../test/interp/ssa/*.bril \
 		 ../../test/interp/mem/*.bril \
-		 ../../test/interp/mixed/*.bril \
+		 ../../test/interp/mixed/*[^r].bril # A hack to exclude store-char.bril by excluding any file ending in r.bril
 
 # Currently ignoring the Cholesky benchmark because of (probably) a floating point rounding bug.
 BENCHMARKS := ../../benchmarks/core/*.bril \
 			  ../../benchmarks/float/*.bril \
 			  ../../benchmarks/mem/*.bril \
-			  ../../benchmarks/mixed/[!cholesky]*.bril
+			  ../../benchmarks/mixed/[^c]*.bril # A hack to exclude cholesky.bril by excluding any file ending in r.bril
 
 clean:
 	cargo clean

--- a/bril-rs/brillvm/Makefile
+++ b/bril-rs/brillvm/Makefile
@@ -8,7 +8,7 @@ TESTS := ../../test/interp/core/*.bril \
 BENCHMARKS := ../../benchmarks/core/*.bril \
 			  ../../benchmarks/float/*.bril \
 			  ../../benchmarks/mem/*.bril \
-			  ../../benchmarks/mixed/[^c]*.bril # A hack to exclude cholesky.bril by excluding any file ending in r.bril
+			  ../../benchmarks/mixed/[^c]*.bril # A hack to exclude cholesky.bril by excluding any file starting in c.
 
 clean:
 	cargo clean

--- a/bril-rs/brillvm/src/lib.rs
+++ b/bril-rs/brillvm/src/lib.rs
@@ -2,6 +2,8 @@
 #![allow(clippy::too_many_lines)]
 #![allow(clippy::needless_for_each)]
 #![doc = include_str!("../README.md")]
+// When you run with --all-targets, you also get --target=all which includes --target=redox. This pulls in redox_sys via a chain of deps through inkwell-parking_lot which uses an older version of bitflags 1.3.2. Given backwards compatibility, it's going to be a very long time, if ever, that this gets updated(because of msrv changes).
+#![allow(clippy::multiple_crate_versions)]
 
 #[doc(hidden)]
 pub mod cli;

--- a/bril-rs/src/conversion.rs
+++ b/bril-rs/src/conversion.rs
@@ -245,6 +245,20 @@ impl TryFrom<AbstractInstruction> for Instruction {
                     "fle" => ValueOps::Fle,
                     #[cfg(feature = "float")]
                     "fge" => ValueOps::Fge,
+                    #[cfg(feature = "char")]
+                    "ceq" => ValueOps::Ceq,
+                    #[cfg(feature = "char")]
+                    "clt" => ValueOps::Clt,
+                    #[cfg(feature = "char")]
+                    "cgt" => ValueOps::Cgt,
+                    #[cfg(feature = "char")]
+                    "cle" => ValueOps::Cle,
+                    #[cfg(feature = "char")]
+                    "cge" => ValueOps::Cge,
+                    #[cfg(feature = "char")]
+                    "char2int" => ValueOps::Char2int,
+                    #[cfg(feature = "char")]
+                    "int2char" => ValueOps::Int2char,
                     #[cfg(feature = "memory")]
                     "alloc" => ValueOps::Alloc,
                     #[cfg(feature = "memory")]
@@ -313,6 +327,8 @@ impl TryFrom<AbstractType> for Type {
             AbstractType::Primitive(t) if t == "bool" => Self::Bool,
             #[cfg(feature = "float")]
             AbstractType::Primitive(t) if t == "float" => Self::Float,
+            #[cfg(feature = "char")]
+            AbstractType::Primitive(t) if t == "char" => Self::Char,
             AbstractType::Primitive(t) => return Err(ConversionError::InvalidPrimitive(t)),
             #[cfg(feature = "memory")]
             AbstractType::Parameterized(t, ty) if t == "ptr" => {

--- a/brilift/Makefile
+++ b/brilift/Makefile
@@ -9,7 +9,7 @@ endif
 
 # Brilift only supports core Bril for now, so we select those tests &
 # benchmarks.
-TESTS := ../test/interp/core/*.bril ../test/interp/float/*.bril ../test/interp/mem/*.bril ../test/interp/mixed/*.bril
+TESTS := ../test/interp/core/*.bril ../test/interp/float/*.bril ../test/interp/mem/*.bril ../test/interp/mixed/store-float.bril
 BENCHMARKS := ../benchmarks/core/*.bril ../benchmarks/float/*.bril ../benchmarks/mem/*.bril ../benchmarks/mixed/*.bril
 
 CFLAGS := $(if $(TARGET),-target $(TARGET))

--- a/brilift/Makefile
+++ b/brilift/Makefile
@@ -9,7 +9,7 @@ endif
 
 # Brilift only supports core Bril for now, so we select those tests &
 # benchmarks.
-TESTS := ../test/interp/core/*.bril ../test/interp/float/*.bril ../test/interp/mem/*.bril ../test/interp/mixed/store-float.bril
+TESTS := ../test/interp/core/*.bril ../test/interp/float/*.bril ../test/interp/mem/*.bril ../test/interp/mixed/*[^r].bril # A hack to exclude store-char.bril by excluding any file ending in r.bril
 BENCHMARKS := ../benchmarks/core/*.bril ../benchmarks/float/*.bril ../benchmarks/mem/*.bril ../benchmarks/mixed/*.bril
 
 CFLAGS := $(if $(TARGET),-target $(TARGET))

--- a/brilift/run.sh
+++ b/brilift/run.sh
@@ -10,7 +10,7 @@ set -e
 #
 
 OS=$(uname -m)
-if [[ "$OS" == 'arm64' ]]; then
+if [ "$OS" = 'arm64' ]; then
     export TARGET=x86_64-unknown-darwin-macho
 fi
 

--- a/brilirs/Cargo.toml
+++ b/brilirs/Cargo.toml
@@ -22,11 +22,12 @@ clap         = { version = "4.2", features = ["derive"] }
 fxhash       = "0.2"
 mimalloc     = "0.1"
 itoa         = "1.0"
+encode_unicode = "1.0.0"
 
 [dependencies.bril-rs]
 version      = "0.1.0"
 path         = "../bril-rs"
-features     = ["ssa", "memory", "float", "speculate"]
+features     = ["ssa", "memory", "float", "speculate", "char"]
 
 [dependencies.bril2json]
 version      = "0.1.0"

--- a/brilirs/Cargo.toml
+++ b/brilirs/Cargo.toml
@@ -13,16 +13,15 @@ keywords = ["compiler", "bril", "interpreter", "data-structures", "language"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [build-dependencies]
-clap         = { version = "4.2", features = ["derive"] }
-clap_complete= { version = "4.2", optional = true }
+clap         = { version = "4.3", features = ["derive"] }
+clap_complete= { version = "4.3", optional = true }
 
 [dependencies]
 thiserror    = "1.0"
-clap         = { version = "4.2", features = ["derive"] }
+clap         = { version = "4.3", features = ["derive"] }
 fxhash       = "0.2"
 mimalloc     = "0.1"
 itoa         = "1.0"
-encode_unicode = "1.0.0"
 
 [dependencies.bril-rs]
 version      = "0.1.0"

--- a/brilirs/Makefile
+++ b/brilirs/Makefile
@@ -2,6 +2,7 @@ TESTS := ../test/check/*.bril \
 ../test/interp*/core*/*.bril \
 ../test/interp*/float/*.bril \
 ../test/interp*/mem*/*.bril \
+../test/interp*/char*/*.bril \
 ../test/interp*/mixed/*.bril \
 ../test/interp*/ssa*/*.bril \
 

--- a/brilirs/src/check.rs
+++ b/brilirs/src/check.rs
@@ -211,6 +211,55 @@ fn type_check_instruction<'a>(
       update_env(env, dest, op_type)
     }
     Instruction::Value {
+      op: ValueOps::Ceq | ValueOps::Cge | ValueOps::Clt | ValueOps::Cgt | ValueOps::Cle,
+      args,
+      dest,
+      funcs,
+      labels,
+      pos: _,
+      op_type,
+    } => {
+      check_num_args(2, args)?;
+      check_num_funcs(0, funcs)?;
+      check_num_labels(0, labels)?;
+      check_asmt_type(&Type::Char, get_type(env, 0, args)?)?;
+      check_asmt_type(&Type::Char, get_type(env, 1, args)?)?;
+      check_asmt_type(&Type::Bool, op_type)?;
+      update_env(env, dest, op_type)
+    }
+    Instruction::Value {
+      op: ValueOps::Char2int,
+      args,
+      dest,
+      funcs,
+      labels,
+      pos: _,
+      op_type,
+    } => {
+      check_num_args(1, args)?;
+      check_num_funcs(0, funcs)?;
+      check_num_labels(0, labels)?;
+      check_asmt_type(&Type::Char, get_type(env, 0, args)?)?;
+      check_asmt_type(&Type::Int, op_type)?;
+      update_env(env, dest, op_type)
+    }
+    Instruction::Value {
+      op: ValueOps::Int2char,
+      args,
+      dest,
+      funcs,
+      labels,
+      pos: _,
+      op_type,
+    } => {
+      check_num_args(1, args)?;
+      check_num_funcs(0, funcs)?;
+      check_num_labels(0, labels)?;
+      check_asmt_type(&Type::Int, get_type(env, 0, args)?)?;
+      check_asmt_type(&Type::Char, op_type)?;
+      update_env(env, dest, op_type)
+    }
+    Instruction::Value {
       op: ValueOps::Call,
       dest,
       op_type,

--- a/brilirs/src/error.rs
+++ b/brilirs/src/error.rs
@@ -21,6 +21,8 @@ pub enum InterpError {
   NoMainFunction,
   #[error("phi node has unequal numbers of labels and args")]
   UnequalPhiNode,
+  #[error("char must have one character")]
+  NotOneChar,
   #[error("multiple functions of the same name found")]
   DuplicateFunction,
   #[error("Expected empty return for `{0}`, found value")]
@@ -53,6 +55,8 @@ pub enum InterpError {
   BadAsmtType(bril_rs::Type, bril_rs::Type), // (expected, actual). For when the LHS type of an instruction is bad
   #[error("There has been an io error: `{0:?}`")]
   IoError(#[from] std::io::Error),
+  #[error("value ${0} cannot be converted to char")]
+  ToCharError(i64),
   #[error("You probably shouldn't see this error, this is here to handle conversions between InterpError and PositionalError")]
   PositionalInterpErrorConversion(#[from] PositionalInterpError),
 }

--- a/docs/tools/brilirs.md
+++ b/docs/tools/brilirs.md
@@ -3,7 +3,7 @@ Fast Interpreter in Rust
 
 The `brilirs` directory contains a fast Bril interpreter written in [Rust][].
 It is a drop-in replacement for the [reference interpreter](interp.md) that prioritizes speed over completeness and hackability.
-It implements [core Bril](../lang/core.md) along with the [SSA][], [memory][], and [floating point][float] extensions.
+It implements [core Bril](../lang/core.md) along with the [SSA][], [memory][], [char][], and [floating point][float] extensions.
 
 Read [more about the implementation][blog], which is originally by Wil Thomason and Daniel Glus.
 
@@ -36,4 +36,5 @@ To see all of the supported flags, run:
 [ssa]: ../lang/ssa.md
 [memory]: ../lang/memory.md
 [float]: ../lang/float.md
+[char]: ../lang/char.md
 [blog]: https://www.cs.cornell.edu/courses/cs6120/2019fa/blog/faster-interpreter/

--- a/docs/tools/rust.md
+++ b/docs/tools/rust.md
@@ -1,7 +1,7 @@
 Rust Library
 ============
 
-This is a no-frills interface between Bril's JSON and your [Rust][] code. It supports the [Bril core][core] along with the [SSA][], [memory][], [floating point][float], [speculative execution][spec], and [source positions][pos] extensions.
+This is a no-frills interface between Bril's JSON and your [Rust][] code. It supports the [Bril core][core] along with the [SSA][], [memory][], [floating point][float], [speculative execution][spec], [char][], and [source positions][pos] extensions.
 
 Use
 ---
@@ -55,4 +55,5 @@ make features
 [float]: ../lang/float.md
 [spec]: ../lang/spec.md
 [pos]: ../lang/syntax.md
+[char]: ../lang/char.md
 [import]: ../lang/import.md

--- a/test/interp-error/char-error/badconversion.bril
+++ b/test/interp-error/char-error/badconversion.bril
@@ -1,6 +1,6 @@
 @main {
   i: int = const 56193;
-  
+
   c: char = int2char i;
 
   print c;


### PR DESCRIPTION
I've gone and implemented the char extension #253 in `bril-rs` and it's corresponding Rust tools: `bril2txt`, `bril2json`, and `brilirs`.

The main implementation difference is that I've used a `u16` as the internal representation of a char which I believe is an equivalent representation. It is possible that implementation differences could lead to slightly different behavior though the rust tools currently pass all char tests.

I have a couple of notes for what they are worth:

- With Control characters, the following doesn't "round trip" `bril2json < test/interp/char/control_char.bril | bril2txt` in the sense that the outputted text file doesn't have the control characters escaped. In this example, the resulting file isn't valid. Similarly, `bril2json < test/interp/char/control_char.bril` will output some of the control values as `\u000b` which doesn't seem to cause an issue but might be surprising given that the larger set of escape characters is unsupported(maybe this is fine, I'm not sure).
- `bril2json < ../test/interp/char/char_args.bril | brili '\n' e y` errors out and probably shouldn't?
- Javascript strings allow for "lone surrogates" which is one half of a surrogate pair that is an invalid character on it's own. Maybe `brili`'s check for the range of `int2char` should be more strict to disallow the following program? `
```
@main() {
  i1: int = const 56193;

  c2: char = int2char i1;

  print c2;
}
```

@tmaradc do you have any thoughts on this?