### PR TITLE
Fix LVN example on blocks that copy-propagate live-ins

### DIFF
--- a/brench/example.toml
+++ b/brench/example.toml
@@ -1,5 +1,5 @@
 extract = 'total_dyn_inst: (\d+)'
-benchmarks = '../benchmarks/*.bril'
+benchmarks = '../benchmarks/core/*.bril'
 
 [runs.baseline]
 pipeline = [

--- a/examples/lvn.py
+++ b/examples/lvn.py
@@ -90,8 +90,13 @@ def lvn_block(block, lookup, canonicalize, fold):
 
     # The *canonical* variable name holding a given numbered value.
     # There is only one canonical variable per value number (so this is
-    # not the inverse of var2num).
-    num2varz = {}
+    # not the inverse of var2num). To make matters even more
+    # complicated, we will also keep a *list* of possible names here,
+    # where the first is the canonical one to use. This is only relevant
+    # when doing copy-propagation, and it helps with situations where a
+    # copy-propagated variable is later "clobbered" so we can fall back
+    # to a different variable holding the same value.
+    num2vars = {}
 
     # Track constant values for values assigned with `const`.
     num2const = {}
@@ -100,7 +105,7 @@ def lvn_block(block, lookup, canonicalize, fold):
     # variables are their own canonical source.
     for var in read_first(block):
         num = var2num.add(var)
-        num2varz[num] = [var]
+        num2vars[num] = [var]
 
     for instr, last_write in zip(block, last_writes(block)):
         # Look up the value numbers for all variable arguments,
@@ -108,10 +113,15 @@ def lvn_block(block, lookup, canonicalize, fold):
         argvars = instr.get('args', [])
         argnums = tuple(var2num[var] for var in argvars)
 
+        # Update argument variable names to canonical variables.
         if 'args' in instr:
-            argz = [num2varz[n][0] for n in argnums]
+            instr['args'] = [num2vars[n][0] for n in argnums]
+
+        # If we write to a variable, we "clobber" any previous value it
+        # may have held. Remove any entries that point to this variable
+        # as the "home" for old values.
         if 'dest' in instr:
-            for rhs in num2varz.values():
+            for rhs in num2vars.values():
                 if instr['dest'] in rhs:
                     rhs.remove(instr['dest'])
 
@@ -138,11 +148,11 @@ def lvn_block(block, lookup, canonicalize, fold):
                     })
                     del instr['args']
                 else:  # Value is in a variable.
-                    num2varz[num].append(instr['dest'])
                     instr.update({
                         'op': 'id',
-                        'args': [num2varz[num][0]],
+                        'args': [num2vars[num][0]],
                     })
+                    num2vars[num].append(instr['dest'])
                 continue
 
         # If this instruction produces a result, give it a number.
@@ -163,7 +173,7 @@ def lvn_block(block, lookup, canonicalize, fold):
                 var = 'lvn.{}'.format(newnum)
 
             # Record the variable name and update the instruction.
-            num2varz[newnum] = [var]
+            num2vars[newnum] = [var]
             instr['dest'] = var
 
             if val is not None:
@@ -181,10 +191,6 @@ def lvn_block(block, lookup, canonicalize, fold):
                 # If not, record the new variable as the canonical
                 # source for the newly computed value.
                 value2num[val] = newnum
-
-        # Update argument variable names to canonical variables.
-        if 'args' in instr:
-            instr['args'] = argz
 
 
 def _lookup(value2num, value):

--- a/examples/test/lvn/clobber-arg.bril
+++ b/examples/test/lvn/clobber-arg.bril
@@ -1,0 +1,6 @@
+@main() {
+  a: int = const 1;
+  b: int = const 2;
+.lbl:
+  b: int = add a b;
+}

--- a/examples/test/lvn/clobber-arg.out
+++ b/examples/test/lvn/clobber-arg.out
@@ -1,0 +1,6 @@
+@main {
+  a: int = const 1;
+  b: int = const 2;
+.lbl:
+  b: int = add a b;
+}

--- a/examples/test/lvn/nonlocal-clobber.bril
+++ b/examples/test/lvn/nonlocal-clobber.bril
@@ -1,0 +1,8 @@
+# ARGS: -p
+@main {
+  x: int = const 1;
+.lb:
+  y: int = id x;
+  x: int = add x x;
+  print y;
+}

--- a/examples/test/lvn/nonlocal-clobber.out
+++ b/examples/test/lvn/nonlocal-clobber.out
@@ -1,0 +1,7 @@
+@main {
+  x: int = const 1;
+.lb:
+  y: int = id x;
+  x: int = add x x;
+  print y;
+}


### PR DESCRIPTION
Closes #256, which points out a very interesting bug, and uses its test case. The trick is that, when copy propagation is turned out, we would lose track of "clobbers" to live-ins (variables that are read before they are written inside the block). #256 proposes to give these generated names; I took a slightly different tactic here that avoids the need for new `id` instructions. The idea is to extend `var2num` to contain lists of multiple possible variables for the same value. We remove variables from these lists when a "clobber" occurs. That means subsequent uses of the value will see a different (and this time, local) variable name.