### PR TITLE
Small batch of Bril/Rust fixes

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -86,7 +86,6 @@ jobs:
       - uses: dtolnay/rust-toolchain@v1
         with:
           toolchain: stable
-          components: rustfmt, clippy
 
       - name: Install LLVM and Clang
         uses: KyleMayes/install-llvm-action@v1

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -91,7 +91,7 @@ jobs:
         uses: KyleMayes/install-llvm-action@v1
         if: matrix.path == 'bril-rs/brillvm/Cargo.toml'
         with:
-          version: "15.0"
+          version: "16.0"
 
       - name: cargo check
         run: cargo check --manifest-path ${{ matrix.path }} --all-targets

--- a/bril-rs/bril2json/Cargo.toml
+++ b/bril-rs/bril2json/Cargo.toml
@@ -16,7 +16,7 @@ keywords = ["compiler", "bril", "parser", "data-structures", "language"]
 [dependencies]
 clap         = { version = "4.3", features = ["derive"] }
 lalrpop-util = { version = "0.20", features = ["lexer"] }
-regex = "1.8"
+regex = "1.9"
 
 # Add a build-time dependency on the lalrpop library:
 [build-dependencies]

--- a/bril-rs/bril2json/src/bril_grammar.lalrpop
+++ b/bril-rs/bril2json/src/bril_grammar.lalrpop
@@ -1,6 +1,5 @@
 #![allow(clippy::needless_lifetimes)]
 #![allow(clippy::just_underscores_and_digits)]
-#![allow(clippy::too_many_arguments)]
 #![allow(clippy::deprecated_cfg_attr)]
 #![allow(clippy::no_effect_underscore_binding)]
 #![allow(clippy::unnested_or_patterns)]

--- a/bril-rs/brild/src/lib.rs
+++ b/bril-rs/brild/src/lib.rs
@@ -2,8 +2,6 @@
 #![warn(missing_docs)]
 #![doc = include_str!("../README.md")]
 #![allow(clippy::module_name_repetitions)]
-// todo until multiple versions of some really far down dependency are fixed
-#![allow(clippy::multiple_crate_versions)]
 
 #[doc(hidden)]
 pub mod cli;

--- a/bril-rs/brillvm/Cargo.toml
+++ b/bril-rs/brillvm/Cargo.toml
@@ -15,9 +15,9 @@ default-run = "main"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-clap         = { version = "4.3", features = ["derive"] }
-inkwell      = { version = "0.2", features = ["llvm15-0"] }
-libc-print   = "0.1"
+clap = { version = "4.3", features = ["derive"] }
+inkwell = { version = "0.2", features = ["llvm16-0"] }
+libc-print = "0.1"
 
 # For overriding parking_lot_core to latest version from 0.9.7
 # To pull in the removal of `window-sys` which was causing duplicate dependencies

--- a/bril-rs/brillvm/Makefile
+++ b/bril-rs/brillvm/Makefile
@@ -4,11 +4,10 @@ TESTS := ../../test/interp/core/*.bril \
 		 ../../test/interp/mem/*.bril \
 		 ../../test/interp/mixed/*[^r].bril # A hack to exclude store-char.bril by excluding any file ending in r.bril
 
-# Currently ignoring the Cholesky benchmark because of (probably) a floating point rounding bug.
 BENCHMARKS := ../../benchmarks/core/*.bril \
 			  ../../benchmarks/float/*.bril \
 			  ../../benchmarks/mem/*.bril \
-			  ../../benchmarks/mixed/[^c]*.bril # A hack to exclude cholesky.bril by excluding any file starting in c.
+			  ../../benchmarks/mixed/*.bril
 
 clean:
 	cargo clean
@@ -20,7 +19,7 @@ rt:
 	cargo rustc --bin rt --release -- --emit=llvm-bc && mv target/release/deps/rt-*.bc rt.bc
 
 example:
-	bril2json < ../../benchmarks/mem/sieve.bril | cargo run -- -i 100
+# bril2json < ../../benchmarks/mem/sieve.bril | cargo run -- -i 100
 	bril2json < ../../benchmarks/mixed/cholesky.bril | cargo run -- -i
 
 .PHONY: test

--- a/bril-rs/brillvm/README.md
+++ b/bril-rs/brillvm/README.md
@@ -21,7 +21,7 @@ Valid Bril programs are assumed as input with no attempt at error handling. Each
 
 ### Floating Point values
 
-There is a known issue where some floating point values are off by a small epsilon.
+Be careful which execution engine you are using which may enable some kind of fast math mode behind your back. This can cause some floating point values to be off by a small epsilon.
 
 ### Missing LLVM
 

--- a/bril-rs/brillvm/src/llvm.rs
+++ b/bril-rs/brillvm/src/llvm.rs
@@ -1242,7 +1242,7 @@ pub fn create_module_from_program<'a>(
                 (llvm_func, instrs, block, heap)
             },
         )
-        .collect(); // Important to collect, can't be done lazily because we need all functions to ne loaded in before a call instruction of a function is processed.
+        .collect(); // Important to collect, can't be done lazily because we need all functions to be loaded in before a call instruction of a function is processed.
 
     // Now actually build each function
     funcs

--- a/bril-rs/brillvm/src/main.rs
+++ b/bril-rs/brillvm/src/main.rs
@@ -3,7 +3,6 @@ use brillvm::{cli::Cli, llvm::create_module_from_program};
 use clap::Parser;
 use inkwell::{
     context::Context,
-    execution_engine::ExecutionEngine,
     module::Module,
     targets::{InitializationConfig, Target},
 };
@@ -35,8 +34,11 @@ fn main() {
     if args.interpreter {
         Target::initialize_native(&InitializationConfig::default())
             .expect("Failed to initialize native target");
-        ExecutionEngine::link_in_interpreter();
-        let engine = llvm_prog.create_execution_engine().unwrap();
+
+        let engine = llvm_prog
+            .create_jit_execution_engine(inkwell::OptimizationLevel::None)
+            .unwrap();
+
         let mut args: Vec<&str> = args.args.iter().map(|s| s.as_ref()).collect();
         args.insert(0, "bril_prog");
         unsafe {

--- a/bril-rs/rs2bril/src/lib.rs
+++ b/bril-rs/rs2bril/src/lib.rs
@@ -405,7 +405,7 @@ fn array_init_helper(
         op: ConstOps::Const,
         pos: None,
         const_type: Type::Int,
-        value: Literal::Int(vars.len() as i64),
+        value: Literal::Int(i64::try_from(vars.len()).unwrap()),
     }));
     code.push(Code::Instruction(Instruction::Value {
         args: vec![size],
@@ -423,7 +423,7 @@ fn array_init_helper(
             op: ConstOps::Const,
             pos: None,
             const_type: Type::Int,
-            value: Literal::Int(i as i64),
+            value: Literal::Int(i64::try_from(i).unwrap()),
         }));
         let index_pointer = state.fresh_var(op_type.clone());
         code.push(Code::Instruction(Instruction::Value {


### PR DESCRIPTION
- A little bit of cleanup of now unnecessary allowed lints/workflow components
- Bumping to Inkwells support of llvm 16
- Fixed the small floating point issue of brillvm by specifically asking for an execution engine without optimizations
- Today's release of Rust 1.72's clippy lints