### PR TITLE
Remove soft numerical comparisons from Brench

### DIFF
--- a/brench/brench.py
+++ b/brench/brench.py
@@ -10,6 +10,7 @@ import sys
 import os
 from concurrent import futures
 import glob
+from itertools import zip_longest
 
 __version__ = '1.0.0'
 
@@ -47,12 +48,12 @@ def run_pipe(cmds, input, timeout):
 
 
 def compare_output(o1, o2, ε=0.0):
-    def my_compare(x, y):
+    def cmp(x, y):
         try:
             return abs(float(x) - float(y)) <= ε
-        except ValueError:
+        except (ValueError, TypeError):
             return x == y
-    return all(my_compare(x, y) for x, y in zip(o1.split(), o2.split()))
+    return all(cmp(x, y) for x, y in zip_longest(o1.split(), o2.split()))
 
 
 def run_bench(pipeline, fn, timeout):

--- a/brench/brench.py
+++ b/brench/brench.py
@@ -10,7 +10,6 @@ import sys
 import os
 from concurrent import futures
 import glob
-from itertools import zip_longest
 
 __version__ = '1.0.0'
 
@@ -45,15 +44,6 @@ def run_pipe(cmds, input, timeout):
     finally:
         for proc in procs:
             proc.kill()
-
-
-def compare_output(o1, o2, ε=0.0):
-    def cmp(x, y):
-        try:
-            return abs(float(x) - float(y)) <= ε
-        except (ValueError, TypeError):
-            return x == y
-    return all(cmp(x, y) for x, y in zip_longest(o1.split(), o2.split()))
 
 
 def run_bench(pipeline, fn, timeout):

--- a/brench/brench.py
+++ b/brench/brench.py
@@ -101,7 +101,6 @@ def brench(config_path, files, jobs):
         files = glob.glob(config['benchmarks'])
 
     timeout = config.get('timeout', 5)
-    ε = config.get('epsilon', 0.0)
 
     with futures.ThreadPoolExecutor(max_workers=jobs) as pool:
         # Submit jobs.
@@ -128,7 +127,7 @@ def brench(config_path, files, jobs):
                 # Check correctness.
                 if first_out is None:
                     first_out = stdout
-                elif not compare_output(stdout, first_out, ε) and not status:
+                elif stdout != first_out and not status:
                     status = 'incorrect'
 
                 # Extract the figure of merit.

--- a/docs/tools/brench.md
+++ b/docs/tools/brench.md
@@ -79,10 +79,4 @@ The latter is the value extracted from the run's standard output and standard er
 
 To check that a run's output is "correct," Brench compares its standard output
 to that of the first run (`baseline` in the above example, but it's whichever run
-configuration comes first). The comparison is mostly an exact string match, but
-Brench also supports an `epsilon` option which can be set for numerical values,
-in which case it will check for absolute difference being less than ε. This is
-primarily to deal with inconsistencies in printing floats, but can be used to
-test for "approximate correctness" with floating point optimizations. Be careful
-that setting the ε value might cause Brench to miss some unsound transformations
-that only slightly affect floating-point accuracy.
+configuration comes first). The comparison is an exact string match.


### PR DESCRIPTION
I first found a bug in Brench's output-checking code that would erroneously consider some outputs to be correct when they were not. (Namely, `zip` was taking the shortest of the two outputs, so whenever an output was _empty_, it was _always_ considered correct.) The first commit in this PR addresses that problem.

However, I then thought it might be best to remove Brench's somewhat odd numerical-comparison option altogether. This was added in #196 and was a nice stopgap, but we eventually actually specified digit-precise float behavior in #218. I hope that this is no longer needed—fuzzily comparing for approximate output is certainly interesting for some cases, but the vast majority of work that we do in 6120 should actually preserve semantics. "Epsilon" comparison for floats seems like a footgun we should not engage with unless absolutely necessary. So removed this (apparently error-prone) special numerical comparison altogether.