### PR TITLE
Specify and check that the `@main` function can't have a return type

### DIFF
--- a/brilck.ts
+++ b/brilck.ts
@@ -394,6 +394,14 @@ function checkProg(prog: bril.Program) {
   // Check each function.
   for (let func of prog.functions) {
     checkFunc(funcEnv, func);
+
+    // The @main function must not return anything.
+    if (func.name === 'main') {
+      if (func.type) {
+        err(`@main must have no return type; found ${typeFmt(func.type)}`,
+            func.pos);
+      }
+    }
   }
 }
 

--- a/docs/lang/syntax.md
+++ b/docs/lang/syntax.md
@@ -15,9 +15,6 @@ It has one key:
 
 * `functions`, a list of Function objects.
 
-There should be at least one function with the name `main`.
-When execution starts, this function will be invoked.
-
 Type
 ----
 
@@ -47,6 +44,10 @@ There are four fields:
 * `instrs`, a list of Label and Instruction objects.
 
 When a function runs, it creates an activation record and transfers control to the first instruction in the sequence.
+
+A Bril program is executable if it contains a function named `main`.
+When execution starts, this function will be invoked.
+The `main` function can have arguments (which implementations may supply using command-line arguments) but must not have a return `type`.
 
 Label
 -----

--- a/test/check/mainret.bril
+++ b/test/check/mainret.bril
@@ -1,0 +1,3 @@
+@main(x: int): int {
+  ret x;
+}

--- a/test/check/mainret.err
+++ b/test/check/mainret.err
@@ -1,0 +1,1 @@
+1:1: @main must have no return type; found int


### PR DESCRIPTION
As discussed in https://github.com/sampsyo/bril/pull/281#discussion_r1319112205 and previously in https://github.com/sampsyo/bril/issues/91, it seems like `@main` shouldn't return anything. (Maybe we will change this in the future—e.g., maybe it should be able to return an OS status code—but we can relax this requirement if we ever want to do that.)

This PR adds this requirement to the docs and adds the obvious check to `brilck`. The CI will fail on this PR until the benchmark from #281 is fixed to obey the new rule.