### PR TITLE
remove the return value of main in csrmv

### DIFF
--- a/benchmarks/mem/csrmv.bril
+++ b/benchmarks/mem/csrmv.bril
@@ -236,7 +236,7 @@
 
 # main function
 # ARGS: 50 50 5
-@main(rows: int, cols: int, degree: int): int {
+@main(rows: int, cols: int, degree: int){
     one: int = const 1;
     rptr_len: int = add rows one;
     nnz: int = mul rows degree;
@@ -262,7 +262,4 @@
     free csr_values;
     free vec;
     free res;
-
-    good: int = const 0;
-    ret good;
 }

--- a/benchmarks/mem/csrmv.prof
+++ b/benchmarks/mem/csrmv.prof
@@ -1,1 +1,1 @@
-total_dyn_inst: 121204
+total_dyn_inst: 121202


### PR DESCRIPTION
Removing the return value of the main function of csrmv, according to the discussion in #281. 