### PR TITLE
Add return code support to brili

### DIFF
--- a/brili.ts
+++ b/brili.ts
@@ -941,7 +941,7 @@ function evalProg(prog: bril.Program) {
     curlabel: null,
     specparent: null,
   }
-  evalFunc(main, state);
+  let retVal = evalFunc(main, state);
 
   if (!heap.isEmpty()) {
     throw error(`Some memory locations have not been freed by end of execution.`);
@@ -951,6 +951,7 @@ function evalProg(prog: bril.Program) {
     console.error(`total_dyn_inst: ${state.icount}`);
   }
 
+  Deno.exit(Number(retVal));
 }
 
 async function main() {


### PR DESCRIPTION
Brili doesn't set the return code of what the main function of bril returns. This fixes that.