### PR TITLE
fastbrili: Conformant float printing

### DIFF
--- a/fastbril/src/interp/interp.c
+++ b/fastbril/src/interp/interp.c
@@ -1,6 +1,7 @@
 #include "interp.h"
 #include <string.h>
 #include <stdio.h>
+#include <math.h>
 
 value_t interpret_insn(program_t  *prog, size_t which_fun,
 		       value_t *context, uint16_t *labels,
@@ -126,8 +127,21 @@ value_t interpret_insn(program_t  *prog, size_t which_fun,
 		    printf("%ld", context[args[2 * a + 1]].int_val);
 		    break;
 		  case BRILFLOAT:
-		    printf("%.17g", context[args[2 * a + 1]].float_val);
-		    break;
+            {
+              double f = context[args[2 * a + 1]].float_val;
+              if (isnan(f)) {
+                  printf("NaN");
+              } else if (isinf(f)) {
+                  if (f < 0) {
+                      printf("-Infinity");
+                  } else {
+                      printf("Infinity");
+                  }
+              } else {
+                  printf("%.17lf", f);
+              }
+		      break;
+            }
 		  default:
 		    fprintf(stderr, "unrecognized type: %d. exiting.\n", args[2 * a]);
 		    exit(1);


### PR DESCRIPTION
As outlined in https://github.com/sampsyo/bril/pull/300#issuecomment-1837602011, the fastbrili interpreter just needed more conformant float printing to pass the benchmarks test suite. Now all 70 benchmarks match the baseline with `turnt -e fastbrili benchmarks/**/*.bril`!

Other than my unforgivable use of spaces instead of tabs, does this look OK to you, @charles-rs?

Remaining things on the to-do list here include:

* write public-facing documentation in the Tools section
* run the tests in CI?