### PR TITLE
Resolve Deno deprecation

### DIFF
--- a/bril-ts/util.ts
+++ b/bril-ts/util.ts
@@ -2,8 +2,12 @@
  * Read all the data from stdin as a string.
  */
 export async function readStdin(): Promise<string> {
-  const buf = await Deno.readAll(Deno.stdin);
-  return (new TextDecoder()).decode(buf);
+  let buf = "";
+  const dec = new TextDecoder();
+  for await (const chunk of Deno.stdin.readable) {
+    buf += dec.decode(chunk);
+  }
+  return buf;
 }
 
 export function unreachable(x: never): never {


### PR DESCRIPTION
Deno started complaining about the more Deno-specific way we were reading from stdin:

```
warning: Use of deprecated "Deno.readAll()" API. This API will be removed in Deno 2. Run again with DENO_VERBOSE_WARNINGS=1 to get more details.
warning: Use of deprecated "new Deno.Buffer()" API. This API will be removed in Deno 2. Run again with DENO_VERBOSE_WARNINGS=1 to get more details.
```

This new way seems to be endorsed (and more ECMAScript-y to boot).