### PR TITLE
Add full bril-rs feature set to rs2bril

### DIFF
--- a/bril-rs/rs2bril/Cargo.toml
+++ b/bril-rs/rs2bril/Cargo.toml
@@ -21,4 +21,4 @@ clap         = { version = "4.4", features = ["derive"] }
 [dependencies.bril-rs]
 version = "0.1.0"
 path = ".."
-features = [ "memory", "float", "position"]
+features = [ "memory", "float", "position", "import"]

--- a/bril-rs/rs2bril/Cargo.toml
+++ b/bril-rs/rs2bril/Cargo.toml
@@ -21,4 +21,4 @@ clap         = { version = "4.4", features = ["derive"] }
 [dependencies.bril-rs]
 version = "0.1.0"
 path = ".."
-features = ["memory", "float", "ssa", "speculate", "position", "import", "char"]
+features = [ "memory", "float", "position", "import" ]

--- a/bril-rs/rs2bril/Cargo.toml
+++ b/bril-rs/rs2bril/Cargo.toml
@@ -21,4 +21,4 @@ clap         = { version = "4.4", features = ["derive"] }
 [dependencies.bril-rs]
 version = "0.1.0"
 path = ".."
-features = [ "memory", "float", "position", "import"]
+features = ["memory", "float", "ssa", "speculate", "position", "import", "char"]

--- a/bril-rs/rs2bril/Cargo.toml
+++ b/bril-rs/rs2bril/Cargo.toml
@@ -21,4 +21,7 @@ clap         = { version = "4.4", features = ["derive"] }
 [dependencies.bril-rs]
 version = "0.1.0"
 path = ".."
-features = [ "memory", "float", "position", "import" ]
+features = [ "memory", "float", "position" ]
+
+[features]
+import = [ "bril-rs/import" ]

--- a/bril-rs/rs2bril/src/lib.rs
+++ b/bril-rs/rs2bril/src/lib.rs
@@ -1173,6 +1173,6 @@ pub fn from_file_to_program(
             })
             .collect(),
         #[cfg(feature = "import")]
-        imports: vec![]
+        imports: vec![],
     }
 }

--- a/bril-rs/rs2bril/src/lib.rs
+++ b/bril-rs/rs2bril/src/lib.rs
@@ -1172,6 +1172,7 @@ pub fn from_file_to_program(
                 from_empty_function_to_function(f, &mut state)
             })
             .collect(),
+        #[cfg(feature = "import")]
         imports: vec![]
     }
 }

--- a/bril-rs/rs2bril/src/lib.rs
+++ b/bril-rs/rs2bril/src/lib.rs
@@ -1172,5 +1172,6 @@ pub fn from_file_to_program(
                 from_empty_function_to_function(f, &mut state)
             })
             .collect(),
+        imports: vec![]
     }
 }


### PR DESCRIPTION
Similar to https://github.com/sampsyo/bril/pull/312, this PR adds the full feature set to `rs2bril` so that we can depend on both.