### PR TITLE
brilirs: error on duplicate labels

### DIFF
--- a/brilirs/src/basic_block.rs
+++ b/brilirs/src/basic_block.rs
@@ -210,12 +210,14 @@ impl BBFunction {
     let mut curr_block = BasicBlock::new();
     for instr in func.instrs {
       match instr {
-        bril_rs::Code::Label { label, pos: _ } => {
+        bril_rs::Code::Label { label, pos } => {
           if !curr_block.instrs.is_empty() || curr_block.label.is_some() {
             blocks.push(curr_block);
             curr_block = BasicBlock::new();
           }
-          label_map.insert(label.to_string(), blocks.len());
+          if label_map.insert(label.to_string(), blocks.len()).is_some() {
+            return Err(InterpError::DuplicateLabel(label).add_pos(pos));
+          }
           curr_block.label = Some(label);
         }
         bril_rs::Code::Instruction(i @ bril_rs::Instruction::Effect { op, .. })

--- a/brilirs/src/basic_block.rs
+++ b/brilirs/src/basic_block.rs
@@ -212,12 +212,10 @@ impl BBFunction {
       match instr {
         bril_rs::Code::Label { label, pos: _ } => {
           if !curr_block.instrs.is_empty() || curr_block.label.is_some() {
-            if let Some(old_label) = curr_block.label.as_ref() {
-              label_map.insert(old_label.to_string(), blocks.len());
-            }
             blocks.push(curr_block);
             curr_block = BasicBlock::new();
           }
+          label_map.insert(label.to_string(), blocks.len());
           curr_block.label = Some(label);
         }
         bril_rs::Code::Instruction(i @ bril_rs::Instruction::Effect { op, .. })
@@ -232,9 +230,6 @@ impl BBFunction {
             func_map,
           )?);
           curr_block.instrs.push(i);
-          if let Some(l) = curr_block.label.as_ref() {
-            label_map.insert(l.to_string(), blocks.len());
-          }
           blocks.push(curr_block);
           curr_block = BasicBlock::new();
         }
@@ -251,9 +246,6 @@ impl BBFunction {
     }
 
     if !curr_block.instrs.is_empty() || curr_block.label.is_some() {
-      if let Some(l) = curr_block.label.as_ref() {
-        label_map.insert(l.to_string(), blocks.len());
-      }
       blocks.push(curr_block);
     }
 

--- a/brilirs/src/basic_block.rs
+++ b/brilirs/src/basic_block.rs
@@ -220,23 +220,11 @@ impl BBFunction {
           }
           curr_block.label = Some(label);
         }
-        bril_rs::Code::Instruction(bril_rs::Instruction::Effect {
-          op,
-          args,
-          funcs,
-          labels,
-          pos,
-        }) if op == bril_rs::EffectOps::Jump
-          || op == bril_rs::EffectOps::Branch
-          || op == bril_rs::EffectOps::Return =>
+        bril_rs::Code::Instruction(i @ bril_rs::Instruction::Effect { op, .. })
+          if op == bril_rs::EffectOps::Jump
+            || op == bril_rs::EffectOps::Branch
+            || op == bril_rs::EffectOps::Return =>
         {
-          let i = bril_rs::Instruction::Effect {
-            op,
-            args,
-            funcs,
-            labels,
-            pos,
-          };
           curr_block.numified_instrs.push(NumifiedInstruction::new(
             &i,
             &mut num_of_vars,

--- a/brilirs/src/error.rs
+++ b/brilirs/src/error.rs
@@ -25,6 +25,8 @@ pub enum InterpError {
   NotOneChar,
   #[error("multiple functions of the same name found")]
   DuplicateFunction,
+  #[error("duplicate label `{0}` found")]
+  DuplicateLabel(String),
   #[error("Expected empty return for `{0}`, found value")]
   NonEmptyRetForFunc(String),
   #[error("cannot allocate `{0}` entries")]


### PR DESCRIPTION
The following is kinda fun because `brili` terminates but `brilirs` does not(Whether one takes the first or last occurrence of a label).

```
@main{
    jmp .A;
    .A:ret;
    .A:jmp  .A;
}
```

While `brilirs` can mirror this behavior, it can also be "helpful" by returning an error when it detects multiple labels as the specification/users intention is ambiguous.

2 commits to clean up the function first