### PR TITLE
inkwell: from git to new 0.5 release

### DIFF
--- a/bril-rs/brillvm/Cargo.toml
+++ b/bril-rs/brillvm/Cargo.toml
@@ -16,9 +16,7 @@ default-run = "main"
 
 [dependencies]
 clap = { version = "4.4", features = ["derive"] }
-inkwell = { git = "https://github.com/TheDan64/inkwell.git", features = [
-    "llvm18-0",
-] }
+inkwell = { version = "0.5", features = ["llvm18-0"] }
 
 [dependencies.bril-rs]
 path = ".."


### PR DESCRIPTION
https://github.com/TheDan64/inkwell/releases/tag/0.5.0 officially publishes Inkwell's support of llvm18 that I rely on.