### PR TITLE
refactor!(bril-rs): Use a standalone `struct` for a concrete label

### DIFF
--- a/bril-rs/Cargo.toml
+++ b/bril-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bril-rs"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Patrick LaFontaine <32135464+Pat-Lafon@users.noreply.github.com>"]
 edition = "2021"
 description = "A rust representation of the Bril language"

--- a/bril-rs/src/program.rs
+++ b/bril-rs/src/program.rs
@@ -153,14 +153,7 @@ impl Display for Argument {
 #[serde(untagged)]
 pub enum Code {
     /// <https://capra.cs.cornell.edu/bril/lang/syntax.html#label>
-    Label {
-        /// The name of the label
-        label: String,
-        /// Where the label is located in source code
-        #[cfg(feature = "position")]
-        #[serde(flatten, skip_serializing_if = "Option::is_none")]
-        pos: Option<Position>,
-    },
+    Label(Label),
     /// <https://capra.cs.cornell.edu/bril/lang/syntax.html#instruction>
     Instruction(Instruction),
 }
@@ -168,13 +161,30 @@ pub enum Code {
 impl Display for Code {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
-            Self::Label {
-                label,
-                #[cfg(feature = "position")]
-                    pos: _,
-            } => write!(f, ".{label}:"),
+            Self::Label(label) => write!(f, ".{}:", label.name),
             Self::Instruction(instr) => write!(f, "  {instr}"),
         }
+    }
+}
+
+/// <https://capra.cs.cornell.edu/bril/lang/syntax.html#label>
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+pub struct Label {
+    /// The name of the label
+    pub name: String,
+
+    /// Where the label is located in source code
+    #[cfg(feature = "position")]
+    #[serde(flatten, skip_serializing_if = "Option::is_none")]
+    pub pos: Option<Position>,
+}
+
+#[cfg(feature = "position")]
+impl Label {
+    /// A helper function to extract the position value if it exists from an instruction
+    #[must_use]
+    pub fn get_pos(&self) -> Option<Position> {
+        self.pos.clone()
     }
 }
 


### PR DESCRIPTION
## Rationale

It would be useful to refer to a `Label` object in source code using `bril-rs` as a library. This can also be done on the user-level by transforming `Code::Label` into an appropriate user-defined `struct`, so I can close this PR if this path is intended.

## Changes

- Changes the `Code::Label` variant in the representation of a concrete program to instead hold a new `Label` `struct`, which contains the same information as the variant. This new `struct` also implements the same traits and other properties as the other items.
- Bumps the version to `0.2` to reflect this breaking change.