### PR TITLE
[bril-ocaml] Fix compilation error involving conversion from sets to lists

### DIFF
--- a/bril-ocaml/lib/func.ml
+++ b/bril-ocaml/lib/func.ml
@@ -204,7 +204,7 @@ module Dominance = struct
   end
 
   module Lists : S with type out := string list = struct
-    let f = Map.map ~f:String.Set.to_list
+    let f = Map.map ~f:Set.to_list
     let dominators ?strict = Fn.compose f (Sets.dominators ?strict)
     let dominated ?strict = Fn.compose f (Sets.dominated ?strict)
 


### PR DESCRIPTION
On recent versions of OCaml, the existing `bril-ocaml` repo has a compilation error when running `dune build`, where the error message complains that the function `String.Set.to_list` doesn't exist in [Jane Street's `Core` library](https://github.com/janestreet/core). (I suspect this is due to recent changes in the library's API -- in the latest version of `Core`, there is no `to_list` function in the [module `String.Set`](https://ocaml.org/p/core/latest/doc/Core/String/Set/index.html).)

This PR fixes this (one-line change)! The resultant code compiles when running `dune build` (tested on both OCaml 5.0.0 & 5.2.0). 