### PR TITLE
Docs and CI: Use uv instead of flit CLI tool

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -30,20 +30,13 @@ jobs:
       - name: Install all TypeScript tools
         run: deno install brili.ts ; deno install brilck.ts ; deno install --allow-env --allow-read ts2bril.ts
 
-      - name: Install Flit
-        run: pip install flit
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
       - name: Install Python tools
-        run: cd bril-txt ; flit install --symlink
+        run: cd bril-txt ; uv tool install .
 
       - name: Install Turnt
-        # run: pip install turnt  # Use instead if pip turnt version >= 1.7
-        uses: actions/checkout@v4
-        with:
-          repository: cucapra/turnt
-          path: './turnt'
-      - name: Install Turnt part 2
-        run: cd turnt ; flit install --symlink
-
+        run: uv tool install turnt
 
       - name: Problem matcher
         run: echo '::add-matcher::.github/tap-matcher.json'
@@ -68,10 +61,10 @@ jobs:
       - name: Install brilck
         run: deno install brilck.ts
 
-      - name: Install Flit
-        run: pip install flit
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
       - name: Install Python tools
-        run: cd bril-txt ; flit install --symlink
+        run: cd bril-txt ; uv tool install .
 
       - name: Problem matcher
         run: echo '::add-matcher::.github/brilck-matcher.json'

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -69,20 +69,13 @@ jobs:
             cache: pip
             cache-dependency-path: bril-txt/pyproject.toml
 
-      - name: Install Flit
-        run: pip install flit
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
       - name: Install Python tools
-        run: cd bril-txt ; flit install --symlink
+        run: cd bril-txt ; uv tool install .
 
       - name: Install Turnt
-        # run: pip install turnt  # Use instead if pip turnt version >= 1.7
-        uses: actions/checkout@v4
-        with:
-          repository: cucapra/turnt
-          path: './turnt'
-      - name: Install Turnt part 2
-        run: flit install --symlink
-        working-directory: ./turnt
+        run: uv tool install turnt
 
       - name: Problem matcher
         run: echo '::add-matcher::.github/tap-matcher.json'

--- a/README.md
+++ b/README.md
@@ -32,19 +32,14 @@ You will then have `brili`, which takes a Bril program as JSON on stdin and exec
 
 ### Text Format
 
-The parser & pretty printer for the human-editable text form of Bril are written for Python 3.
-To install them, you need [Flit][], so run this:
+The parser & pretty printer for the human-editable text form of Bril are in Python.
+A good way to install them is using [uv][].
+[Install uv][uv-install], then go to the `bril-txt` directory and type:
 
-    $ pip install --user flit
-
-Then, go to the `bril-txt` directory and use Flit to install symlinks to the tools:
-
-    $ flit install --symlink --user
+    $ uv tool install .
 
 The tools are called `bril2json` and `bril2txt`.
 They also take input on stdin and produce output on stdout.
-
-[flit]: https://flit.readthedocs.io/
 
 
 Tests
@@ -61,3 +56,5 @@ Then run all the tests by typing `make test`.
 [pip]: https://packaging.python.org/tutorials/installing-packages/
 [cs6120]: https://www.cs.cornell.edu/courses/cs6120/2020fa/
 [turnt]: https://github.com/cucapra/turnt
+[uv]: https://docs.astral.sh/uv/
+[uv-install]: https://docs.astral.sh/uv/getting-started/installation/

--- a/docs/tools/brench.md
+++ b/docs/tools/brench.md
@@ -9,11 +9,11 @@ Set Up
 
 Brench is a Python tool.
 There is a `brench/` subdirectory in the Bril repository.
-Get [Flit][] and then type:
+Get [uv][] and then type:
 
-    $ flit install --symlink --user
+    $ uv tool install .
 
-[flit]: https://flit.readthedocs.io/
+[uv]: https://docs.astral.sh/uv/
 
 Configure
 ---------

--- a/docs/tools/text.md
+++ b/docs/tools/text.md
@@ -36,11 +36,10 @@ Tools
 -----
 
 [The `bril-txt` parser & pretty printer][briltxt] are written in Python.
-You can install them with [Flit][] by doing something like:
+You can install them with [uv][] by doing something like:
 
-    $ pip install --user flit
     $ cd bril-txt
-    $ flit install --symlink --user
+    $ uv tool install .
 
 You'll now have tools called `bril2json` and `bril2txt`.
 Both read from standard input and write to standard output.
@@ -50,5 +49,5 @@ You can try a "round trip" like this, for example:
 
 The `bril2json` parser also supports a `-p` flag to include [source positions](../lang/syntax.md#source-positions).
 
-[flit]: https://flit.readthedocs.io/
 [briltxt]: https://github.com/sampsyo/bril/blob/main/bril-txt/briltxt.py
+[uv]: https://docs.astral.sh/uv/


### PR DESCRIPTION
Using `uv tool install .` has a few advantages over `flit install --symlink --user`: maybe the biggest one is avoiding complaints from modern pip about breaking system packages. (It's also faster, and I guess it's good that the tools get installed into isolated virtualenvs.)