### PR TITLE
[bril-ocaml] Add support for floats

### DIFF
--- a/bril-ocaml/count/count.ml
+++ b/bril-ocaml/count/count.ml
@@ -2,22 +2,24 @@ open! Core
 open! Bril
 
 let () =
-  let (ints, bools, ptrs) =
+  let (ints, bools, floats, ptrs) =
     In_channel.input_all In_channel.stdin
     |> Yojson.Basic.from_string
     |> Bril.from_json
-    |> List.fold ~init:(0, 0, 0) ~f:(fun (ints, bools, ptrs) func ->
-           func
-           |> Bril.Func.instrs
-           |> List.fold ~init:(ints, bools, ptrs) ~f:(fun (ints, bools, ptrs) -> function
-                | Const ((_, bril_type), _)
-                | Binary ((_, bril_type), _, _, _)
-                | Unary ((_, bril_type), _, _)
-                | Call (Some (_, bril_type), _, _) ->
-                  ( match bril_type with
-                  | IntType -> (ints + 1, bools, ptrs)
-                  | BoolType -> (ints, bools + 1, ptrs)
-                  | PtrType _ -> (ints, bools, ptrs + 1))
-                | _ -> (ints, bools, ptrs)))
+    |> List.fold ~init:(0, 0, 0, 0) ~f:(fun (ints, bools, floats, ptrs) func ->
+      func
+      |> Bril.Func.instrs
+      |> List.fold ~init:(ints, bools, floats, ptrs) ~f:(fun (ints, bools, floats, ptrs) ->
+          function
+          | Const ((_, bril_type), _)
+          | Binary ((_, bril_type), _, _, _)
+          | Unary ((_, bril_type), _, _)
+          | Call (Some (_, bril_type), _, _) ->
+            (match bril_type with
+            | IntType -> (ints + 1, bools, floats, ptrs)
+            | BoolType -> (ints, bools + 1, floats, ptrs)
+            | FloatType -> (ints, bools, floats + 1, ptrs)
+            | PtrType _ -> (ints, bools, floats, ptrs + 1))
+          | _ -> (ints, bools, floats, ptrs)))
   in
-  printf "Ints: %d Bools: %d Pointers: %d \n" ints bools ptrs
+  printf "Ints: %d Bools: %d Floats: %d Pointers: %d \n" ints bools floats ptrs

--- a/bril-ocaml/lib/bril_type.ml
+++ b/bril-ocaml/lib/bril_type.ml
@@ -3,6 +3,7 @@ open! Core
 type t =
   | IntType
   | BoolType
+  | FloatType
   | PtrType of t
 [@@deriving compare, equal, sexp_of]
 
@@ -11,6 +12,7 @@ let rec of_json =
   function
   | `String "int" -> IntType
   | `String "bool" -> BoolType
+  | `String "float" -> FloatType
   | `Assoc [ ("ptr", inner) ] -> PtrType (of_json inner)
   | json -> failwithf "invalid type: %s" (json |> to_string) ()
 
@@ -21,9 +23,11 @@ let of_json_opt = function
 let rec to_json = function
   | IntType -> `String "int"
   | BoolType -> `String "bool"
+  | FloatType -> `String "float"
   | PtrType inner -> `Assoc [ ("ptr", to_json inner) ]
 
 let rec to_string = function
   | IntType -> "int"
   | BoolType -> "bool"
+  | FloatType -> "float"
   | PtrType inner -> sprintf "ptr[%s]" (to_string inner)

--- a/bril-ocaml/lib/bril_type.mli
+++ b/bril-ocaml/lib/bril_type.mli
@@ -3,6 +3,7 @@ open! Core
 type t =
   | IntType
   | BoolType
+  | FloatType
   | PtrType of t
 [@@deriving compare, equal, sexp_of]
 

--- a/bril-ocaml/lib/const.ml
+++ b/bril-ocaml/lib/const.ml
@@ -4,8 +4,10 @@ open! Common
 type t =
   | Int of int
   | Bool of bool
+  | Float of float
 [@@deriving compare, equal, sexp_of]
 
 let to_string = function
   | Int i -> Int.to_string i
   | Bool b -> Bool.to_string b
+  | Float f -> Float.to_string f

--- a/bril-ocaml/lib/const.mli
+++ b/bril-ocaml/lib/const.mli
@@ -4,6 +4,7 @@ open! Common
 type t =
   | Int of int
   | Bool of bool
+  | Float of float
 [@@deriving compare, equal, sexp_of]
 
 val to_string : t -> string

--- a/bril-ocaml/lib/instr.ml
+++ b/bril-ocaml/lib/instr.ml
@@ -154,7 +154,8 @@ let of_json json =
         match json |> member "type" |> Bril_type.of_json with
         | IntType -> Const.Int (json |> member "value" |> to_int)
         | BoolType -> Const.Bool (json |> member "value" |> to_bool)
-        | FloatType -> Const.Float (json |> member "value" |> to_float)
+        | FloatType ->
+          Const.Float (json |> member "value" |> Yojson.Basic.to_string |> Float.of_string)
         | PtrType _ -> failwith "pointer is not supported in constants"
       in
       Const (dest (), const)

--- a/bril-ocaml/lib/instr.ml
+++ b/bril-ocaml/lib/instr.ml
@@ -42,9 +42,9 @@ let to_string =
       ~f:(Fn.non String.is_empty)
     |> String.concat ~sep:" "
   | Ret arg ->
-    ( match arg with
+    (match arg with
     | Some arg -> sprintf "ret %s" arg
-    | None -> "ret" )
+    | None -> "ret")
   | Print args -> String.concat ~sep:" " ("print" :: args)
   | Nop -> "nop"
   | Phi (dest, alist) ->
@@ -148,12 +148,13 @@ let of_json json =
     let labels () = json |> member "labels" |> to_list_nonnull |> List.map ~f:to_string in
     let arg = List.nth_exn (args ()) in
     let label = List.nth_exn (labels ()) in
-    ( match json |> member "op" |> to_string with
+    (match json |> member "op" |> to_string with
     | "const" ->
       let const =
         match json |> member "type" |> Bril_type.of_json with
         | IntType -> Const.Int (json |> member "value" |> to_int)
         | BoolType -> Const.Bool (json |> member "value" |> to_bool)
+        | FloatType -> Const.Float (json |> member "value" |> to_float)
         | PtrType _ -> failwith "pointer is not supported in constants"
       in
       Const (dest (), const)
@@ -178,7 +179,7 @@ let of_json json =
     | "store" -> Store (arg 0, arg 1)
     | "load" -> Load (dest (), arg 0)
     | "ptradd" -> PtrAdd (dest (), arg 0, arg 1)
-    | op -> failwithf "invalid op: %s" op () )
+    | op -> failwithf "invalid op: %s" op ())
   | json -> failwithf "invalid label: %s" (json |> to_string) ()
 
 let to_json =
@@ -187,35 +188,36 @@ let to_json =
   in
   let build_op ?dest ?args ~op () =
     `Assoc
-      ( [ ("op", `String op) ]
-      @ ( match args with
+      ([ ("op", `String op) ]
+      @ (match args with
         | None -> []
-        | Some args -> [ ("args", `List (List.map args ~f:(fun a -> `String a))) ] )
+        | Some args -> [ ("args", `List (List.map args ~f:(fun a -> `String a))) ])
       @
       match dest with
       | None -> []
-      | Some dest -> dest_to_json dest )
+      | Some dest -> dest_to_json dest)
   in
   function
   | Label label -> `Assoc [ ("label", `String label) ]
   | Const (dest, const) ->
     `Assoc
-      ( [
-          ("op", `String "const");
-          ( "value",
-            match const with
-            | Int i -> `Int i
-            | Bool b -> `Bool b );
-        ]
-      @ dest_to_json dest )
+      ([
+         ("op", `String "const");
+         ( "value",
+           match const with
+           | Int i -> `Int i
+           | Bool b -> `Bool b
+           | Float f -> `Float f );
+       ]
+      @ dest_to_json dest)
   | Binary (dest, op, arg1, arg2) ->
     `Assoc
-      ( [ ("op", `String (Op.Binary.to_string op)); ("args", `List [ `String arg1; `String arg2 ]) ]
-      @ dest_to_json dest )
+      ([ ("op", `String (Op.Binary.to_string op)); ("args", `List [ `String arg1; `String arg2 ]) ]
+      @ dest_to_json dest)
   | Unary (dest, op, arg) ->
     `Assoc
-      ( [ ("op", `String (Op.Unary.to_string op)); ("args", `List [ `String arg ]) ]
-      @ dest_to_json dest )
+      ([ ("op", `String (Op.Unary.to_string op)); ("args", `List [ `String arg ]) ]
+      @ dest_to_json dest)
   | Jmp label -> `Assoc [ ("op", `String "jmp"); ("labels", `List [ `String label ]) ]
   | Br (arg, l1, l2) ->
     `Assoc
@@ -226,12 +228,12 @@ let to_json =
       ]
   | Call (dest, func_name, args) ->
     `Assoc
-      ( [
-          ("op", `String "call");
-          ("funcs", `List [ `String func_name ]);
-          ("args", `List (List.map args ~f:(fun arg -> `String arg)));
-        ]
-      @ Option.value_map dest ~default:[] ~f:dest_to_json )
+      ([
+         ("op", `String "call");
+         ("funcs", `List [ `String func_name ]);
+         ("args", `List (List.map args ~f:(fun arg -> `String arg)));
+       ]
+      @ Option.value_map dest ~default:[] ~f:dest_to_json)
   | Ret arg ->
     `Assoc
       [
@@ -243,12 +245,12 @@ let to_json =
   | Nop -> `Assoc [ ("op", `String "nop") ]
   | Phi (dest, alist) ->
     `Assoc
-      ( [
-          ("op", `String "phi");
-          ("labels", `List (List.map alist ~f:(fun (label, _) -> `String label)));
-          ("args", `List (List.map alist ~f:(fun (_, arg) -> `String arg)));
-        ]
-      @ dest_to_json dest )
+      ([
+         ("op", `String "phi");
+         ("labels", `List (List.map alist ~f:(fun (label, _) -> `String label)));
+         ("args", `List (List.map alist ~f:(fun (_, arg) -> `String arg)));
+       ]
+      @ dest_to_json dest)
   | Speculate -> `Assoc [ ("op", `String "speculate") ]
   | Commit -> `Assoc [ ("op", `String "commit") ]
   | Guard (arg, l) ->

--- a/bril-ocaml/lib/op.mli
+++ b/bril-ocaml/lib/op.mli
@@ -13,6 +13,15 @@ module Binary : sig
     | Ge
     | And
     | Or
+    | FAdd
+    | FMul
+    | FSub
+    | FDiv
+    | FEq
+    | FLt
+    | FGt
+    | FLe
+    | FGe
   [@@deriving compare, equal, sexp_of]
 
   val is_op : string -> bool

--- a/bril-ocaml/test/count/bools.out
+++ b/bril-ocaml/test/count/bools.out
@@ -1,1 +1,1 @@
-Ints: 1 Bools: 2
+Ints: 1 Bools: 2 Floats: 0 Pointers: 0 

--- a/bril-ocaml/test/count/empty.out
+++ b/bril-ocaml/test/count/empty.out
@@ -1,1 +1,1 @@
-Ints: 0 Bools: 0
+Ints: 0 Bools: 0 Floats: 0 Pointers: 0 

--- a/bril-ocaml/test/count/floats.bril
+++ b/bril-ocaml/test/count/floats.bril
@@ -1,0 +1,7 @@
+@main {
+  a: float = const 2;
+  b: float = const 3;
+  x: int   = const 4;
+  y: bool  = eq x x;
+  print a;
+}

--- a/bril-ocaml/test/count/floats.out
+++ b/bril-ocaml/test/count/floats.out
@@ -1,0 +1,1 @@
+Ints: 1 Bools: 1 Floats: 2 Pointers: 0 

--- a/bril-ocaml/test/count/funcs.out
+++ b/bril-ocaml/test/count/funcs.out
@@ -1,1 +1,1 @@
-Ints: 3 Bools: 3
+Ints: 3 Bools: 3 Floats: 0 Pointers: 0 

--- a/bril-ocaml/test/count/ints.out
+++ b/bril-ocaml/test/count/ints.out
@@ -1,1 +1,1 @@
-Ints: 2 Bools: 0
+Ints: 2 Bools: 0 Floats: 0 Pointers: 0 


### PR DESCRIPTION
What it says on the tin: hopefully `bril-ocaml` no longer crashes on encountering floats.

Changes:
- Add constructors `FloatType` to `Bril_type.t` and `Float` to `Const.t`
- Add constructors for floating point binary ops to `Op.Binary.t`
- Tweak `count.ml` to count number of floats as well (and change tests accordingly) 


To test these tweaks, I checked this simple pass is correct on all benchmarks using `brench`:
```ocaml
(* no-op.ml: read in Bril JSON, do nothing to it, and print it out *)
open Bril

let _ =
    In_channel.(stdin |> input_all)
    |> Yojson.Basic.from_string
    |> from_json
    |> to_json
    |> Yojson.Basic.to_string
    |> print_endline
```
Previously, this crashed on all of `benchmarks/floats` and a few others.

Also, apologies for large diff; much of it is just from running `ocamlformat` (using the existing `.ocamlformat`).