### PR TITLE
feat(bril-rs): Support optional type annotations on value operations

### DIFF
--- a/bril-rs/src/conversion.rs
+++ b/bril-rs/src/conversion.rs
@@ -209,9 +209,15 @@ impl TryFrom<AbstractInstruction> for Instruction {
                 dest,
                 funcs,
                 labels,
-                op_type: op_type
-                    .try_into()
-                    .map_err(|e: ConversionError| e.add_pos(pos.clone()))?,
+                op_type: if let Some(op_type) = op_type {
+                    Some(
+                        op_type
+                            .try_into()
+                            .map_err(|e: ConversionError| e.add_pos(pos.clone()))?,
+                    )
+                } else {
+                    None
+                },
                 #[cfg(feature = "position")]
                 pos: pos.clone(),
                 op: op.parse().map_err(|e: ConversionError| e.add_pos(pos))?,

--- a/bril-rs/src/program.rs
+++ b/bril-rs/src/program.rs
@@ -222,8 +222,8 @@ pub enum Instruction {
         #[serde(flatten, skip_serializing_if = "Option::is_none")]
         pos: Option<Position>,
         /// Type of variable
-        #[serde(rename = "type")]
-        op_type: Type,
+        #[serde(rename = "type", flatten, skip_serializing_if = "Option::is_none")]
+        op_type: Option<Type>,
     },
     /// <https://capra.cs.cornell.edu/bril/lang/syntax.html#effect-operation>
     Effect {

--- a/bril-rs/src/program.rs
+++ b/bril-rs/src/program.rs
@@ -281,7 +281,11 @@ impl Display for Instruction {
                 #[cfg(feature = "position")]
                     pos: _,
             } => {
-                write!(f, "{dest}: {op_type} = {op}")?;
+                write!(f, "{dest}")?;
+                if let Some(op_type) = op_type {
+                    write!(f, ": {op_type}")?;
+                }
+                write!(f, " = {op}")?;
                 for func in funcs {
                     write!(f, " @{func}")?;
                 }


### PR DESCRIPTION
This PR changes `bril-rs/src/program.rs`'s definition of a value operation to accept value operations omitting type annotations.