### PR TITLE
Rust 1.87 lints

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -28,7 +28,7 @@ name: Workflow checks for rust code
 
 env:
   LLVM_VERSION: 18.0
-  RUST_VERSION: 1.85.0
+  RUST_VERSION: 1.87.0
 
 jobs:
   test:

--- a/bril-rs/bril2json/src/bril_grammar.lalrpop
+++ b/bril-rs/bril2json/src/bril_grammar.lalrpop
@@ -9,7 +9,7 @@
 #![expect(clippy::use_self)]
 #![expect(clippy::cast_sign_loss)]
 #![expect(clippy::must_use_candidate)]
-#![expect(clippy::uninlined_format_args)]
+#![expect(clippy::elidable_lifetime_names)]
 #![expect(clippy::match_same_arms)]
 #![expect(clippy::option_if_let_else)]
 #![expect(clippy::extra_unused_lifetimes)]

--- a/bril-rs/bril2json/src/lib.rs
+++ b/bril-rs/bril2json/src/lib.rs
@@ -34,6 +34,7 @@ pub fn escape_control_chars(s: &str) -> Option<char> {
 pub struct Lines {
     use_pos: bool,
     with_end: bool,
+    #[expect(clippy::struct_field_names, reason = "Names are hard")]
     new_lines: Vec<usize>,
     src_name: Option<String>,
 }

--- a/bril-rs/brild/src/lib.rs
+++ b/bril-rs/brild/src/lib.rs
@@ -243,7 +243,10 @@ fn locate_import<S: BuildHasher>(
     }
 
     if located_libs.len() > 1 {
-        eprintln!("Warning, more than one valid path for {path:?} was found, using the first one.");
+        eprintln!(
+            "Warning, more than one valid path for {} was found, using the first one.",
+            path.display()
+        );
     }
 
     let next_path = canonicalize(located_libs.first().unwrap().join(path))?;

--- a/bril-rs/brillvm/src/llvm.rs
+++ b/bril-rs/brillvm/src/llvm.rs
@@ -1000,7 +1000,7 @@ fn build_instruction<'a, 'b>(
                     Type::Pointer(_) => {
                         unreachable!()
                     }
-                };
+                }
                 if i < len - 1 {
                     builder.build_call(print_sep, &[], "print_sep").unwrap();
                 }

--- a/brilirs/src/interp.rs
+++ b/brilirs/src/interp.rs
@@ -662,7 +662,7 @@ fn execute<'a, T: std::io::Write>(
             state
               .env
               .set(numified_code.dest.unwrap(), Value::from(value));
-          };
+          }
         }
         Instruction::Value {
           op,
@@ -741,7 +741,7 @@ fn parse_args(
               ));
             }
             Ok(b) => env.set(*arg_as_num, Value::Bool(b)),
-          };
+          }
           Ok(())
         }
         bril_rs::Type::Int => {
@@ -753,7 +753,7 @@ fn parse_args(
               ));
             }
             Ok(i) => env.set(*arg_as_num, Value::Int(i)),
-          };
+          }
           Ok(())
         }
         bril_rs::Type::Float => {
@@ -765,7 +765,7 @@ fn parse_args(
               ));
             }
             Ok(f) => env.set(*arg_as_num, Value::Float(f)),
-          };
+          }
           Ok(())
         }
         bril_rs::Type::Char => escape_control_chars(inputs.get(index).unwrap().as_ref())


### PR DESCRIPTION
- Bumb ci workflow to 1.87
- Address the various clippy/formatting lints