### PR TITLE
Enable typechecking for all interpreter tests, and support `any` in brilck

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -14,9 +14,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: denoland/setup-deno@v1
+      - uses: denoland/setup-deno@v2
         with:
-          deno-version: v1.x
+          deno-version: v2.x
 
       - uses: actions/setup-python@v4
         with:
@@ -25,7 +25,7 @@ jobs:
         run: deno check brili.ts brilck.ts ts2bril.ts
 
       - name: Install all TypeScript tools
-        run: deno install brili.ts ; deno install brilck.ts ; deno install --allow-env --allow-read ts2bril.ts
+        run: deno install -g brili.ts ; deno install -g brilck.ts ; deno install -g --allow-env --allow-read ts2bril.ts
 
       - name: Install uv
         uses: astral-sh/setup-uv@v5
@@ -53,7 +53,7 @@ jobs:
         with:
             python-version: '3.13'
       - name: Install brilck
-        run: deno install brilck.ts
+        run: deno install -g brilck.ts
 
       - name: Install uv
         uses: astral-sh/setup-uv@v5

--- a/Makefile
+++ b/Makefile
@@ -17,13 +17,7 @@ TESTS := test/parse/*.bril \
 	benchmarks/mixed/*.bril \
 
 CHECKS := test/parse/*.bril \
-	test/interp/core/*.bril \
-	test/interp/char/*.bril \
-	test/interp/float/*.bril \
-	test/interp/mixed/*.bril \
-	test/interp/spec/*.bril \
-	test/interp/ssa/*.bril \
-	test/interp/mem/*.bril \
+	test/interp/*/*.bril \
 	examples/test/*/*.bril \
 	benchmarks/core/*.bril \
 	benchmarks/float/*.bril \

--- a/brilck.ts
+++ b/brilck.ts
@@ -85,7 +85,7 @@ function addType(
 ) {
   const oldType = env.get(id);
   if (oldType) {
-    if (!typeCompat(oldType, type)) {
+    if (!typeEq(oldType, type)) {
       err(
         `new type ${type} for ${id} conflicts with old type ${oldType}`,
         pos,
@@ -154,6 +154,29 @@ function typeCompat(a: bril.Type, b: PolyType, tenv?: TypeEnv): boolean {
   } else {
     return false;
   }
+}
+
+/**
+ * Check for type equality.
+ *
+ * The types must be syntactically equal. `any` is not equal to any other type.
+ * Type variariables are only equal to themselves.
+ */
+function typeEq(a: PolyType, b: PolyType): boolean {
+  if (typeof a === "object" && typeof b === "object") {
+    if ("tv" in a || "tv" in b) {
+      if ("tv" in a && "tv" in b) {
+        return a.tv === b.tv;
+      } else {
+        return false;
+      }
+    } else {
+      return typeEq(a.ptr, b.ptr);
+    }
+  } else if (typeof a === "string" && typeof b === "string") {
+    return a === b;
+  }
+  return false;
 }
 
 /**

--- a/test/interp/dynamic/mem_dynamic_dispatch.bril
+++ b/test/interp/dynamic/mem_dynamic_dispatch.bril
@@ -24,8 +24,8 @@
     ret;
 
 .call_my_print_2:
-    data : any = load args;
-    call @my_print_2 data;
+    data2 : any = load args;
+    call @my_print_2 data2;
     ret;
 .end:
     ret;


### PR DESCRIPTION
@Pat-Lafon noticed in #421 that one of the interpreter tests had a local-variable type conflict:
https://github.com/sampsyo/bril/pull/421/files/91aa29c14eb6030c788e183cee3c918933e967bc#diff-cf8e1d0b09219fd42b48600ce963612871635f239feb58146a34ae5b3f4ca541

It turns out that the typechecking in the CI was using a hard-coded list of subdirectories, so we were excluding some new categories of tests. Now we include them all with a wildcard.

Doing this revealed that `brilck` did not yet support the dynamic `any` type, so I also added support for that. One tricky thing is the need for a distinction between type *compatibility* (what is assignable to what?) and type *equality* (requirements that local variables have syntactically identical types throughout a function).
