### PR TITLE
Add support for unary ! and parenthesis

### DIFF
--- a/ts2bril.ts
+++ b/ts2bril.ts
@@ -181,6 +181,20 @@ function emitBril(prog: ts.Node, checker: ts.TypeChecker): bril.Program {
           }
         }
       }
+      case ts.SyntaxKind.PrefixUnaryExpression: {
+        const un = expr as ts.PrefixUnaryExpression;
+        const operand = emitExpr(un.operand);
+        switch (un.operator) {
+          case ts.SyntaxKind.ExclamationToken:
+            return builder.buildValue("not", "bool", [operand.dest]);
+          default:
+            throw `unhandled prefix unary operator ${un.operator}`;
+        }
+      }
+      case ts.SyntaxKind.ParenthesizedExpression: {
+        const paren = expr as ts.ParenthesizedExpression;
+        return emitExpr(paren.expression);
+      }
       default:
         throw `unsupported expression kind: ${expr.getText()}`;
     }


### PR DESCRIPTION
This PR addresses the lack of support for unary boolean negation and basic parenthesized expressions.
- Support for unary boolean negation is made with extensibility to other unary operators in mind (i.e. there is a switch-case that can be expanded).
- Support for parenthesized expressions is achieved by unwrapping the parenthesis and recursively calling `emitExpr`.