### PR TITLE
Turn down tail-call iteration count (fix #471)

### DIFF
--- a/benchmarks/core/tail-call.bril
+++ b/benchmarks/core/tail-call.bril
@@ -1,4 +1,4 @@
-#ARGS: 1500
+#ARGS: 1400
 @main(depth: int) {
   zero: int = const 0;
   cond: bool = eq depth zero;

--- a/benchmarks/core/tail-call.prof
+++ b/benchmarks/core/tail-call.prof
@@ -1,1 +1,1 @@
-total_dyn_inst: 10504
+total_dyn_inst: 9804


### PR DESCRIPTION
Just avoid a stack overflow in Deno. I'm not sure what changed, but 1500 seems to be too many for the reference interpreter and 1400 is OK.